### PR TITLE
Remove unsafe from the request parsing code

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -118,21 +118,18 @@ impl Channel {
     }
 
     /// Receives data up to the capacity of the given buffer (can block).
-    pub fn receive(&self, buffer: &mut Vec<u8>) -> io::Result<()> {
+    pub fn receive(&self, buffer: &mut [u8]) -> io::Result<usize> {
         let rc = unsafe {
             libc::read(
                 self.fd,
                 buffer.as_ptr() as *mut c_void,
-                buffer.capacity() as size_t,
+                buffer.len() as size_t,
             )
         };
         if rc < 0 {
             Err(io::Error::last_os_error())
         } else {
-            unsafe {
-                buffer.set_len(rc as usize);
-            }
-            Ok(())
+            Ok(rc as usize)
         }
     }
 

--- a/src/fuse_abi.rs
+++ b/src/fuse_abi.rs
@@ -24,7 +24,7 @@
 #[cfg(feature = "abi-7-9")]
 use crate::consts::{FATTR_ATIME_NOW, FATTR_MTIME_NOW};
 use std::convert::TryFrom;
-use zerocopy::AsBytes;
+use zerocopy::{AsBytes, FromBytes};
 
 pub const FUSE_KERNEL_VERSION: u32 = 7;
 
@@ -130,7 +130,7 @@ pub struct fuse_kstatfs {
 }
 
 #[repr(C)]
-#[derive(Debug, AsBytes)]
+#[derive(Debug, AsBytes, FromBytes)]
 pub struct fuse_file_lock {
     pub start: u64,
     pub end: u64,
@@ -508,7 +508,7 @@ pub struct fuse_entry_out {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_forget_in {
     pub nlookup: u64,
 }
@@ -523,7 +523,7 @@ pub struct fuse_forget_one {
 
 #[cfg(feature = "abi-7-16")]
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_batch_forget_in {
     pub count: u32,
     pub dummy: u32,
@@ -531,7 +531,7 @@ pub struct fuse_batch_forget_in {
 
 #[cfg(feature = "abi-7-9")]
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_getattr_in {
     pub getattr_flags: u32,
     pub dummy: u32,
@@ -558,7 +558,7 @@ pub struct fuse_getxtimes_out {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_mknod_in {
     pub mode: u32,
     pub rdev: u32,
@@ -569,7 +569,7 @@ pub struct fuse_mknod_in {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_mkdir_in {
     pub mode: u32,
     #[cfg(not(feature = "abi-7-12"))]
@@ -579,13 +579,13 @@ pub struct fuse_mkdir_in {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_rename_in {
     pub newdir: u64,
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_rename2_in {
     pub newdir: u64,
     pub flags: u32,
@@ -594,7 +594,7 @@ pub struct fuse_rename2_in {
 
 #[cfg(target_os = "macos")]
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_exchange_in {
     pub olddir: u64,
     pub newdir: u64,
@@ -602,13 +602,13 @@ pub struct fuse_exchange_in {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_link_in {
     pub oldnodeid: u64,
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_setattr_in {
     pub valid: u32,
     pub padding: u32,
@@ -680,7 +680,7 @@ impl fuse_setattr_in {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_open_in {
     // NOTE: this field is defined as u32 in fuse_kernel.h in libfuse. However, it is then cast
     // to an i32 when invoking the filesystem's open method and this matches the open() syscall
@@ -689,7 +689,7 @@ pub struct fuse_open_in {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_create_in {
     // NOTE: this field is defined as u32 in fuse_kernel.h in libfuse. However, it is then cast
     // to an i32 when invoking the filesystem's create method and this matches the open() syscall
@@ -714,7 +714,7 @@ pub struct fuse_open_out {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_release_in {
     pub fh: u64,
     // NOTE: this field is defined as u32 in fuse_kernel.h in libfuse. However, it is then cast
@@ -725,7 +725,7 @@ pub struct fuse_release_in {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_flush_in {
     pub fh: u64,
     pub unused: u32,
@@ -734,7 +734,7 @@ pub struct fuse_flush_in {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_read_in {
     pub fh: u64,
     // NOTE: this field is defined as u64 in fuse_kernel.h in libfuse. However, it is then cast
@@ -754,7 +754,7 @@ pub struct fuse_read_in {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_write_in {
     pub fh: u64,
     // NOTE: this field is defined as u64 in fuse_kernel.h in libfuse. However, it is then cast
@@ -786,7 +786,7 @@ pub struct fuse_statfs_out {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_fsync_in {
     pub fh: u64,
     pub fsync_flags: u32,
@@ -794,7 +794,7 @@ pub struct fuse_fsync_in {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_setxattr_in {
     pub size: u32,
     // NOTE: this field is defined as u32 in fuse_kernel.h in libfuse. However, it is then cast
@@ -807,7 +807,7 @@ pub struct fuse_setxattr_in {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_getxattr_in {
     pub size: u32,
     pub padding: u32,
@@ -825,7 +825,7 @@ pub struct fuse_getxattr_out {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_lk_in {
     pub fh: u64,
     pub owner: u64,
@@ -843,7 +843,7 @@ pub struct fuse_lk_out {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_access_in {
     // NOTE: this field is defined as u32 in fuse_kernel.h in libfuse. However, it is then cast
     // to an i32 when invoking the filesystem's access method
@@ -852,7 +852,7 @@ pub struct fuse_access_in {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_init_in {
     pub major: u32,
     pub minor: u32,
@@ -888,7 +888,7 @@ pub struct fuse_init_out {
 
 #[cfg(feature = "abi-7-12")]
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct cuse_init_in {
     pub major: u32,
     pub minor: u32,
@@ -912,13 +912,13 @@ pub struct cuse_init_out {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_interrupt_in {
     pub unique: u64,
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_bmap_in {
     pub block: u64,
     pub blocksize: u32,
@@ -933,7 +933,7 @@ pub struct fuse_bmap_out {
 
 #[cfg(feature = "abi-7-11")]
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_ioctl_in {
     pub fh: u64,
     pub flags: u32,
@@ -962,7 +962,7 @@ pub struct fuse_ioctl_out {
 
 #[cfg(feature = "abi-7-11")]
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_poll_in {
     pub fh: u64,
     pub kh: u64,
@@ -990,7 +990,7 @@ pub struct fuse_notify_poll_wakeup_out {
 
 #[cfg(feature = "abi-7-19")]
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_fallocate_in {
     pub fh: u64,
     // NOTE: this field is defined as u64 in fuse_kernel.h in libfuse. However, it is treated as signed
@@ -1003,7 +1003,7 @@ pub struct fuse_fallocate_in {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_in_header {
     pub len: u32,
     pub opcode: u32,
@@ -1092,7 +1092,7 @@ pub struct fuse_notify_retrieve_out {
 
 #[cfg(feature = "abi-7-15")]
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_notify_retrieve_in {
     // matches the size of fuse_write_in
     pub dummy1: u64,
@@ -1104,7 +1104,7 @@ pub struct fuse_notify_retrieve_in {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_lseek_in {
     pub fh: u64,
     pub offset: i64,
@@ -1120,7 +1120,7 @@ pub struct fuse_lseek_out {
 }
 
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_copy_file_range_in {
     pub fh_in: u64,
     // NOTE: this field is defined as u64 in fuse_kernel.h in libfuse. However, it is treated as signed

--- a/src/ll/argument.rs
+++ b/src/ll/argument.rs
@@ -4,7 +4,6 @@
 //! structures (request arguments).
 
 use std::ffi::OsStr;
-use std::mem;
 use std::os::unix::ffi::OsStrExt;
 
 /// An iterator that can be used to fetch typed arguments from a byte slice.
@@ -30,42 +29,50 @@ impl<'a> ArgumentIterator<'a> {
         bytes
     }
 
-    /// Fetch a slice of bytes of the given size. Returns `None` if there's not enough data left.
-    pub fn fetch_bytes(&mut self, amt: usize) -> Option<&'a [u8]> {
-        if amt > self.data.len() {
-            return None;
+    /// Fetch a typed argument. Returns `None` if there's not enough data left.
+    pub fn fetch<T: zerocopy::FromBytes>(&mut self) -> Option<&'a T> {
+        match zerocopy::LayoutVerified::<_, T>::new_from_prefix(self.data) {
+            None => {
+                if self.data.as_ptr() as usize % core::mem::align_of::<T>() != 0 {
+                    // Panic on alignment errors as this is under the control
+                    // of the programmer, we can still return None for size
+                    // failures as this may be caused by insufficient external
+                    // data.
+                    panic!("Data unaligned");
+                } else {
+                    None
+                }
+            }
+            Some((x, rest)) => {
+                self.data = rest;
+                Some(x.into_ref())
+            }
         }
-        let bytes = &self.data[..amt];
-        self.data = &self.data[amt..];
-        Some(bytes)
-    }
-
-    /// Fetch a typed argument. Returns `None` if there's not enough data left. This function is
-    /// unsafe because there is no guarantee that the data actually contains the type T.
-    pub unsafe fn fetch<T>(&mut self) -> Option<&'a T> {
-        let len = mem::size_of::<T>();
-        let bytes = self.fetch_bytes(len)?;
-        (bytes.as_ptr() as *const T).as_ref()
     }
 
     /// Fetch a (zero-terminated) string (can be non-utf8). Returns `None` if there's not enough
-    /// data left or no zero-termination could be found. This function is unsafe because there is
-    /// no guarantee that the data actually contains a string.
-    pub unsafe fn fetch_str(&mut self) -> Option<&'a OsStr> {
+    /// data left or no zero-termination could be found.
+    pub fn fetch_str(&mut self) -> Option<&'a OsStr> {
         let len = self.data.iter().position(|&c| c == 0)?;
-        let bytes = self.fetch_bytes(len)?;
-        let _zero = self.fetch_bytes(1)?;
-        Some(OsStr::from_bytes(&bytes))
+        let (out, rest) = self.data.split_at(len);
+        self.data = &rest[1..];
+        Some(OsStr::from_bytes(out))
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
+pub mod tests {
+    use std::ops::Deref;
 
-    const TEST_DATA: [u8; 10] = [0x66, 0x6f, 0x6f, 0x00, 0x62, 0x61, 0x72, 0x00, 0x62, 0x61];
+    use super::super::test::AlignedData;
+    use super::*;
+    use zerocopy::FromBytes;
+
+    const TEST_DATA: AlignedData<[u8; 10]> =
+        AlignedData([0x66, 0x6f, 0x6f, 0x00, 0x62, 0x61, 0x72, 0x00, 0x62, 0x61]);
 
     #[repr(C)]
+    #[derive(FromBytes)]
     struct TestArgument {
         p1: u8,
         p2: u8,
@@ -74,30 +81,20 @@ mod tests {
 
     #[test]
     fn all_data() {
-        let mut it = ArgumentIterator::new(&TEST_DATA);
-        unsafe { it.fetch_str().unwrap() };
+        let mut it = ArgumentIterator::new(TEST_DATA.deref());
+        it.fetch_str().unwrap();
         let arg = it.fetch_all();
         assert_eq!(arg, [0x62, 0x61, 0x72, 0x00, 0x62, 0x61]);
     }
 
     #[test]
-    fn bytes_data() {
-        let mut it = ArgumentIterator::new(&TEST_DATA);
-        let arg = it.fetch_bytes(5).unwrap();
-        assert_eq!(arg, [0x66, 0x6f, 0x6f, 0x00, 0x62]);
-        let arg = it.fetch_bytes(2).unwrap();
-        assert_eq!(arg, [0x61, 0x72]);
-        assert_eq!(it.len(), 3);
-    }
-
-    #[test]
     fn generic_argument() {
-        let mut it = ArgumentIterator::new(&TEST_DATA);
-        let arg: &TestArgument = unsafe { it.fetch().unwrap() };
+        let mut it = ArgumentIterator::new(TEST_DATA.deref());
+        let arg: &TestArgument = it.fetch().unwrap();
         assert_eq!(arg.p1, 0x66);
         assert_eq!(arg.p2, 0x6f);
         assert_eq!(arg.p3, 0x006f);
-        let arg: &TestArgument = unsafe { it.fetch().unwrap() };
+        let arg: &TestArgument = it.fetch().unwrap();
         assert_eq!(arg.p1, 0x62);
         assert_eq!(arg.p2, 0x61);
         assert_eq!(arg.p3, 0x0072);
@@ -106,22 +103,22 @@ mod tests {
 
     #[test]
     fn string_argument() {
-        let mut it = ArgumentIterator::new(&TEST_DATA);
-        let arg = unsafe { it.fetch_str().unwrap() };
+        let mut it = ArgumentIterator::new(TEST_DATA.deref());
+        let arg = it.fetch_str().unwrap();
         assert_eq!(arg, "foo");
-        let arg = unsafe { it.fetch_str().unwrap() };
+        let arg = it.fetch_str().unwrap();
         assert_eq!(arg, "bar");
         assert_eq!(it.len(), 2);
     }
 
     #[test]
     fn mixed_arguments() {
-        let mut it = ArgumentIterator::new(&TEST_DATA);
-        let arg: &TestArgument = unsafe { it.fetch().unwrap() };
+        let mut it = ArgumentIterator::new(TEST_DATA.deref());
+        let arg: &TestArgument = it.fetch().unwrap();
         assert_eq!(arg.p1, 0x66);
         assert_eq!(arg.p2, 0x6f);
         assert_eq!(arg.p3, 0x006f);
-        let arg = unsafe { it.fetch_str().unwrap() };
+        let arg = it.fetch_str().unwrap();
         assert_eq!(arg, "bar");
         let arg = it.fetch_all();
         assert_eq!(arg, [0x62, 0x61]);
@@ -129,12 +126,12 @@ mod tests {
 
     #[test]
     fn out_of_data() {
-        let mut it = ArgumentIterator::new(&TEST_DATA);
-        let _arg = it.fetch_bytes(8).unwrap();
-        let arg: Option<&TestArgument> = unsafe { it.fetch() };
+        let mut it = ArgumentIterator::new(TEST_DATA.deref());
+        it.fetch::<u64>().unwrap();
+        let arg: Option<&TestArgument> = it.fetch();
         assert!(arg.is_none());
         assert_eq!(it.len(), 2);
-        let arg = unsafe { it.fetch_str() };
+        let arg = it.fetch_str();
         assert!(arg.is_none());
         assert_eq!(it.len(), 2);
     }

--- a/src/ll/mod.rs
+++ b/src/ll/mod.rs
@@ -3,4 +3,27 @@
 mod argument;
 
 mod request;
+
 pub use request::{Operation, Request, RequestError};
+
+#[cfg(test)]
+mod test {
+    use std::ops::{Deref, DerefMut};
+    /// If we want to be able to cast bytes to our fuse C struct types we need it
+    /// to be aligned.  This struct helps getting &[u8]s which are 8 byte aligned.
+    #[cfg(test)]
+    #[repr(align(8))]
+    pub(crate) struct AlignedData<T>(pub T);
+    impl<T> Deref for AlignedData<T> {
+        type Target = T;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+    impl<T> DerefMut for AlignedData<T> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
+    }
+}

--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -291,132 +291,128 @@ impl<'a> fmt::Display for Operation<'a> {
 
 impl<'a> Operation<'a> {
     fn parse(opcode: &fuse_opcode, data: &mut ArgumentIterator<'a>) -> Option<Self> {
-        unsafe {
-            Some(match opcode {
-                fuse_opcode::FUSE_LOOKUP => Operation::Lookup {
-                    name: data.fetch_str()?,
-                },
-                fuse_opcode::FUSE_FORGET => Operation::Forget { arg: data.fetch()? },
-                fuse_opcode::FUSE_GETATTR => Operation::GetAttr,
-                fuse_opcode::FUSE_SETATTR => Operation::SetAttr { arg: data.fetch()? },
-                fuse_opcode::FUSE_READLINK => Operation::ReadLink,
-                fuse_opcode::FUSE_SYMLINK => Operation::SymLink {
-                    name: data.fetch_str()?,
-                    link: data.fetch_str()?,
-                },
-                fuse_opcode::FUSE_MKNOD => Operation::MkNod {
-                    arg: data.fetch()?,
-                    name: data.fetch_str()?,
-                },
-                fuse_opcode::FUSE_MKDIR => Operation::MkDir {
-                    arg: data.fetch()?,
-                    name: data.fetch_str()?,
-                },
-                fuse_opcode::FUSE_UNLINK => Operation::Unlink {
-                    name: data.fetch_str()?,
-                },
-                fuse_opcode::FUSE_RMDIR => Operation::RmDir {
-                    name: data.fetch_str()?,
-                },
-                fuse_opcode::FUSE_RENAME => Operation::Rename {
-                    arg: data.fetch()?,
-                    name: data.fetch_str()?,
-                    newname: data.fetch_str()?,
-                },
-                fuse_opcode::FUSE_LINK => Operation::Link {
-                    arg: data.fetch()?,
-                    name: data.fetch_str()?,
-                },
-                fuse_opcode::FUSE_OPEN => Operation::Open { arg: data.fetch()? },
-                fuse_opcode::FUSE_READ => Operation::Read { arg: data.fetch()? },
-                fuse_opcode::FUSE_WRITE => Operation::Write {
-                    arg: data.fetch()?,
-                    data: data.fetch_all(),
-                },
-                fuse_opcode::FUSE_STATFS => Operation::StatFs,
-                fuse_opcode::FUSE_RELEASE => Operation::Release { arg: data.fetch()? },
-                fuse_opcode::FUSE_FSYNC => Operation::FSync { arg: data.fetch()? },
-                fuse_opcode::FUSE_SETXATTR => Operation::SetXAttr {
-                    arg: data.fetch()?,
-                    name: data.fetch_str()?,
-                    value: data.fetch_all(),
-                },
-                fuse_opcode::FUSE_GETXATTR => Operation::GetXAttr {
-                    arg: data.fetch()?,
-                    name: data.fetch_str()?,
-                },
-                fuse_opcode::FUSE_LISTXATTR => Operation::ListXAttr { arg: data.fetch()? },
-                fuse_opcode::FUSE_REMOVEXATTR => Operation::RemoveXAttr {
-                    name: data.fetch_str()?,
-                },
-                fuse_opcode::FUSE_FLUSH => Operation::Flush { arg: data.fetch()? },
-                fuse_opcode::FUSE_INIT => Operation::Init { arg: data.fetch()? },
-                fuse_opcode::FUSE_OPENDIR => Operation::OpenDir { arg: data.fetch()? },
-                fuse_opcode::FUSE_READDIR => Operation::ReadDir { arg: data.fetch()? },
-                fuse_opcode::FUSE_RELEASEDIR => Operation::ReleaseDir { arg: data.fetch()? },
-                fuse_opcode::FUSE_FSYNCDIR => Operation::FSyncDir { arg: data.fetch()? },
-                fuse_opcode::FUSE_GETLK => Operation::GetLk { arg: data.fetch()? },
-                fuse_opcode::FUSE_SETLK => Operation::SetLk { arg: data.fetch()? },
-                fuse_opcode::FUSE_SETLKW => Operation::SetLkW { arg: data.fetch()? },
-                fuse_opcode::FUSE_ACCESS => Operation::Access { arg: data.fetch()? },
-                fuse_opcode::FUSE_CREATE => Operation::Create {
-                    arg: data.fetch()?,
-                    name: data.fetch_str()?,
-                },
-                fuse_opcode::FUSE_INTERRUPT => Operation::Interrupt { arg: data.fetch()? },
-                fuse_opcode::FUSE_BMAP => Operation::BMap { arg: data.fetch()? },
-                fuse_opcode::FUSE_DESTROY => Operation::Destroy,
-                #[cfg(feature = "abi-7-11")]
-                fuse_opcode::FUSE_IOCTL => Operation::IoCtl {
-                    arg: data.fetch()?,
-                    data: data.fetch_all(),
-                },
-                #[cfg(feature = "abi-7-11")]
-                fuse_opcode::FUSE_POLL => Operation::Poll { arg: data.fetch()? },
-                #[cfg(feature = "abi-7-15")]
-                fuse_opcode::FUSE_NOTIFY_REPLY => Operation::NotifyReply {
-                    data: data.fetch_all(),
-                },
-                #[cfg(feature = "abi-7-16")]
-                // TODO: parse the nodes
-                fuse_opcode::FUSE_BATCH_FORGET => Operation::BatchForget {
-                    arg: data.fetch()?,
-                    nodes: &[],
-                },
-                #[cfg(feature = "abi-7-19")]
-                fuse_opcode::FUSE_FALLOCATE => Operation::FAllocate { arg: data.fetch()? },
-                #[cfg(feature = "abi-7-21")]
-                fuse_opcode::FUSE_READDIRPLUS => Operation::ReadDirPlus { arg: data.fetch()? },
-                #[cfg(feature = "abi-7-23")]
-                fuse_opcode::FUSE_RENAME2 => Operation::Rename2 {
-                    arg: data.fetch()?,
-                    name: data.fetch_str()?,
-                    newname: data.fetch_str()?,
-                },
-                #[cfg(feature = "abi-7-24")]
-                fuse_opcode::FUSE_LSEEK => Operation::Lseek { arg: data.fetch()? },
-                #[cfg(feature = "abi-7-28")]
-                fuse_opcode::FUSE_COPY_FILE_RANGE => {
-                    Operation::CopyFileRange { arg: data.fetch()? }
-                }
+        Some(match opcode {
+            fuse_opcode::FUSE_LOOKUP => Operation::Lookup {
+                name: data.fetch_str()?,
+            },
+            fuse_opcode::FUSE_FORGET => Operation::Forget { arg: data.fetch()? },
+            fuse_opcode::FUSE_GETATTR => Operation::GetAttr,
+            fuse_opcode::FUSE_SETATTR => Operation::SetAttr { arg: data.fetch()? },
+            fuse_opcode::FUSE_READLINK => Operation::ReadLink,
+            fuse_opcode::FUSE_SYMLINK => Operation::SymLink {
+                name: data.fetch_str()?,
+                link: data.fetch_str()?,
+            },
+            fuse_opcode::FUSE_MKNOD => Operation::MkNod {
+                arg: data.fetch()?,
+                name: data.fetch_str()?,
+            },
+            fuse_opcode::FUSE_MKDIR => Operation::MkDir {
+                arg: data.fetch()?,
+                name: data.fetch_str()?,
+            },
+            fuse_opcode::FUSE_UNLINK => Operation::Unlink {
+                name: data.fetch_str()?,
+            },
+            fuse_opcode::FUSE_RMDIR => Operation::RmDir {
+                name: data.fetch_str()?,
+            },
+            fuse_opcode::FUSE_RENAME => Operation::Rename {
+                arg: data.fetch()?,
+                name: data.fetch_str()?,
+                newname: data.fetch_str()?,
+            },
+            fuse_opcode::FUSE_LINK => Operation::Link {
+                arg: data.fetch()?,
+                name: data.fetch_str()?,
+            },
+            fuse_opcode::FUSE_OPEN => Operation::Open { arg: data.fetch()? },
+            fuse_opcode::FUSE_READ => Operation::Read { arg: data.fetch()? },
+            fuse_opcode::FUSE_WRITE => Operation::Write {
+                arg: data.fetch()?,
+                data: data.fetch_all(),
+            },
+            fuse_opcode::FUSE_STATFS => Operation::StatFs,
+            fuse_opcode::FUSE_RELEASE => Operation::Release { arg: data.fetch()? },
+            fuse_opcode::FUSE_FSYNC => Operation::FSync { arg: data.fetch()? },
+            fuse_opcode::FUSE_SETXATTR => Operation::SetXAttr {
+                arg: data.fetch()?,
+                name: data.fetch_str()?,
+                value: data.fetch_all(),
+            },
+            fuse_opcode::FUSE_GETXATTR => Operation::GetXAttr {
+                arg: data.fetch()?,
+                name: data.fetch_str()?,
+            },
+            fuse_opcode::FUSE_LISTXATTR => Operation::ListXAttr { arg: data.fetch()? },
+            fuse_opcode::FUSE_REMOVEXATTR => Operation::RemoveXAttr {
+                name: data.fetch_str()?,
+            },
+            fuse_opcode::FUSE_FLUSH => Operation::Flush { arg: data.fetch()? },
+            fuse_opcode::FUSE_INIT => Operation::Init { arg: data.fetch()? },
+            fuse_opcode::FUSE_OPENDIR => Operation::OpenDir { arg: data.fetch()? },
+            fuse_opcode::FUSE_READDIR => Operation::ReadDir { arg: data.fetch()? },
+            fuse_opcode::FUSE_RELEASEDIR => Operation::ReleaseDir { arg: data.fetch()? },
+            fuse_opcode::FUSE_FSYNCDIR => Operation::FSyncDir { arg: data.fetch()? },
+            fuse_opcode::FUSE_GETLK => Operation::GetLk { arg: data.fetch()? },
+            fuse_opcode::FUSE_SETLK => Operation::SetLk { arg: data.fetch()? },
+            fuse_opcode::FUSE_SETLKW => Operation::SetLkW { arg: data.fetch()? },
+            fuse_opcode::FUSE_ACCESS => Operation::Access { arg: data.fetch()? },
+            fuse_opcode::FUSE_CREATE => Operation::Create {
+                arg: data.fetch()?,
+                name: data.fetch_str()?,
+            },
+            fuse_opcode::FUSE_INTERRUPT => Operation::Interrupt { arg: data.fetch()? },
+            fuse_opcode::FUSE_BMAP => Operation::BMap { arg: data.fetch()? },
+            fuse_opcode::FUSE_DESTROY => Operation::Destroy,
+            #[cfg(feature = "abi-7-11")]
+            fuse_opcode::FUSE_IOCTL => Operation::IoCtl {
+                arg: data.fetch()?,
+                data: data.fetch_all(),
+            },
+            #[cfg(feature = "abi-7-11")]
+            fuse_opcode::FUSE_POLL => Operation::Poll { arg: data.fetch()? },
+            #[cfg(feature = "abi-7-15")]
+            fuse_opcode::FUSE_NOTIFY_REPLY => Operation::NotifyReply {
+                data: data.fetch_all(),
+            },
+            #[cfg(feature = "abi-7-16")]
+            // TODO: parse the nodes
+            fuse_opcode::FUSE_BATCH_FORGET => Operation::BatchForget {
+                arg: data.fetch()?,
+                nodes: &[],
+            },
+            #[cfg(feature = "abi-7-19")]
+            fuse_opcode::FUSE_FALLOCATE => Operation::FAllocate { arg: data.fetch()? },
+            #[cfg(feature = "abi-7-21")]
+            fuse_opcode::FUSE_READDIRPLUS => Operation::ReadDirPlus { arg: data.fetch()? },
+            #[cfg(feature = "abi-7-23")]
+            fuse_opcode::FUSE_RENAME2 => Operation::Rename2 {
+                arg: data.fetch()?,
+                name: data.fetch_str()?,
+                newname: data.fetch_str()?,
+            },
+            #[cfg(feature = "abi-7-24")]
+            fuse_opcode::FUSE_LSEEK => Operation::Lseek { arg: data.fetch()? },
+            #[cfg(feature = "abi-7-28")]
+            fuse_opcode::FUSE_COPY_FILE_RANGE => Operation::CopyFileRange { arg: data.fetch()? },
 
-                #[cfg(target_os = "macos")]
-                fuse_opcode::FUSE_SETVOLNAME => Operation::SetVolName {
-                    name: data.fetch_str()?,
-                },
-                #[cfg(target_os = "macos")]
-                fuse_opcode::FUSE_GETXTIMES => Operation::GetXTimes,
-                #[cfg(target_os = "macos")]
-                fuse_opcode::FUSE_EXCHANGE => Operation::Exchange {
-                    arg: data.fetch()?,
-                    oldname: data.fetch_str()?,
-                    newname: data.fetch_str()?,
-                },
+            #[cfg(target_os = "macos")]
+            fuse_opcode::FUSE_SETVOLNAME => Operation::SetVolName {
+                name: data.fetch_str()?,
+            },
+            #[cfg(target_os = "macos")]
+            fuse_opcode::FUSE_GETXTIMES => Operation::GetXTimes,
+            #[cfg(target_os = "macos")]
+            fuse_opcode::FUSE_EXCHANGE => Operation::Exchange {
+                arg: data.fetch()?,
+                oldname: data.fetch_str()?,
+                newname: data.fetch_str()?,
+            },
 
-                #[cfg(feature = "abi-7-12")]
-                fuse_opcode::CUSE_INIT => Operation::CuseInit { arg: data.fetch()? },
-            })
-        }
+            #[cfg(feature = "abi-7-12")]
+            fuse_opcode::CUSE_INIT => Operation::CuseInit { arg: data.fetch()? },
+        })
     }
 }
 
@@ -446,8 +442,9 @@ impl<'a> TryFrom<&'a [u8]> for Request<'a> {
         let data_len = data.len();
         let mut data = ArgumentIterator::new(data);
         // Parse header
-        let header: &fuse_in_header =
-            unsafe { data.fetch() }.ok_or_else(|| RequestError::ShortReadHeader(data.len()))?;
+        let header: &fuse_in_header = data
+            .fetch()
+            .ok_or_else(|| RequestError::ShortReadHeader(data.len()))?;
         // Parse/check opcode
         let opcode = fuse_opcode::try_from(header.opcode)
             .map_err(|_: InvalidOpcodeError| RequestError::UnknownOperation(header.opcode))?;
@@ -506,10 +503,11 @@ impl<'a> Request<'a> {
 
 #[cfg(test)]
 mod tests {
+    use super::super::test::AlignedData;
     use super::*;
 
     #[cfg(target_endian = "big")]
-    const INIT_REQUEST: [u8; 56] = [
+    const INIT_REQUEST: AlignedData<[u8; 56]> = AlignedData([
         0x00, 0x00, 0x00, 0x38, 0x00, 0x00, 0x00, 0x1a, // len, opcode
         0xde, 0xad, 0xbe, 0xef, 0xba, 0xad, 0xd0, 0x0d, // unique
         0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, // nodeid
@@ -517,10 +515,10 @@ mod tests {
         0xc0, 0xde, 0xba, 0x5e, 0x00, 0x00, 0x00, 0x00, // pid, padding
         0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x08, // major, minor
         0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, // max_readahead, flags
-    ];
+    ]);
 
     #[cfg(target_endian = "little")]
-    const INIT_REQUEST: [u8; 56] = [
+    const INIT_REQUEST: AlignedData<[u8; 56]> = AlignedData([
         0x38, 0x00, 0x00, 0x00, 0x1a, 0x00, 0x00, 0x00, // len, opcode
         0x0d, 0xf0, 0xad, 0xba, 0xef, 0xbe, 0xad, 0xde, // unique
         0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, // nodeid
@@ -528,10 +526,10 @@ mod tests {
         0x5e, 0xba, 0xde, 0xc0, 0x00, 0x00, 0x00, 0x00, // pid, padding
         0x07, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, // major, minor
         0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // max_readahead, flags
-    ];
+    ]);
 
     #[cfg(target_endian = "big")]
-    const MKNOD_REQUEST: [u8; 56] = [
+    const MKNOD_REQUEST: AlignedData<[u8; 56]> = [
         0x00, 0x00, 0x00, 0x38, 0x00, 0x00, 0x00, 0x08, // len, opcode
         0xde, 0xad, 0xbe, 0xef, 0xba, 0xad, 0xd0, 0x0d, // unique
         0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, // nodeid
@@ -542,7 +540,7 @@ mod tests {
     ];
 
     #[cfg(all(target_endian = "little", not(feature = "abi-7-12")))]
-    const MKNOD_REQUEST: [u8; 56] = [
+    const MKNOD_REQUEST: AlignedData<[u8; 56]> = AlignedData([
         0x38, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, // len, opcode
         0x0d, 0xf0, 0xad, 0xba, 0xef, 0xbe, 0xad, 0xde, // unique
         0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, // nodeid
@@ -550,10 +548,10 @@ mod tests {
         0x5e, 0xba, 0xde, 0xc0, 0x00, 0x00, 0x00, 0x00, // pid, padding
         0xa4, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // mode, rdev
         0x66, 0x6f, 0x6f, 0x2e, 0x74, 0x78, 0x74, 0x00, // name
-    ];
+    ]);
 
     #[cfg(all(target_endian = "little", feature = "abi-7-12"))]
-    const MKNOD_REQUEST: [u8; 64] = [
+    const MKNOD_REQUEST: AlignedData<[u8; 64]> = AlignedData([
         0x38, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, // len, opcode
         0x0d, 0xf0, 0xad, 0xba, 0xef, 0xbe, 0xad, 0xde, // unique
         0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, // nodeid
@@ -562,7 +560,7 @@ mod tests {
         0xa4, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // mode, rdev
         0xed, 0x01, 0x00, 0x00, 0xe7, 0x03, 0x00, 0x00, // umask, padding
         0x66, 0x6f, 0x6f, 0x2e, 0x74, 0x78, 0x74, 0x00, // name
-    ];
+    ]);
 
     #[test]
     fn short_read_header() {


### PR DESCRIPTION
Instead we use `zerocopy::FromBytes`.

Previously the code did not ensure alignment, which could lead to undefined
behaviour.  Now we do check alignment I've had to fix it in a few places
using `AlignedData<[u8; sz]>` as a buffer in tests.  Unfortunately we can't
use `Box<AlignedData<u8; BUFFER_SIZE>>` as our main buffer because it's too
large to create on the stack and Rust currently offers no way to allocate
it directly on the heap.  Instead we have to fiddle with offsets for the
`Vec`.