### PR TITLE
autodetect installed macfuse version 4 in build.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Installer packages can be downloaded from the [FUSE for macOS homepage][FUSE for
 
 #### To install using Homebrew
 
+**Note:** only needed if you prefer to run the opensource version 3.x, for version 4.x (binary only but needed for e.g. M1 macs) use the link mentioned above.
+
 ```sh
 brew cask install osxfuse
 ```

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
+static MAC_FUSE_4: &str = "/Library/Filesystems/macfuse.fs/Contents/Resources/mount_macfuse";
+
 fn main() {
     #[cfg(all(not(feature = "libfuse"), not(target_os = "linux")))]
     unimplemented!("Building without libfuse is only supported on Linux");
@@ -6,9 +8,14 @@ fn main() {
     {
         #[cfg(target_os = "macos")]
         {
+            let probelib = if std::path::Path::new(MAC_FUSE_4).exists() {
+                "fuse"
+            } else {
+                "osxfuse"
+            };
             pkg_config::Config::new()
                 .atleast_version("2.6.0")
-                .probe("osxfuse")
+                .probe(probelib)
                 .map_err(|e| eprintln!("{}", e))
                 .unwrap();
             println!("cargo:rustc-cfg=feature=\"libfuse2\"");


### PR DESCRIPTION
I was redirected here in my issue report for zargony/fuse-rs#155 when building the crate against macFUSE 4.x. There were lots of renames going on, one of them being the pkg-config information. This PR autodetects an installed v4 and makes it build against v4 - the hello.rs example plus tests work fine for me (tested on macOS 11.1 with macFUSE 4.0.5 on a M1 MacBook Air).