### PR TITLE
Safety: Make Channel/Session safer by clarifying ownership

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,6 +18,6 @@ task:
     - cargo doc --all --no-deps --features=abi-7-21
   test_script:
     - . $HOME/.cargo/env
-    - cargo test --all --all-targets
-    - cargo test --all --all-targets --features=abi-7-21
+    - cargo test --all --all-targets -- --skip=channel::test::mount_unmount
+    - cargo test --all --all-targets --features=abi-7-21 -- --skip=channel::test::mount_unmount
   before_cache_script: rm -rf $CARGO_HOME/registry/index

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,7 @@ dependencies = [
  "page_size",
  "pkg-config",
  "serde",
+ "tempfile",
  "users",
  "zerocopy",
 ]
@@ -241,6 +242,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +323,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,6 +359,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +424,15 @@ name = "regex-syntax"
 version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "serde"
@@ -414,6 +490,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +557,12 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ clap = "2.32"
 bincode = "1.3.1"
 serde = {version = "1.0.102", features=["std", "derive"]}
 futures-await-test = "0.3.0"
+tempfile = "3"
 
 [build-dependencies]
 pkg-config = {version = "0.3.14", optional = true }

--- a/pjdfs.Dockerfile
+++ b/pjdfs.Dockerfile
@@ -16,4 +16,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --de
 
 ENV PATH=/root/.cargo/bin:$PATH
 
+ADD Cargo.toml Cargo.lock build.rs /code/fuser/
+RUN cd /code/fuser && mkdir src && touch src/lib.rs && cargo build --locked --release --examples $BUILD_FEATURES
+
 ADD . /code/fuser/

--- a/src/async_api/mod.rs
+++ b/src/async_api/mod.rs
@@ -18,11 +18,11 @@ use std::path::Path;
 
 use std::time::SystemTime;
 
-use crate::ll::TimeOrNow;
 #[cfg(feature = "async_impl")]
-use crate::mount_options::check_option_conflicts;
+use crate::channel::mount_options::check_option_conflicts;
 #[cfg(all(feature = "libfuse", feature = "async_impl"))]
-use crate::mount_options::option_to_string;
+use crate::channel::mount_options::option_to_string;
+use crate::ll::TimeOrNow;
 
 use crate::KernelConfig;
 

--- a/src/channel/fuse2.rs
+++ b/src/channel/fuse2.rs
@@ -1,0 +1,49 @@
+use fuse2_sys::*;
+use std::{fs::File, os::unix::prelude::FromRawFd};
+
+use super::*;
+
+#[derive(Debug)]
+pub struct Mount {
+    mountpoint: CString,
+}
+impl Mount {
+    pub fn new(mountpoint: CString, options: &[&OsStr]) -> io::Result<(File, Mount)> {
+        with_fuse_args(options, |args| {
+            let fd = unsafe { fuse_mount_compat25(mountpoint.as_ptr(), args) };
+            if fd < 0 {
+                Err(io::Error::last_os_error())
+            } else {
+                Ok((unsafe { File::from_raw_fd(fd) }, Mount { mountpoint }))
+            }
+        })
+    }
+}
+impl Drop for Mount {
+    fn drop(&mut self) {
+        use std::io::ErrorKind::PermissionDenied;
+
+        // fuse_unmount_compat22 unfortunately doesn't return a status. Additionally,
+        // it attempts to call realpath, which in turn calls into the filesystem. So
+        // if the filesystem returns an error, the unmount does not take place, with
+        // no indication of the error available to the caller. So we call unmount
+        // directly, which is what osxfuse does anyway, since we already converted
+        // to the real path when we first mounted.
+        let rc = super::libc_umount(&self.mountpoint);
+        if rc < 0 && io::Error::last_os_error().kind() == PermissionDenied {
+            // Linux always returns EPERM for non-root users.  We have to let the
+            // library go through the setuid-root "fusermount -u" to unmount.
+            #[cfg(not(any(
+                target_os = "macos",
+                target_os = "freebsd",
+                target_os = "dragonfly",
+                target_os = "openbsd",
+                target_os = "bitrig",
+                target_os = "netbsd"
+            )))]
+            unsafe {
+                fuse_unmount_compat22(self.mountpoint.as_ptr());
+            }
+        }
+    }
+}

