### PR TITLE
Split up integration testing, and try cache some state

### DIFF
--- a/.github/scripts/xfs_inside_docker_tests.sh
+++ b/.github/scripts/xfs_inside_docker_tests.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+# Check for rustup installed
+if [ ! -f ~/.rustup/settings.toml ]; then
+ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.47.0
+fi
+export PATH=/root/.cargo/bin:$PATH
+
+if [ ! -f /code/fuse-xfstests/check ]; then 
+    mkdir -p /code
+    cd /code 
+    git clone https://github.com/fleetfs/fuse-xfstests
+    cd fuse-xfstests
+    git checkout 0166199783962f0d988dfc5fbfea6aba4ac9143f
+    make
+fi
+
+cd /code/fuser
+
+cargo build --release --examples --features=abi-7-28
+
+cp target/release/examples/simple /bin/fuser
+
+cd /code/fuser
+exec ./xfstests.sh "$@"

--- a/.github/scripts/xfstests_min.Dockerfile
+++ b/.github/scripts/xfstests_min.Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:18.04
+
+RUN apt update && apt install -y git build-essential autoconf curl cmake libfuse-dev pkg-config fuse bc libtool \
+  uuid-dev xfslibs-dev libattr1-dev libacl1-dev libaio-dev attr acl quota bsdmainutils dbench psmisc
+
+RUN adduser --disabled-password --gecos '' fsgqa
+
+RUN echo 'user_allow_other' >> /etc/fuse.conf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  pull_request:
+  push:
 
 jobs:
   compile:
@@ -63,4 +63,4 @@ jobs:
         run: cargo install --force cargo-deny --locked
 
       - name: Run tests
-        run: INTERACTIVE="" make test
+        run: INTERACTIVE="" make pre

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,74 @@
+name: Integration tests
+
+on:
+  push:
+
+jobs:
+  integration_tests:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        test_group: [mount_tests, pjdfs_tests_fuse2, pjdfs_tests_fuse3, pjdfs_tests_pure]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install packages
+        run: |
+          sudo apt update
+          sudo apt install -y libfuse-dev libfuse3-dev build-essential
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run tests
+        run: INTERACTIVE="" make ${{ matrix.test_group }}
+  xfs_integration_tests:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        test_group: ["generic/0*", "generic/1*", "generic/2*", "generic/3*", "generic/4*", "generic/5*", "generic/6*"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup cache location
+        run: mkdir -p ~/docker_data
+      - name: Cache dockerdata
+        uses: actions/cache@v1
+        with:
+          path: ~/docker_data
+          key: ${{ runner.os }}-docker-data-${{ hashFiles('.github/**') }}-${{ hashFiles('**/Cargo.lock') }}
+      - name: Make cache folders
+        run: mkdir -p $HOME/docker_data/docker-target:/code/fuser/target $HOME/docker_data/docker-cargo:/root/.cargo $HOME/docker_data/docker-rustup:/root/.rustup $HOME/docker_data/docker-xfstests
+      - name: Build docker image
+        run: |
+          docker build -t fuser:xfstests -f .github/scripts/xfstests_min.Dockerfile .
+      - name: Run tests
+        run: >-
+          docker run --rm -t --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined
+          --memory=2g --kernel-memory=200m 
+          -v "$GITHUB_WORKSPACE:/code/fuser"
+          -v "$HOME/docker_data/docker-target:/code/fuser/target"
+          -v "$HOME/docker_data/docker-cargo:/root/.cargo"
+          -v "$HOME/docker_data/docker-rustup:/root/.rustup"
+          -v "$HOME/docker_data/docker-xfstests:/code/xfstests"
+          -v "$GITHUB_WORKSPACE/logs:/code/logs"
+          fuser:xfstests
+          bash -c "/code/fuser/.github/scripts/xfs_inside_docker_tests.sh ${{matrix.test_group}}"
+      - name: Fix permissions
+        run: sudo chown -R $USER ~/docker_data

--- a/xfstests.sh
+++ b/xfstests.sh
@@ -126,7 +126,7 @@ echo "generic/467" >> xfs_excludes.txt
 echo "generic/477" >> xfs_excludes.txt
 
 FUSER_EXTRA_MOUNT_OPTIONS="" TEST_DEV="$TEST_DATA_DIR" TEST_DIR="$TEST_DIR" SCRATCH_DEV="$SCRATCH_DATA_DIR" SCRATCH_MNT="$SCRATCH_DIR" \
-./check-fuser -E xfs_excludes.txt \
+./check-fuser -E xfs_excludes.txt "$@" \
 | tee /code/logs/xfstests.log
 
 export XFSTESTS_EXIT_STATUS=${PIPESTATUS[0]}


### PR DESCRIPTION
This one is to try take the really long test which seems to have random kills or out of disk space issues for me and make it both more reliable and also much much faster. Takes 36mins now for the slowest segment. (Driven heavily by one test we could disable too if we felt like it)