### PR TITLE
Add feature-flagged serde support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Add ABI 7.21
 * Add ABI 7.22
 
+## 0.4.1 - 2020-10-07
+
+* Added new feature `serializable` that will enable serde serialization/deserialization for `FileType`, `FileAttr`
+
 ## 0.4.0 - 2020-06-18
 
 * Forked as `fuser` crate, at https://github.com/cberner/fuser

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fuser"
 edition = "2018"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Christopher Berner <christopherberner@gmail.com>"]
 description = "Filesystem in Userspace (FUSE) for Rust"
 documentation = "https://docs.rs/fuser"
@@ -21,6 +21,7 @@ libc = "0.2.51"
 log = "0.4.6"
 thread-scoped = "1.0.2"
 users = "0.10.0"
+serde = {version = "1.0.102", features = ["std", "derive"], optional = true}
 
 [dev-dependencies]
 env_logger = "0.7"
@@ -34,6 +35,7 @@ pkg-config = {version = "0.3.14", optional = true }
 [features]
 default = ["libfuse"]
 libfuse = ["pkg-config"]
+serializable = ["serde"]
 abi-7-9 = []
 abi-7-10 = ["abi-7-9"]
 abi-7-11 = ["abi-7-10"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 
 use libc::{c_int, ENOSYS};
+#[cfg(feature = "serializable")]
+use serde::{Deserialize, Serialize};
 use std::convert::AsRef;
 use std::ffi::OsStr;
 use std::io;
@@ -37,6 +39,7 @@ mod session;
 
 /// File types
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
 pub enum FileType {
     /// Named pipe (S_IFIFO)
     NamedPipe,
@@ -56,6 +59,7 @@ pub enum FileType {
 
 /// File attributes
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
 pub struct FileAttr {
     /// Inode number
     pub ino: u64,


### PR DESCRIPTION
Introduces a new `serializable` feature flag that when enabled will auto-derive serde support for `FileType` and `FileAttr`. Also bumps the version to `0.4.1`.

The motivation for this is to be facilitate use-cases that require serializing (either for persistence or network transport) the aforementioned structs.