--- a/src/channel/fuse2.rs
+++ b/src/channel/fuse2.rs
@@ -8,7 +8,8 @@ pub struct Mount {
     mountpoint: CString,
 }
 impl Mount {
-    pub fn new(mountpoint: CString, options: &[&OsStr]) -> io::Result<(File, Mount)> {
+    pub fn new(mountpoint: &Path, options: &[&OsStr]) -> io::Result<(File, Mount)> {
+        let mountpoint = CString::new(mountpoint.as_os_str().as_bytes()).unwrap();
         with_fuse_args(options, |args| {
             let fd = unsafe { fuse_mount_compat25(mountpoint.as_ptr(), args) };
             if fd < 0 {

--- a/src/channel/fuse2_sys.rs
+++ b/src/channel/fuse2_sys.rs
@@ -1,0 +1,34 @@
+//! Native FFI bindings to libfuse2.
+//!
+//! This is a small set of bindings that are required to mount/unmount FUSE filesystems and
+//! open/close a fd to the FUSE kernel driver.
+
+#![warn(missing_debug_implementations)]
+#![allow(missing_docs)]
+
+use libc::{c_char, c_int};
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct fuse_args {
+    pub argc: c_int,
+    pub argv: *const *const c_char,
+    pub allocated: c_int,
+}
+
+#[cfg(feature = "libfuse2")]
+extern "C" {
+    // *_compat25 functions were introduced in FUSE 2.6 when function signatures changed.
+    // Therefore, the minimum version requirement for *_compat25 functions is libfuse-2.6.0.
+
+    pub fn fuse_mount_compat25(mountpoint: *const c_char, args: *const fuse_args) -> c_int;
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "openbsd",
+        target_os = "bitrig",
+        target_os = "netbsd"
+    )))]
+    pub fn fuse_unmount_compat22(mountpoint: *const c_char);
+}

--- a/src/channel/fuse3.rs
+++ b/src/channel/fuse3.rs
@@ -1,0 +1,48 @@
+use super::fuse3_sys::{
+    fuse_session_destroy, fuse_session_fd, fuse_session_mount, fuse_session_new,
+    fuse_session_unmount,
+};
+use super::*;
+use std::os::unix::prelude::FromRawFd;
+use std::ptr;
+
+#[derive(Debug)]
+pub struct Mount {
+    fuse_session: *mut c_void,
+}
+impl Mount {
+    pub fn new(mnt: CString, options: &[&OsStr]) -> io::Result<(File, Mount)> {
+        with_fuse_args(options, |args| {
+            let fuse_session = unsafe { fuse_session_new(args, ptr::null(), 0, ptr::null_mut()) };
+            if fuse_session.is_null() {
+                return Err(io::Error::last_os_error());
+            }
+            let mount = Mount { fuse_session };
+            let result = unsafe { fuse_session_mount(mount.fuse_session, mnt.as_ptr()) };
+            if result != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            let fd = unsafe { fuse_session_fd(mount.fuse_session) };
+            if fd < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            // We dup the fd here as the existing fd is owned by the fuse_session, and we
+            // don't want it being closed out from under us:
+            let fd = unsafe { libc::dup(fd) };
+            if fd < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            let file = unsafe { File::from_raw_fd(fd) };
+            Ok((file, mount))
+        })
+    }
+}
+impl Drop for Mount {
+    fn drop(&mut self) {
+        unsafe {
+            fuse_session_unmount(self.fuse_session);
+            fuse_session_destroy(self.fuse_session);
+        }
+    }
+}
+unsafe impl Send for Mount {}

--- a/src/channel/fuse3.rs
+++ b/src/channel/fuse3.rs
@@ -11,7 +11,8 @@ pub struct Mount {
     fuse_session: *mut c_void,
 }
 impl Mount {
-    pub fn new(mnt: CString, options: &[&OsStr]) -> io::Result<(File, Mount)> {
+    pub fn new(mnt: &Path, options: &[&OsStr]) -> io::Result<(File, Mount)> {
+        let mnt = CString::new(mnt.as_os_str().as_bytes()).unwrap();
         with_fuse_args(options, |args| {
             let fuse_session = unsafe { fuse_session_new(args, ptr::null(), 0, ptr::null_mut()) };
             if fuse_session.is_null() {

--- a/src/channel/fuse3_sys.rs
+++ b/src/channel/fuse3_sys.rs
@@ -1,0 +1,31 @@
+//! Native FFI bindings to libfuse3.
+//!
+//! This is a small set of bindings that are required to mount/unmount FUSE filesystems and
+//! open/close a fd to the FUSE kernel driver.
+
+#![warn(missing_debug_implementations)]
+#![allow(missing_docs)]
+
+use super::fuse2_sys::fuse_args;
+use libc::c_void;
+use libc::{c_char, c_int};
+
+extern "C" {
+    // Really this returns *fuse_session, but we don't need to access its fields
+    pub fn fuse_session_new(
+        args: *const fuse_args,
+        op: *const c_void, // This argument is really a *const fuse_lowlevel_ops, but we don't use them
+        op_size: libc::size_t,
+        userdata: *mut c_void,
+    ) -> *mut c_void;
+    pub fn fuse_session_mount(
+        se: *mut c_void, // This argument is really a *fuse_session
+        mountpoint: *const c_char,
+    ) -> c_int;
+    // This function's argument is really a *fuse_session
+    pub fn fuse_session_fd(se: *mut c_void) -> c_int;
+    // This function's argument is really a *fuse_session
+    pub fn fuse_session_unmount(se: *mut c_void);
+    // This function's argument is really a *fuse_session
+    pub fn fuse_session_destroy(se: *mut c_void);
+}

--- a/src/channel/fuse_pure.rs
+++ b/src/channel/fuse_pure.rs
@@ -63,9 +63,7 @@ impl Drop for Mount {
             // fusermount in auto-unmount mode, no more work to do.
             return;
         }
-        let rc = super::libc_umount(&self.mountpoint);
-        if rc < 0 {
-            let err = io::Error::last_os_error();
+        if let Err(err) = super::libc_umount(&self.mountpoint) {
             if err.kind() == PermissionDenied {
                 // Linux always returns EPERM for non-root users.  We have to let the
                 // library go through the setuid-root "fusermount -u" to unmount.

--- a/src/channel/fuse_pure.rs
+++ b/src/channel/fuse_pure.rs
@@ -6,8 +6,8 @@
 #![warn(missing_debug_implementations)]
 #![allow(missing_docs)]
 
-use crate::mount_options::{option_group, option_to_flag, option_to_string, MountOptionGroup};
-use crate::MountOption;
+use super::mount_options::MountOption;
+use super::mount_options::{option_group, option_to_flag, option_to_string, MountOptionGroup};
 use libc::c_int;
 use log::{debug, error};
 use std::ffi::{CStr, CString, OsStr};

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -13,6 +13,7 @@ mod fuse3_sys;
 
 #[cfg(not(feature = "libfuse"))]
 mod fuse_pure;
+pub mod mount_options;
 
 #[cfg(any(feature = "libfuse", test))]
 use fuse2_sys::fuse_args;

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -2,32 +2,32 @@
 //!
 //! Raw communication channel to the FUSE kernel driver.
 
+#[cfg(feature = "libfuse2")]
+mod fuse2;
 #[cfg(any(feature = "libfuse", test))]
 mod fuse2_sys;
 #[cfg(feature = "libfuse3")]
+mod fuse3;
+#[cfg(feature = "libfuse3")]
 mod fuse3_sys;
+
 #[cfg(not(feature = "libfuse"))]
 mod fuse_pure;
 
 #[cfg(any(feature = "libfuse", test))]
 use fuse2_sys::fuse_args;
-#[cfg(feature = "libfuse2")]
-use fuse2_sys::fuse_mount_compat25;
-#[cfg(not(feature = "libfuse"))]
-use fuse_pure::{fuse_mount_pure, fuse_unmount_pure};
-#[cfg(feature = "libfuse3")]
-use fuse3_sys::{
-    fuse_session_destroy, fuse_session_fd, fuse_session_mount, fuse_session_new,
-    fuse_session_unmount,
-};
 use libc::{self, c_int, c_void, size_t};
 use log::error;
+use std::io;
+use std::os::unix::prelude::AsRawFd;
+use std::path::Path;
+use std::{ffi::CStr, fs::File, sync::Arc};
 #[cfg(any(feature = "libfuse", test))]
-use std::ffi::OsStr;
-use std::ffi::{CStr, CString};
-use std::os::unix::ffi::OsStrExt;
-use std::path::{Path, PathBuf};
-use std::{io, ptr};
+use std::{
+    ffi::{CString, OsStr},
+    os::unix::ffi::OsStrExt,
+    sync::Arc,
+};
 
 use crate::reply::ReplySender;
 #[cfg(not(feature = "libfuse"))]
@@ -47,88 +47,39 @@ pub(in crate) fn with_fuse_args<T, F: FnOnce(&fuse_args) -> T>(options: &[&OsStr
     })
 }
 
+#[cfg(feature = "libfuse2")]
+pub use fuse2::Mount;
+#[cfg(feature = "libfuse3")]
+pub use fuse3::Mount;
+#[cfg(not(feature = "libfuse"))]
+pub use fuse_pure::Mount;
+
 /// A raw communication channel to the FUSE kernel driver
 #[derive(Debug)]
-pub struct Channel {
-    mountpoint: PathBuf,
-    pub(in crate) fd: c_int,
-    pub(in crate) fuse_session: *mut c_void,
-}
+pub struct Channel(File);
 
 impl Channel {
     /// Create a new communication channel to the kernel driver by mounting the
     /// given path. The kernel driver will delegate filesystem operations of
-    /// the given path to the channel. If the channel is dropped, the path is
-    /// unmounted.
-    #[cfg(feature = "libfuse2")]
-    pub fn new(mountpoint: &Path, options: &[&OsStr]) -> io::Result<Channel> {
+    /// the given path to the channel.
+    #[cfg(feature = "libfuse")]
+    pub fn new(mountpoint: &Path, options: &[&OsStr]) -> io::Result<(Channel, Mount)> {
         let mountpoint = mountpoint.canonicalize()?;
-        with_fuse_args(options, |args| {
-            let mnt = CString::new(mountpoint.as_os_str().as_bytes())?;
-            let fd = unsafe { fuse_mount_compat25(mnt.as_ptr(), args) };
-            if fd < 0 {
-                Err(io::Error::last_os_error())
-            } else {
-                Ok(Channel {
-                    mountpoint,
-                    fd,
-                    fuse_session: ptr::null_mut(),
-                })
-            }
-        })
-    }
-
-    #[cfg(feature = "libfuse3")]
-    pub fn new(mountpoint: &Path, options: &[&OsStr]) -> io::Result<Channel> {
-        let mountpoint = mountpoint.canonicalize()?;
-        with_fuse_args(options, |args| {
-            let mnt = CString::new(mountpoint.as_os_str().as_bytes())?;
-            let fuse_session = unsafe { fuse_session_new(args, ptr::null(), 0, ptr::null_mut()) };
-            if fuse_session.is_null() {
-                return Err(io::Error::last_os_error());
-            }
-            let result = unsafe { fuse_session_mount(fuse_session, mnt.as_ptr()) };
-            if result != 0 {
-                return Err(io::Error::last_os_error());
-            }
-            let fd = unsafe { fuse_session_fd(fuse_session) };
-            if fd < 0 {
-                Err(io::Error::last_os_error())
-            } else {
-                Ok(Channel {
-                    mountpoint,
-                    fd,
-                    fuse_session,
-                })
-            }
-        })
+        let (file, mount) = Mount::new(CString::new(mountpoint.as_os_str().as_bytes())?, options)?;
+        Ok((Channel(Arc::new(file)), mount))
     }
 
     #[cfg(not(feature = "libfuse"))]
-    pub fn new2(mountpoint: &Path, options: &[MountOption]) -> io::Result<Channel> {
-        let mountpoint = mountpoint.canonicalize()?;
-        let fd = fuse_mount_pure(mountpoint.as_os_str(), options)?;
-        if fd < 0 {
-            Err(io::Error::last_os_error())
-        } else {
-            Ok(Channel {
-                mountpoint,
-                fd,
-                fuse_session: ptr::null_mut(),
-            })
-        }
-    }
-
-    /// Return path of the mounted filesystem
-    pub fn mountpoint(&self) -> &Path {
-        &self.mountpoint
+    pub fn new2(mountpoint: &Path, options: &[MountOption]) -> io::Result<(Channel, Mount)> {
+        let (file, mount) = fuse_pure::Mount::new(mountpoint, options)?;
+        Ok((Channel(Arc::new(file)), mount))
     }
 
     /// Receives data up to the capacity of the given buffer (can block).
     pub fn receive(&self, buffer: &mut [u8]) -> io::Result<usize> {
         let rc = unsafe {
             libc::read(
-                self.fd,
+                self.0.as_raw_fd(),
                 buffer.as_ptr() as *mut c_void,
                 buffer.len() as size_t,
             )
@@ -148,23 +99,7 @@ impl Channel {
         // a sender by using the same fd and use it in other threads. Only
         // the channel closes the fd when dropped. If any sender is used after
         // dropping the channel, it'll return an EBADF error.
-        ChannelSender { fd: self.fd }
-    }
-}
-
-unsafe impl Send for Channel {}
-
-impl Drop for Channel {
-    fn drop(&mut self) {
-        // TODO: send ioctl FUSEDEVIOCSETDAEMONDEAD on macOS before closing the fd
-        // Close the communication channel to the kernel driver
-        // (closing it before unnmount prevents sync unmount deadlock)
-        unsafe {
-            libc::close(self.fd);
-        }
-        // Unmount this channel's mount point
-        let _ = unmount(&self.mountpoint, self.fuse_session, self.fd);
-        self.fuse_session = ptr::null_mut(); // unmount frees this pointer
+        ChannelSender { fd: self.0.as_raw_fd() }
     }
 }
 
@@ -200,74 +135,32 @@ impl ReplySender for ChannelSender {
     }
 }
 
-/// Unmount an arbitrary mount point
-#[allow(unused_variables)]
-pub fn unmount(mountpoint: &Path, fuse_session: *mut c_void, fd: c_int) -> io::Result<()> {
-    // fuse_unmount_compat22 unfortunately doesn't return a status. Additionally,
-    // it attempts to call realpath, which in turn calls into the filesystem. So
-    // if the filesystem returns an error, the unmount does not take place, with
-    // no indication of the error available to the caller. So we call unmount
-    // directly, which is what osxfuse does anyway, since we already converted
-    // to the real path when we first mounted.
+#[cfg(not(feature = "libfuse3"))]
+#[cfg(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "dragonfly",
+    target_os = "openbsd",
+    target_os = "bitrig",
+    target_os = "netbsd"
+))]
+#[inline]
+fn libc_umount(mnt: &CStr) -> c_int {
+    unsafe { libc::unmount(mnt.as_ptr(), 0) }
+}
 
-    #[cfg(any(
-        target_os = "macos",
-        target_os = "freebsd",
-        target_os = "dragonfly",
-        target_os = "openbsd",
-        target_os = "bitrig",
-        target_os = "netbsd"
-    ))]
-    #[inline]
-    fn libc_umount(mnt: &CStr, _fuse_session: *mut c_void, _fd: c_int) -> c_int {
-        unsafe { libc::unmount(mnt.as_ptr(), 0) }
-    }
-
-    #[cfg(not(any(
-        target_os = "macos",
-        target_os = "freebsd",
-        target_os = "dragonfly",
-        target_os = "openbsd",
-        target_os = "bitrig",
-        target_os = "netbsd"
-    )))]
-    #[inline]
-    fn libc_umount(mnt: &CStr, fuse_session: *mut c_void, fd: c_int) -> c_int {
-        #[cfg(feature = "libfuse2")]
-        use fuse2_sys::fuse_unmount_compat22;
-        use std::io::ErrorKind::PermissionDenied;
-
-        let rc = unsafe { libc::umount(mnt.as_ptr()) };
-        if rc < 0 && io::Error::last_os_error().kind() == PermissionDenied {
-            // Linux always returns EPERM for non-root users.  We have to let the
-            // library go through the setuid-root "fusermount -u" to unmount.
-            #[cfg(feature = "libfuse2")]
-            unsafe {
-                fuse_unmount_compat22(mnt.as_ptr());
-            }
-            #[cfg(feature = "libfuse3")]
-            unsafe {
-                if fuse_session.is_null() {
-                    fuse_session_unmount(fuse_session);
-                    fuse_session_destroy(fuse_session);
-                }
-            }
-            #[cfg(not(feature = "libfuse"))]
-            fuse_unmount_pure(mnt, fd);
-
-            0
-        } else {
-            rc
-        }
-    }
-
-    let mnt = CString::new(mountpoint.as_os_str().as_bytes())?;
-    let rc = libc_umount(&mnt, fuse_session, fd);
-    if rc < 0 {
-        Err(io::Error::last_os_error())
-    } else {
-        Ok(())
-    }
+#[cfg(not(feature = "libfuse3"))]
+#[cfg(not(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "dragonfly",
+    target_os = "openbsd",
+    target_os = "bitrig",
+    target_os = "netbsd"
+)))]
+#[inline]
+fn libc_umount(mnt: &CStr) -> c_int {
+    unsafe { libc::umount(mnt.as_ptr()) }
 }
 
 #[cfg(test)]

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -248,6 +248,10 @@ mod test {
         eprintln!("Our mountpoint: {:?}\nfuse mounts:\n{}", tmp.path(), mnt,);
 
         let detached = !mnt.contains(&*tmp.path().to_string_lossy());
+        // Linux supports MNT_DETACH, so we expect unmount to succeed even if the FS
+        // is busy.  Other systems don't so the unmount may fail and we will still
+        // have the mount listed.  The mount will get cleaned up later.
+        #[cfg(target_os = "linux")]
         assert!(detached);
 
         if detached {

--- a/src/channel/mod.rs
+++ b/src/channel/mod.rs
@@ -3,13 +3,20 @@
 //! Raw communication channel to the FUSE kernel driver.
 
 #[cfg(any(feature = "libfuse", test))]
-use crate::fuse_sys::fuse_args;
-#[cfg(feature = "libfuse2")]
-use crate::fuse_sys::fuse_mount_compat25;
-#[cfg(not(feature = "libfuse"))]
-use crate::fuse_sys::{fuse_mount_pure, fuse_unmount_pure};
+mod fuse2_sys;
 #[cfg(feature = "libfuse3")]
-use crate::fuse_sys::{
+mod fuse3_sys;
+#[cfg(not(feature = "libfuse"))]
+mod fuse_pure;
+
+#[cfg(any(feature = "libfuse", test))]
+use fuse2_sys::fuse_args;
+#[cfg(feature = "libfuse2")]
+use fuse2_sys::fuse_mount_compat25;
+#[cfg(not(feature = "libfuse"))]
+use fuse_pure::{fuse_mount_pure, fuse_unmount_pure};
+#[cfg(feature = "libfuse3")]
+use fuse3_sys::{
     fuse_session_destroy, fuse_session_fd, fuse_session_mount, fuse_session_new,
     fuse_session_unmount,
 };
@@ -227,7 +234,7 @@ pub fn unmount(mountpoint: &Path, fuse_session: *mut c_void, fd: c_int) -> io::R
     #[inline]
     fn libc_umount(mnt: &CStr, fuse_session: *mut c_void, fd: c_int) -> c_int {
         #[cfg(feature = "libfuse2")]
-        use crate::fuse_sys::fuse_unmount_compat22;
+        use fuse2_sys::fuse_unmount_compat22;
         use std::io::ErrorKind::PermissionDenied;
 
         let rc = unsafe { libc::umount(mnt.as_ptr()) };

--- a/src/channel/mount_options.rs
+++ b/src/channel/mount_options.rs
@@ -197,8 +197,8 @@ pub fn option_to_flag(option: &MountOption) -> libc::c_int {
 
 #[cfg(test)]
 mod test {
-    use crate::mount_options::check_option_conflicts;
-    use crate::MountOption;
+    use super::check_option_conflicts;
+    use super::MountOption;
 
     #[test]
     fn option_checking() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,14 +17,14 @@ use std::path::Path;
 use std::time::Duration;
 use std::time::SystemTime;
 
+use crate::channel::mount_options::check_option_conflicts;
+#[cfg(feature = "libfuse")]
+use crate::channel::mount_options::option_to_string;
 use crate::ll::fuse_abi::consts::*;
 pub use crate::ll::fuse_abi::FUSE_ROOT_ID;
 pub use crate::ll::{fuse_abi::consts, TimeOrNow};
-use crate::mount_options::check_option_conflicts;
-#[cfg(feature = "libfuse")]
-use crate::mount_options::option_to_string;
 use crate::session::MAX_WRITE_SIZE;
-pub use mount_options::MountOption;
+pub use channel::mount_options::MountOption;
 #[cfg(target_os = "macos")]
 pub use reply::ReplyXTimes;
 pub use reply::ReplyXattr;
@@ -44,7 +44,6 @@ use std::cmp::min;
 pub mod async_api;
 mod channel;
 mod ll;
-mod mount_options;
 mod reply;
 mod request;
 mod session;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,6 @@ use std::cmp::min;
 #[cfg(feature = "async_api")]
 pub mod async_api;
 mod channel;
-mod fuse_sys;
 mod ll;
 mod mount_options;
 mod reply;

--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -1338,7 +1338,7 @@ impl<'a> fmt::Display for Operation<'a> {
             #[cfg(feature = "abi-7-11")]
             Operation::Poll(x) => write!(f, "POLL fh {:?}", x.file_handle()),
             #[cfg(feature = "abi-7-15")]
-            Operation::NotifyReply(_x) => write!(f, "NOTIFYREPLY"),
+            Operation::NotifyReply(_) => write!(f, "NOTIFYREPLY"),
             #[cfg(feature = "abi-7-16")]
             Operation::BatchForget(x) => write!(f, "BATCHFORGET nodes {:?}", x.nodes()),
             #[cfg(feature = "abi-7-19")]
@@ -1384,7 +1384,7 @@ impl<'a> fmt::Display for Operation<'a> {
             ),
 
             #[cfg(feature = "abi-7-12")]
-            Operation::CuseInit(_x) => write!(f, "CUSE_INIT"),
+            Operation::CuseInit(_) => write!(f, "CUSE_INIT"),
         }
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -291,7 +291,11 @@ impl<'a> Request<'a> {
                     self.request.nodeid().into(),
                     x.file_handle().into(),
                     x.offset(),
-                    ReplyDirectory::new(self.request.unique().into(), self.ch, x.size() as usize),
+                    ReplyDirectory::new(
+                        self.request.unique().into(),
+                        self.ch.clone(),
+                        x.size() as usize,
+                    ),
                 );
             }
             ll::Operation::ReleaseDir(x) => {
@@ -466,7 +470,7 @@ impl<'a> Request<'a> {
                     x.offset(),
                     ReplyDirectoryPlus::new(
                         self.request.unique().into(),
-                        self.ch,
+                        self.ch.clone(),
                         x.size() as usize,
                     ),
                 );
@@ -543,7 +547,7 @@ impl<'a> Request<'a> {
     /// Create a reply object for this request that can be passed to the filesystem
     /// implementation and makes sure that a request is replied exactly once
     fn reply<T: Reply>(&self) -> T {
-        Reply::new(self.request.unique().into(), self.ch)
+        Reply::new(self.request.unique().into(), self.ch.clone())
     }
 
     /// Returns the unique identifier of this request

--- a/src/session.rs
+++ b/src/session.rs
@@ -133,6 +133,10 @@ impl<FS: Filesystem> Session<FS> {
         }
         Ok(())
     }
+    /// Unmount the filesystem
+    pub fn unmount(&mut self) {
+        drop(std::mem::take(&mut self.mount));
+    }
 }
 
 fn aligned_sub_buf(buf: &mut [u8], alignment: usize) -> &mut [u8] {
@@ -188,6 +192,15 @@ impl BackgroundSession {
             _mount: mount,
         })
     }
+    /// Unmount the filesystem and join the background thread.
+    pub fn join(self) {
+        let Self {
+            mountpoint: _,
+            guard,
+            _mount,
+        } = self;
+        drop(_mount);
+        guard.join().unwrap().unwrap();
     }
 }
 


### PR DESCRIPTION
This splits `Channel` in two.  `Channel` now only encapsulates reading from the FUSE device.  It is no longer responsible for unmounting the filesystem.  Unmounting falls to a new, backend-specific, struct `Mount`. `Channel` and `ChannelSender` now have shared ownership (via `Arc`) of the FUSE device, and it's closed when it's no longer needed.

The `Mount` belongs to session.  This way the `Session` can drop the mount
without also closing the fuse device file. This is important as we don't
want to close an FD that is still in use as we can cause the equivalent
of use-after-free bugs†.  When a filesystem is unmounted the devices
return `ENODEV`, so should naturally exit as well in an orderly fashion
and without races.

Ownership is now a lot more straightforward.  In particular the libfuse3
`fuse_session` lifecycle was a little confused before, while now we use
RAII in a straightforward fashion to ensure things are cleaned up
correctly, and not cleaned up twice.  The previous implementation had a
bug where it would never be freed because `fuse_session_unmount` would
only be called on null pointers.

The fuse device objects are plain `std::fs::File`s with ownership over the
underlying FD.  Note: although they are Files, we still implement our own
reading and writing via `libc::read` and `libc::writev` due to concerns
about the guarantees that `std::fs::File`'s `AsyncRead` and `AsyncWrite`
provides.  We can still revisit this decison in the future.

Generally I've followed the principle that it's a good idea to encapsulate
an FD as soon as we can for greater confidence that it will get cleaned
up correctly.

This contains API additions, but no API breakage.

**TODO:**

- [x] Re-instate polling fd before attempting unmount