### PR TITLE
Allow Filesystem to configure kernel parameters

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -3,8 +3,8 @@
 use clap::{crate_version, App, Arg};
 use fuser::TimeOrNow::Now;
 use fuser::{
-    Filesystem, MountOption, ReplyAttr, ReplyCreate, ReplyData, ReplyDirectory, ReplyEmpty,
-    ReplyEntry, ReplyOpen, ReplyStatfs, ReplyWrite, Request, TimeOrNow, FUSE_ROOT_ID,
+    Filesystem, KernelConfig, MountOption, ReplyAttr, ReplyCreate, ReplyData, ReplyDirectory,
+    ReplyEmpty, ReplyEntry, ReplyOpen, ReplyStatfs, ReplyWrite, Request, TimeOrNow, FUSE_ROOT_ID,
 };
 use log::LevelFilter;
 use log::{debug, error, warn};
@@ -340,7 +340,7 @@ impl SimpleFS {
 }
 
 impl Filesystem for SimpleFS {
-    fn init(&mut self, _req: &Request) -> Result<(), c_int> {
+    fn init(&mut self, _req: &Request, _config: &mut KernelConfig) -> Result<(), c_int> {
         fs::create_dir_all(Path::new(&self.data_dir).join("inodes")).unwrap();
         fs::create_dir_all(Path::new(&self.data_dir).join("contents")).unwrap();
         if self.get_inode(FUSE_ROOT_ID).is_err() {


### PR DESCRIPTION
Currently max_background is the only configurable parameter, but others
can now be added easily

Fixes #21 