### PR TITLE
Soft-deprecate FileAttr::padding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ pub struct FileAttr {
     pub rdev: u32,
     /// Block size
     pub blksize: u32,
-    /// Padding
+    /// Unused - this will be removed in the future.
     pub padding: u32,
     /// Flags (macOS only, see chflags(2))
     pub flags: u32,

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -115,7 +115,7 @@ fn fuse_attr_from_attr(attr: &FileAttr) -> fuse_attr {
         #[cfg(feature = "abi-7-9")]
         blksize: attr.blksize,
         #[cfg(feature = "abi-7-9")]
-        padding: attr.padding,
+        padding: 0,
     }
 }
 
@@ -144,7 +144,7 @@ fn fuse_attr_from_attr(attr: &FileAttr) -> fuse_attr {
         #[cfg(feature = "abi-7-9")]
         blksize: attr.blksize,
         #[cfg(feature = "abi-7-9")]
-        padding: attr.padding,
+        padding: 0,
     }
 }
 
@@ -1020,7 +1020,7 @@ mod test {
         };
 
         if cfg!(feature = "abi-7-9") {
-            expected[1].extend(vec![0xbb, 0x00, 0x00, 0x00, 0xcc, 0x00, 0x00, 0x00]);
+            expected[1].extend(vec![0xbb, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
         }
         expected[0][0] = (expected[0].len() + expected[1].len()) as u8;
 
@@ -1089,7 +1089,7 @@ mod test {
         };
 
         if cfg!(feature = "abi-7-9") {
-            expected[1].extend(vec![0xbb, 0x00, 0x00, 0x00, 0xcc, 0x00, 0x00, 0x00]);
+            expected[1].extend(vec![0xbb, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
         }
         expected[0][0] = (expected[0].len() + expected[1].len()) as u8;
 
@@ -1243,7 +1243,7 @@ mod test {
             let insert_at = expected[1].len() - 16;
             expected[1].splice(
                 insert_at..insert_at,
-                vec![0xdd, 0x00, 0x00, 0x00, 0xee, 0x00, 0x00, 0x00],
+                vec![0xdd, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
             );
         }
         expected[0][0] = (expected[0].len() + expected[1].len()) as u8;


### PR DESCRIPTION
This was added in 7f677ce34642870b36b2bb73c952762b42c26eac, but I think it
was a mistake.  AFAICS the padding is required by the FUSE ABI, but isn't
actually used, so it shouldn appear in `fuse_abi::fuse_attr`, but not in
in our `FileAttr` API.

Removing it now would be a breaking change, so I'll just ignore it and
document that it's unused.  It can be removed for 0.8.