### PR TITLE
Switch to Appveyor for OSX CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,6 @@ jobs:
 #      dist: focal
 #      env: FEATURES=abi-7-21
 #      install: sudo apt-get update && sudo apt-get install -y libfuse3-dev fuse3
-    - os: osx
-      env: FEATURES=
-      install: brew update && brew cask install osxfuse
-    - os: osx
-      env: FEATURES=abi-7-19
-      install: brew update && brew cask install osxfuse
 script:
   - cargo build --all --all-targets --features=$FEATURES
   - cargo build --all --all-targets --no-default-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Add FUSE_AUTO_INVAL_DATA constant
 * Add ABI 7.20 to 7.31 feature flags. Support for these are incomplete.
 * Add support for building with libfuse3
-* Add support for building without libfuse/libfuse3
+* Add support for building without libfuse/libfuse3 on Linux (i.e. there's now a pure Rust implementation of all features)
 * Add `mount2()` with improved option API
 
 ## 0.4.1 - 2020-10-12

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+image: macOS
+
+install:
+  - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.42.0
+  - brew update > /dev/null && brew cask install osxfuse
+  - export PATH=$HOME/.cargo/bin:$PATH
+  - export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
+  - sudo /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse
+
+test_script:
+  - cargo build --all --all-targets
+  - cargo build --all --all-targets --all-features
+  - cargo test --all
+  - cargo test --all --all-features
+  - cargo doc --all --no-deps --all-features
+  - bash osx_mount_tests.sh
+
+build: false

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,7 @@
 fn main() {
+    #[cfg(all(not(feature = "libfuse"), not(target_os = "linux")))]
+    unimplemented!("Building without libfuse is only supported on Linux");
+
     #[cfg(feature = "libfuse")]
     {
         #[cfg(target_os = "macos")]

--- a/mount_tests.sh
+++ b/mount_tests.sh
@@ -3,10 +3,10 @@
 set -x
 
 exit_handler() {
-    exit "$TEST_EXIT_STATUS"
+    exit "${TEST_EXIT_STATUS:-1}"
 }
 trap exit_handler TERM
-trap "kill 0" INT EXIT
+trap 'kill $(jobs -p); exit $TEST_EXIT_STATUS' INT EXIT
 
 export RUST_BACKTRACE=1
 
@@ -23,14 +23,14 @@ function run_test {
 
   echo "mounting at $DIR"
   # Make sure FUSE was successfully mounted
-  mount | grep hello || exit
+  mount | grep hello || exit 1
 
   if [[ $(cat ${DIR}/hello.txt) = "Hello World!" ]]; then
       echo -e "$GREEN OK $2 $3 $NC"
   else
       echo -e "$RED FAILED $2 $3 $NC"
       export TEST_EXIT_STATUS=1
-      exit
+      exit 1
   fi
 
   kill $FUSE_PID

--- a/osx_mount_tests.sh
+++ b/osx_mount_tests.sh
@@ -3,10 +3,10 @@
 set -x
 
 exit_handler() {
-    exit "$TEST_EXIT_STATUS"
+    exit "${TEST_EXIT_STATUS:-1}"
 }
 trap exit_handler TERM
-trap "kill 0" INT EXIT
+trap 'kill $(jobs -p); exit $TEST_EXIT_STATUS' INT EXIT
 
 export RUST_BACKTRACE=1
 
@@ -23,21 +23,21 @@ function run_test {
 
   echo "mounting at $DIR"
   # Make sure FUSE was successfully mounted
-  mount | grep hello || exit
+  mount | grep hello || exit 1
 
   if [[ $(cat ${DIR}/hello.txt) = "Hello World!" ]]; then
       echo -e "$GREEN OK $2 $3 $NC"
   else
       echo -e "$RED FAILED $2 $3 $NC"
       export TEST_EXIT_STATUS=1
-      exit
+      exit 1
   fi
 
   kill $FUSE_PID
   wait $FUSE_PID
 }
 
-run_test --no-default-features 'without libfuse'
-run_test --no-default-features 'without libfuse' --auto_unmount
+run_test --features=libfuse 'with libfuse'
+run_test --features=libfuse 'with libfuse' --auto_unmount
 
 export TEST_EXIT_STATUS=0

--- a/src/fuse_sys.rs
+++ b/src/fuse_sys.rs
@@ -57,7 +57,17 @@ extern "C" {
 
     #[cfg(feature = "libfuse2")]
     pub fn fuse_mount_compat25(mountpoint: *const c_char, args: *const fuse_args) -> c_int;
-    #[cfg(feature = "libfuse2")]
+    #[cfg(all(
+        feature = "libfuse2",
+        not(any(
+            target_os = "macos",
+            target_os = "freebsd",
+            target_os = "dragonfly",
+            target_os = "openbsd",
+            target_os = "bitrig",
+            target_os = "netbsd"
+        ))
+    ))]
     pub fn fuse_unmount_compat22(mountpoint: *const c_char);
     #[cfg(feature = "libfuse3")]
     // Really this returns *fuse_session, but we don't need to access its fields


### PR DESCRIPTION
Appveyor is needed because it allows disabling SIP. Travis & Github
Actions both do not allow this