### PR TITLE
Adding a macos github actions ci step

### DIFF
--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -1,0 +1,49 @@
+name: Macos CI
+
+on:
+  push:
+
+jobs:
+  ci-macos:
+    runs-on: macos-latest
+    env:
+      PKG_CONFIG_PATH: /usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install packages
+        run: |
+          brew update > /dev/null && brew install --cask osxfuse
+      - name: Start fuse
+        run: |
+          /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build all targets
+        run: cargo build --all --all-targets
+      - name: Build all targets, all features
+        run: cargo build --all --all-targets --all-features
+      - name: Run all tests
+        run: cargo test --all
+      - name: Run all tests, all features
+        run: cargo test --all --all-features
+      - name: Run cargo doc for all features
+        run: cargo doc --all --no-deps --all-features
+      - name: Run macos mount tests
+        run: bash osx_mount_tests.sh


### PR DESCRIPTION
This is a reproduction of the appveyor ci checks for macos. The reason is the appveyor is slow, but also they kill/fail tests rather than any sort of queue if push more than a few commits.

Making this purely additive as a new check to start with, then could remove appveyor if unneeded.