### PR TITLE
Remove unsafe from reply.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ log = "0.4.6"
 users = "0.11.0"
 page_size = "0.4.2"
 serde = {version = "1.0.102", features = ["std", "derive"], optional = true}
+zerocopy = "0.3"
 
 [dev-dependencies]
 env_logger = "0.8"

--- a/deny.toml
+++ b/deny.toml
@@ -70,6 +70,7 @@ unlicensed = "deny"
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.7 short identifier (+ optional exception)].
 allow = [
+    "BSD-3-Clause",
     "MIT",
 ]
 # List of explictly disallowed licenses

--- a/src/fuse_abi.rs
+++ b/src/fuse_abi.rs
@@ -24,6 +24,7 @@
 #[cfg(feature = "abi-7-9")]
 use crate::consts::{FATTR_ATIME_NOW, FATTR_MTIME_NOW};
 use std::convert::TryFrom;
+use zerocopy::AsBytes;
 
 pub const FUSE_KERNEL_VERSION: u32 = 7;
 
@@ -79,7 +80,7 @@ pub const FUSE_KERNEL_MINOR_VERSION: u32 = 31;
 pub const FUSE_ROOT_ID: u64 = 1;
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, AsBytes)]
 pub struct fuse_attr {
     pub ino: u64,
     pub size: u64,
@@ -114,7 +115,7 @@ pub struct fuse_attr {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, AsBytes)]
 pub struct fuse_kstatfs {
     pub blocks: u64,  // Total blocks (in units of frsize)
     pub bfree: u64,   // Free blocks
@@ -129,7 +130,7 @@ pub struct fuse_kstatfs {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, AsBytes)]
 pub struct fuse_file_lock {
     pub start: u64,
     pub end: u64,
@@ -495,7 +496,7 @@ impl TryFrom<u32> for fuse_notify_code {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, AsBytes)]
 pub struct fuse_entry_out {
     pub nodeid: u64,
     pub generation: u64,
@@ -538,7 +539,7 @@ pub struct fuse_getattr_in {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, AsBytes)]
 pub struct fuse_attr_out {
     pub attr_valid: u64,
     pub attr_valid_nsec: u32,
@@ -548,7 +549,7 @@ pub struct fuse_attr_out {
 
 #[cfg(target_os = "macos")]
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, AsBytes)]
 pub struct fuse_getxtimes_out {
     pub bkuptime: u64,
     pub crtime: u64,
@@ -701,7 +702,11 @@ pub struct fuse_create_in {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, AsBytes)]
+pub struct fuse_create_out(pub fuse_entry_out, pub fuse_open_out);
+
+#[repr(C)]
+#[derive(Debug, AsBytes)]
 pub struct fuse_open_out {
     pub fh: u64,
     pub open_flags: u32,
@@ -768,14 +773,14 @@ pub struct fuse_write_in {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, AsBytes)]
 pub struct fuse_write_out {
     pub size: u32,
     pub padding: u32,
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, AsBytes)]
 pub struct fuse_statfs_out {
     pub st: fuse_kstatfs,
 }
@@ -813,7 +818,7 @@ pub struct fuse_getxattr_in {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, AsBytes)]
 pub struct fuse_getxattr_out {
     pub size: u32,
     pub padding: u32,
@@ -832,7 +837,7 @@ pub struct fuse_lk_in {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, AsBytes)]
 pub struct fuse_lk_out {
     pub lk: fuse_file_lock,
 }
@@ -856,7 +861,7 @@ pub struct fuse_init_in {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, AsBytes)]
 pub struct fuse_init_out {
     pub major: u32,
     pub minor: u32,
@@ -921,7 +926,7 @@ pub struct fuse_bmap_in {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, AsBytes)]
 pub struct fuse_bmap_out {
     pub block: u64,
 }
@@ -947,7 +952,7 @@ pub struct fuse_ioctl_iovec {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, AsBytes)]
 pub struct fuse_ioctl_out {
     pub result: i32,
     pub flags: u32,
@@ -1011,7 +1016,7 @@ pub struct fuse_in_header {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, AsBytes)]
 pub struct fuse_out_header {
     pub len: u32,
     pub error: i32,
@@ -1019,7 +1024,7 @@ pub struct fuse_out_header {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, AsBytes)]
 pub struct fuse_dirent {
     pub ino: u64,
     // NOTE: this field is defined as u64 in fuse_kernel.h in libfuse. However, it is treated as signed
@@ -1030,7 +1035,7 @@ pub struct fuse_dirent {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, AsBytes)]
 pub struct fuse_direntplus {
     pub entry_out: fuse_entry_out,
     pub dirent: fuse_dirent,
@@ -1109,7 +1114,7 @@ pub struct fuse_lseek_in {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, AsBytes)]
 pub struct fuse_lseek_out {
     pub offset: i64,
 }


### PR DESCRIPTION
Instead we use the zerocopy crate, which should be safer.  The code here
is a lot more straightforward, particularly around `dirent` handling.

Note the previous implementation was unsound: Rust doesn't guarantee a
memory layout for tuples.  Also the previous implementation of `as_bytes`
was unsound.  It could be applied to structs with padding or uninitialised
memory.

AFAIU this is not a breaking change because `ReplyRaw` is not exported by
`lib.rs` so already cannot be used externally.