### PR TITLE
Remove merge marker from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ This library was originally forked from the [`fuse` crate](https://github.com/za
 ## Documentation
 
 [FUSE-Rust reference][Documentation]
->>>>>>> abddaa3... Update README
 
 ## Details
 


### PR DESCRIPTION
This was mistakenly commited when merging from upstream