### PR TITLE
Fix spurious failures in mount_tests

### DIFF
--- a/mount_tests.sh
+++ b/mount_tests.sh
@@ -37,6 +37,7 @@ function run_test {
   wait $FUSE_PID
 }
 
+apt update
 apt install -y fuse
 echo 'user_allow_other' >> /etc/fuse.conf
 


### PR DESCRIPTION
Without "apt update" these tests my fail due to out of date apt host lists, which happens easily since Docker caches the image layers