### PR TITLE
Fix AutoUnmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Ensure that `Filesystem::destroy` is always called
 * Remove request parameter to `Filesystem::destroy`
 * Fix `MountOption::AllowRoot`. Previously using it resulted in a crash.
+* Fix `MountOption::AutoUnmount` to work when `AllowRoot` and `AllowOther` are both not set
 
 ## 0.8.0 - 2021-06-11
 * Deprecate `mount()`

--- a/mount_tests.sh
+++ b/mount_tests.sh
@@ -76,6 +76,19 @@ function run_test {
 
   kill $FUSE_PID
   wait $FUSE_PID
+
+  if [[ "$3" == "--auto_unmount" ]]; then
+      # Make sure the FUSE mount automatically unmounted
+      if [[ $(mount | grep hello) ]]; then
+          echo -e "$RED FAILED Mount not cleaned up: $2 $3 $NC"
+          export TEST_EXIT_STATUS=1
+          exit 1
+      else
+          echo -e "$GREEN OK Mount cleaned up: $2 $3 $NC"
+      fi
+  else
+      umount $DIR
+  fi
 }
 
 apt update


### PR DESCRIPTION
Previously it only worked if AllowRoot or AllowOther was also set. This was because the fusermount3 binary was unable to automatically unmount these unless they were run as root, since it runs as the root user and so needs access to the FUSE filesystem.

Fixes #121 