### PR TITLE
Api changes to support async api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         libfuse: [libfuse-dev, libfuse3-dev]
-        features: [ '', 'abi-7-19' ]
+        features: [ '', 'abi-7-19', "async_impl" ]
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +84,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,9 +111,13 @@ dependencies = [
 name = "fuser"
 version = "0.7.0"
 dependencies = [
+ "async-trait",
  "bincode",
  "clap",
+ "derivative",
  "env_logger",
+ "futures",
+ "futures-await-test",
  "libc",
  "log",
  "page_size",
@@ -99,6 +125,119 @@ dependencies = [
  "serde",
  "users",
  "zerocopy",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-await-test"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae0d3d05bce73a572ba581e4f4a7f20164c18150169c3a67f406aada3e48c7e8"
+dependencies = [
+ "futures-await-test-macro",
+ "futures-executor",
+]
+
+[[package]]
+name = "futures-await-test-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f150175e6832600500334550e00e4dc563a0b32f58a9d1ad407f6473378c839"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
+
+[[package]]
+name = "futures-task"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
+
+[[package]]
+name = "futures-util"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
 ]
 
 [[package]]
@@ -154,10 +293,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -216,6 +379,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,9 +392,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "8fd9bc7ccc2688b3344c2f48b9b546648b25ce0b20fc717ee7fa7981a8ca9717"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ users = "0.11.0"
 page_size = "0.4.2"
 serde = {version = "1.0.102", features = ["std", "derive"], optional = true}
 zerocopy = "0.3"
-async-trait = "0.1.42"
-futures = "0.3.13"
-derivative = "2.2.0"
+async-trait = {version = "0.1.42", optional = true}
+futures = {version = "0.3.13", optional = true}
+derivative = {version = "2.2.0", optional = true}
 
 [dev-dependencies]
 env_logger = "0.8"
@@ -41,7 +41,8 @@ pkg-config = {version = "0.3.14", optional = true }
 default = ["libfuse"]
 libfuse = ["pkg-config"]
 serializable = ["serde"]
-async_impl = []
+async_api = ["async-trait", "futures", "derivative"]
+async_impl = ["async_api"]
 abi-7-9 = []
 abi-7-10 = ["abi-7-9"]
 abi-7-11 = ["abi-7-10"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,16 @@ users = "0.11.0"
 page_size = "0.4.2"
 serde = {version = "1.0.102", features = ["std", "derive"], optional = true}
 zerocopy = "0.3"
+async-trait = "0.1.42"
+futures = "0.3.13"
+derivative = "2.2.0"
 
 [dev-dependencies]
 env_logger = "0.8"
 clap = "2.32"
 bincode = "1.3.1"
 serde = {version = "1.0.102", features=["std", "derive"]}
+futures-await-test = "0.3.0"
 
 [build-dependencies]
 pkg-config = {version = "0.3.14", optional = true }
@@ -37,6 +41,7 @@ pkg-config = {version = "0.3.14", optional = true }
 default = ["libfuse"]
 libfuse = ["pkg-config"]
 serializable = ["serde"]
+async_impl = []
 abi-7-9 = []
 abi-7-10 = ["abi-7-9"]
 abi-7-11 = ["abi-7-10"]

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ pre:
 	cargo clippy --all-targets
 	cargo clippy --all-targets --no-default-features
 	cargo clippy --all-targets --features=abi-7-30
-
+	cargo clippy --all-targets --features async_api
+	cargo clippy --all-targets --features async_impl
 xfstests:
 	docker build -t fuser:xfstests -f xfstests.Dockerfile .
 	# Additional permissions are needed to be able to mount FUSE

--- a/src/async_api/active_session.rs
+++ b/src/async_api/active_session.rs
@@ -1,0 +1,192 @@
+//! Filesystem session
+//!
+//! A session runs a filesystem implementation while it is being mounted to a specific mount
+//! point. A session begins by mounting the filesystem and ends by unmounting it. While the
+//! filesystem is mounted, the session loop receives, dispatches and replies to kernel requests
+//! for filesystem operations under its mount point.
+
+use crate::async_api::request::Request;
+#[cfg(feature = "async_impl")]
+use crate::async_api::Filesystem;
+#[cfg(feature = "async_impl")]
+use crate::ll::fuse_abi as abi;
+
+#[cfg(feature = "async_impl")]
+use crate::session::BUFFER_SIZE;
+
+#[cfg(feature = "async_impl")]
+use log::warn;
+#[cfg(feature = "async_impl")]
+use std::ops::DerefMut;
+
+use std::{io, sync::Arc};
+
+use super::reply::ReplySender;
+#[derive(Debug, Clone, Default)]
+pub struct SessionConfiguration {
+    /// FUSE protocol major version
+    pub proto_major: u32,
+    /// FUSE protocol minor version
+    pub proto_minor: u32,
+}
+/// This is a handle that can be returned to the caller/user to query
+/// some high level aspects about the session or request it shut down.
+#[async_trait::async_trait]
+pub trait SessionHandle: Send + Sync {
+    /// Destroy the session and commence shutdown.
+    async fn destroy(&self) -> ();
+
+    /// Wait until the system has been destroyed, cleaned up and shut down.
+    async fn wait_destroy(&self) -> ();
+}
+#[async_trait::async_trait]
+pub(super) trait ActiveSession: SessionHandle {
+    /// Query if a session has been marked destroyed
+    /// The shutdown/cleanup may still be ongoing
+    fn destroyed(&self) -> bool;
+
+    /// Have we received an init message (version in formation will be available)
+    fn initialized(&self) -> bool;
+
+    async fn initialize(&self, version: &crate::ll::Version) -> ();
+    async fn wait_worker_shutdown(&self) -> ();
+
+    /// If an init message has been received/processed then this should return Some
+    /// otherwise None.
+    async fn session_configuration(&self) -> Option<SessionConfiguration>;
+}
+
+#[async_trait::async_trait]
+pub(in crate::async_api) trait Worker: Send + Sync {
+    // this method can presumed to only return when the worker/session is being shut down
+    // generally something like a one shot channel will back this.
+    async fn return_on_destory(&mut self) -> ();
+
+    async fn read_single_request<'a, 'b>(
+        &mut self,
+        buffer: &'b mut [u8],
+    ) -> Option<io::Result<Request<'b>>>;
+
+    async fn sender(&self) -> Arc<dyn ReplySender>;
+}
+
+#[cfg(feature = "async_impl")]
+pub(in crate::async_api) async fn main_request_loop(
+    active_session: &Arc<dyn ActiveSession>,
+    worker: &mut dyn Worker,
+    filesystem: Arc<dyn Filesystem>,
+) -> io::Result<()> {
+    // Buffer for receiving requests from the kernel. Only one is allocated and
+    // it is reused immediately after dispatching to conserve memory and allocations.
+    let mut buffer = vec![0; BUFFER_SIZE];
+    let buf = aligned_sub_buf(
+        buffer.deref_mut(),
+        std::mem::align_of::<abi::fuse_in_header>(),
+    );
+
+    loop {
+        if active_session.destroyed() {
+            return Ok(());
+        }
+
+        if let Some(req_or_err) = worker.read_single_request(buf).await {
+            let req = req_or_err?;
+            let filesystem = filesystem.clone();
+
+            match req
+                .dispatch(&active_session, filesystem, worker.sender().await)
+                .await
+            {
+                Ok(_) => {}
+                Err(e) => {
+                    warn!("I/O failure in dispatch paths: {:#?}", e);
+                }
+            };
+        }
+    }
+}
+
+/// Spin around in the state waiting to ensure we are initialized.
+/// There is a possbile race/blocking condition here in that one channel may get an init, and another channel may then
+/// get a valid message. So while we won't process messages _before_ an init, a single channel if it gets its first message
+/// after a different channel got the init we will need to process that as if we were in the main loop.
+#[cfg(feature = "async_impl")]
+pub(in crate::async_api) async fn wait_for_init(
+    active_session: &Arc<dyn ActiveSession>,
+    worker: &mut dyn Worker,
+    filesystem: Arc<dyn Filesystem>,
+) -> io::Result<()> {
+    loop {
+        let mut buffer = vec![0; BUFFER_SIZE];
+        let buf = aligned_sub_buf(
+            buffer.deref_mut(),
+            std::mem::align_of::<abi::fuse_in_header>(),
+        );
+
+        if active_session.destroyed() {
+            return Ok(());
+        }
+
+        if let Some(req_or_err) = worker.read_single_request(buf).await {
+            let req = req_or_err?;
+            if !active_session.initialized() {
+                req.dispatch_init(&active_session, &filesystem, worker.sender().await)
+                    .await;
+            } else {
+                let filesystem = filesystem.clone();
+                match req
+                    .dispatch(&active_session, filesystem, worker.sender().await)
+                    .await
+                {
+                    Ok(_) => {}
+                    Err(e) => {
+                        warn!("I/O failure in dispatch paths: {:#?}", e);
+                    }
+                };
+            }
+
+            if active_session.initialized() {
+                return Ok(());
+            }
+        }
+    }
+}
+
+#[cfg(feature = "async_impl")]
+pub(in crate::async_api) async fn spawn_worker_loop(
+    active_session: Arc<dyn ActiveSession>,
+    worker: &mut dyn Worker,
+    filesystem: Arc<dyn Filesystem>,
+) -> io::Result<()> {
+    crate::async_api::active_session::wait_for_init(&active_session, worker, filesystem.clone())
+        .await?;
+    crate::async_api::active_session::main_request_loop(&active_session, worker, filesystem.clone())
+        .await
+}
+
+#[cfg(feature = "async_impl")]
+pub(in crate::async_api) async fn driver_evt_loop(
+    active_session: Arc<dyn ActiveSession>,
+    mut filesystem: Arc<dyn Filesystem>,
+) -> io::Result<()> {
+    let _ = active_session.wait_destroy().await;
+    active_session.wait_worker_shutdown().await;
+
+    loop {
+        if let Some(fs) = Arc::get_mut(&mut filesystem) {
+            fs.destroy().await;
+            break;
+        }
+    }
+    return Ok(());
+}
+
+#[cfg(feature = "async_impl")]
+fn aligned_sub_buf(buf: &mut [u8], alignment: usize) -> &mut [u8] {
+    let off = alignment - (buf.as_ptr() as usize) % alignment;
+    if off == alignment {
+        buf
+    } else {
+        &mut buf[off..]
+    }
+}

--- a/src/async_api/active_session.rs
+++ b/src/async_api/active_session.rs
@@ -60,7 +60,7 @@ pub(super) trait ActiveSession: SessionHandle {
 pub(in crate::async_api) trait Worker: Send + Sync {
     // this method can presumed to only return when the worker/session is being shut down
     // generally something like a one shot channel will back this.
-    async fn return_on_destory(&mut self) -> ();
+    async fn wait_for_shutdown(&mut self) -> ();
 
     async fn read_single_request<'a, 'b>(
         &mut self,

--- a/src/async_api/opened_session.rs
+++ b/src/async_api/opened_session.rs
@@ -1,0 +1,47 @@
+//! Filesystem session
+//!
+//! A session runs a filesystem implementation while it is being mounted to a specific mount
+//! point. A session begins by mounting the filesystem and ends by unmounting it. While the
+//! filesystem is mounted, the session loop receives, dispatches and replies to kernel requests
+//! for filesystem operations under its mount point.
+
+use crate::async_api::Filesystem;
+
+use std::{io, sync::Arc};
+
+use super::SessionHandle;
+
+#[async_trait::async_trait]
+pub trait OpenedFlavor {
+    async fn spawn_run(self, fs: Arc<dyn Filesystem>) -> io::Result<Arc<dyn SessionHandle>>;
+}
+
+/// The session data structure
+#[derive(Debug)]
+pub struct OpenedSession<FS: Filesystem + 'static, OF: OpenedFlavor + 'static> {
+    /// Filesystem operation implementations
+    pub filesystem: FS,
+    /// Communication channel to the kernel driver
+    pub(in crate::async_api) opened_flavor: OF,
+}
+
+impl<FS: Filesystem + 'static, OF: OpenedFlavor + 'static> OpenedSession<FS, OF> {
+    /// Run the session loop that receives kernel requests and dispatches them to method
+    /// calls into the filesystem. This spawns as a task in tokio returning that task
+    #[cfg(feature = "async_impl")]
+    pub async fn spawn_run(self) -> io::Result<Arc<dyn SessionHandle>> {
+        let OpenedSession {
+            filesystem,
+            opened_flavor,
+        } = self;
+        opened_flavor.spawn_run(Arc::new(filesystem)).await
+    }
+
+    /// Run the session loop that receives kernel requests and dispatches them to method
+    /// calls into the filesystem. This async method will not return until the system is shut down.
+    #[cfg(feature = "async_impl")]
+    pub async fn run(self) -> io::Result<()> {
+        self.spawn_run().await?.wait_destroy().await;
+        Ok(())
+    }
+}

--- a/src/async_api/reply.rs
+++ b/src/async_api/reply.rs
@@ -1,0 +1,1336 @@
+//! Filesystem operation reply
+//!
+//! A reply is passed to filesystem operation implementations and must be used to send back the
+//! result of an operation. The reply can optionally be sent to another thread to asynchronously
+//! work on an operation and provide the result later. Also it allows replying with a block of
+//! data without cloning the data. A reply *must always* be used (by calling either ok() or
+//! error() exactly once).
+
+#[cfg(target_os = "macos")]
+use crate::ll::fuse_abi::fuse_getxtimes_out;
+use crate::ll::fuse_abi::{
+    fuse_attr, fuse_attr_out, fuse_bmap_out, fuse_create_out, fuse_dirent, fuse_direntplus,
+    fuse_entry_out, fuse_file_lock, fuse_getxattr_out, fuse_ioctl_out, fuse_kstatfs, fuse_lk_out,
+    fuse_lseek_out, fuse_open_out, fuse_out_header, fuse_statfs_out, fuse_write_out,
+};
+use crate::{FileAttr, FileType};
+use async_trait::async_trait;
+use libc::{c_int, EIO, S_IFBLK, S_IFCHR, S_IFDIR, S_IFIFO, S_IFLNK, S_IFREG, S_IFSOCK};
+use log::warn;
+use std::ffi::OsStr;
+use std::fmt;
+use std::marker::PhantomData;
+use std::mem;
+use std::os::unix::ffi::OsStrExt;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::{
+    convert::{AsRef, TryInto},
+    sync::Arc,
+};
+use zerocopy::AsBytes;
+
+/// Generic reply callback to send data
+#[async_trait]
+pub trait ReplySender: Send + Sync + 'static {
+    /// Send data.
+    async fn send(&self, data: &[&[u8]]);
+}
+
+impl fmt::Debug for Box<dyn ReplySender> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "Box<ReplySender>")
+    }
+}
+
+/// Generic reply trait
+pub trait Reply {
+    /// Create a new reply for the given request
+    fn new(unique: u64, sender: Arc<dyn ReplySender>) -> Self;
+}
+
+fn time_from_system_time(system_time: &SystemTime) -> (i64, u32) {
+    // Convert to signed 64-bit time with epoch at 0
+    match system_time.duration_since(UNIX_EPOCH) {
+        Ok(duration) => (duration.as_secs() as i64, duration.subsec_nanos()),
+        Err(before_epoch_error) => (
+            -(before_epoch_error.duration().as_secs() as i64),
+            before_epoch_error.duration().subsec_nanos(),
+        ),
+    }
+}
+
+// Some platforms like Linux x86_64 have mode_t = u32, and lint warns of a trivial_numeric_casts.
+// But others like macOS x86_64 have mode_t = u16, requiring a typecast.  So, just silence lint.
+#[allow(trivial_numeric_casts)]
+/// Returns the mode for a given file kind and permission
+fn mode_from_kind_and_perm(kind: FileType, perm: u16) -> u32 {
+    (match kind {
+        FileType::NamedPipe => S_IFIFO,
+        FileType::CharDevice => S_IFCHR,
+        FileType::BlockDevice => S_IFBLK,
+        FileType::Directory => S_IFDIR,
+        FileType::RegularFile => S_IFREG,
+        FileType::Symlink => S_IFLNK,
+        FileType::Socket => S_IFSOCK,
+    }) as u32
+        | perm as u32
+}
+
+/// Returns a fuse_attr from FileAttr
+#[cfg(target_os = "macos")]
+fn fuse_attr_from_attr(attr: &FileAttr) -> fuse_attr {
+    let (atime_secs, atime_nanos) = time_from_system_time(&attr.atime);
+    let (mtime_secs, mtime_nanos) = time_from_system_time(&attr.mtime);
+    let (ctime_secs, ctime_nanos) = time_from_system_time(&attr.ctime);
+    let (crtime_secs, crtime_nanos) = time_from_system_time(&attr.crtime);
+
+    fuse_attr {
+        ino: attr.ino,
+        size: attr.size,
+        blocks: attr.blocks,
+        atime: atime_secs,
+        mtime: mtime_secs,
+        ctime: ctime_secs,
+        crtime: crtime_secs as u64,
+        atimensec: atime_nanos,
+        mtimensec: mtime_nanos,
+        ctimensec: ctime_nanos,
+        crtimensec: crtime_nanos,
+        mode: mode_from_kind_and_perm(attr.kind, attr.perm),
+        nlink: attr.nlink,
+        uid: attr.uid,
+        gid: attr.gid,
+        rdev: attr.rdev,
+        flags: attr.flags,
+        #[cfg(feature = "abi-7-9")]
+        blksize: attr.blksize,
+        #[cfg(feature = "abi-7-9")]
+        padding: attr.padding,
+    }
+}
+
+/// Returns a fuse_attr from FileAttr
+#[cfg(not(target_os = "macos"))]
+fn fuse_attr_from_attr(attr: &FileAttr) -> fuse_attr {
+    let (atime_secs, atime_nanos) = time_from_system_time(&attr.atime);
+    let (mtime_secs, mtime_nanos) = time_from_system_time(&attr.mtime);
+    let (ctime_secs, ctime_nanos) = time_from_system_time(&attr.ctime);
+
+    fuse_attr {
+        ino: attr.ino,
+        size: attr.size,
+        blocks: attr.blocks,
+        atime: atime_secs,
+        mtime: mtime_secs,
+        ctime: ctime_secs,
+        atimensec: atime_nanos,
+        mtimensec: mtime_nanos,
+        ctimensec: ctime_nanos,
+        mode: mode_from_kind_and_perm(attr.kind, attr.perm),
+        nlink: attr.nlink,
+        uid: attr.uid,
+        gid: attr.gid,
+        rdev: attr.rdev,
+        #[cfg(feature = "abi-7-9")]
+        blksize: attr.blksize,
+        #[cfg(feature = "abi-7-9")]
+        padding: attr.padding,
+    }
+}
+
+///
+/// Raw reply
+///
+#[derive(derivative::Derivative)]
+#[derivative(Debug)]
+pub(crate) struct ReplyRaw<T: AsBytes> {
+    /// Unique id of the request to reply to
+    unique: u64,
+    /// Closure to call for sending the reply
+    #[derivative(Debug = "ignore")]
+    sender: Option<Arc<dyn ReplySender>>,
+    /// Marker for being able to have T on this struct (which enforces
+    /// reply types to send the correct type of data)
+    marker: PhantomData<T>,
+}
+
+impl<T: AsBytes> Reply for ReplyRaw<T> {
+    fn new(unique: u64, sender: Arc<dyn ReplySender>) -> ReplyRaw<T> {
+        ReplyRaw {
+            unique,
+            sender: Some(sender),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<T: AsBytes> ReplyRaw<T> {
+    /// Reply to a request with the given error code and data. Must be called
+    /// only once (the `ok` and `error` methods ensure this by consuming `self`)
+    async fn send(&mut self, err: c_int, bytes: &[&[u8]]) {
+        assert!(self.sender.is_some());
+        let len = bytes.iter().fold(0, |l, b| l + b.len());
+        let header = fuse_out_header {
+            len: (mem::size_of::<fuse_out_header>() + len) as u32,
+            error: -err,
+            unique: self.unique,
+        };
+        let sender = self.sender.take().unwrap();
+        let mut sendbytes = [header.as_bytes()].to_vec();
+        sendbytes.extend(bytes);
+        sender.send(&sendbytes).await;
+    }
+
+    /// Reply to a request with the given type
+    pub async fn ok(mut self, data: &T) {
+        self.send(0, &[data.as_bytes()]).await;
+    }
+
+    /// Reply to a request with the given error code
+    pub async fn error(mut self, err: c_int) {
+        self.send(err, &[]).await;
+    }
+}
+
+impl<T: AsBytes> Drop for ReplyRaw<T> {
+    fn drop(&mut self) {
+        if self.sender.is_some() {
+            warn!(
+                "Reply not sent for operation {}, replying with I/O error",
+                self.unique
+            );
+            futures::executor::block_on(self.send(EIO, &[]));
+        }
+    }
+}
+
+///
+/// Empty reply
+///
+#[derive(Debug)]
+pub struct ReplyEmpty {
+    reply: ReplyRaw<()>,
+}
+
+impl Reply for ReplyEmpty {
+    fn new(unique: u64, sender: Arc<dyn ReplySender>) -> ReplyEmpty {
+        ReplyEmpty {
+            reply: Reply::new(unique, sender),
+        }
+    }
+}
+
+impl ReplyEmpty {
+    /// Reply to a request with nothing
+    pub async fn ok(mut self) {
+        self.reply.send(0, &[]).await;
+    }
+
+    /// Reply to a request with the given error code
+    pub async fn error(self, err: c_int) {
+        self.reply.error(err).await;
+    }
+}
+
+///
+/// Data reply
+///
+#[derive(Debug)]
+pub struct ReplyData {
+    reply: ReplyRaw<()>,
+}
+
+impl Reply for ReplyData {
+    fn new(unique: u64, sender: Arc<dyn ReplySender>) -> ReplyData {
+        ReplyData {
+            reply: Reply::new(unique, sender),
+        }
+    }
+}
+
+impl ReplyData {
+    /// Reply to a request with the given data
+    pub async fn data(mut self, data: &[u8]) {
+        self.reply.send(0, &[data]).await
+    }
+
+    /// Reply to a request with the given error code
+    pub async fn error(self, err: c_int) {
+        self.reply.error(err).await
+    }
+}
+
+///
+/// Entry reply
+///
+#[derive(Debug)]
+pub struct ReplyEntry {
+    reply: ReplyRaw<fuse_entry_out>,
+}
+
+impl Reply for ReplyEntry {
+    fn new(unique: u64, sender: Arc<dyn ReplySender>) -> ReplyEntry {
+        ReplyEntry {
+            reply: Reply::new(unique, sender),
+        }
+    }
+}
+
+impl ReplyEntry {
+    /// Reply to a request with the given entry
+    pub async fn entry(self, ttl: &Duration, attr: &FileAttr, generation: u64) {
+        self.reply
+            .ok(&fuse_entry_out {
+                nodeid: attr.ino,
+                generation,
+                entry_valid: ttl.as_secs(),
+                attr_valid: ttl.as_secs(),
+                entry_valid_nsec: ttl.subsec_nanos(),
+                attr_valid_nsec: ttl.subsec_nanos(),
+                attr: fuse_attr_from_attr(attr),
+            })
+            .await;
+    }
+
+    /// Reply to a request with the given error code
+    pub async fn error(self, err: c_int) {
+        self.reply.error(err).await
+    }
+}
+
+///
+/// Attribute Reply
+///
+#[derive(Debug)]
+pub struct ReplyAttr {
+    reply: ReplyRaw<fuse_attr_out>,
+}
+
+impl Reply for ReplyAttr {
+    fn new(unique: u64, sender: Arc<dyn ReplySender>) -> ReplyAttr {
+        ReplyAttr {
+            reply: Reply::new(unique, sender),
+        }
+    }
+}
+
+impl ReplyAttr {
+    /// Reply to a request with the given attribute
+    pub async fn attr(self, ttl: &Duration, attr: &FileAttr) {
+        self.reply
+            .ok(&fuse_attr_out {
+                attr_valid: ttl.as_secs(),
+                attr_valid_nsec: ttl.subsec_nanos(),
+                dummy: 0,
+                attr: fuse_attr_from_attr(attr),
+            })
+            .await
+    }
+
+    /// Reply to a request with the given error code
+    pub async fn error(self, err: c_int) {
+        self.reply.error(err).await
+    }
+}
+
+///
+/// XTimes Reply
+///
+#[cfg(target_os = "macos")]
+#[derive(Debug)]
+pub struct ReplyXTimes {
+    reply: ReplyRaw<fuse_getxtimes_out>,
+}
+
+#[cfg(target_os = "macos")]
+impl Reply for ReplyXTimes {
+    fn new(unique: u64, sender: Arc<dyn ReplySender>) -> ReplyXTimes {
+        ReplyXTimes {
+            reply: Reply::new(unique, sender),
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl ReplyXTimes {
+    /// Reply to a request with the given xtimes
+    pub async fn xtimes(self, bkuptime: SystemTime, crtime: SystemTime) {
+        let (bkuptime_secs, bkuptime_nanos) = time_from_system_time(&bkuptime);
+        let (crtime_secs, crtime_nanos) = time_from_system_time(&crtime);
+        self.reply
+            .ok(&fuse_getxtimes_out {
+                bkuptime: bkuptime_secs as u64,
+                crtime: crtime_secs as u64,
+                bkuptimensec: bkuptime_nanos,
+                crtimensec: crtime_nanos,
+            })
+            .await;
+    }
+
+    /// Reply to a request with the given error code
+    pub async fn error(self, err: c_int) {
+        self.reply.error(err).await;
+    }
+}
+
+///
+/// Open Reply
+///
+#[derive(Debug)]
+pub struct ReplyOpen {
+    reply: ReplyRaw<fuse_open_out>,
+}
+
+impl Reply for ReplyOpen {
+    fn new(unique: u64, sender: Arc<dyn ReplySender>) -> ReplyOpen {
+        ReplyOpen {
+            reply: Reply::new(unique, sender),
+        }
+    }
+}
+
+impl ReplyOpen {
+    /// Reply to a request with the given open result
+    pub async fn opened(self, fh: u64, flags: u32) {
+        self.reply
+            .ok(&fuse_open_out {
+                fh,
+                open_flags: flags,
+                padding: 0,
+            })
+            .await
+    }
+
+    /// Reply to a request with the given error code
+    pub async fn error(self, err: c_int) {
+        self.reply.error(err).await
+    }
+}
+
+///
+/// Write Reply
+///
+#[derive(Debug)]
+pub struct ReplyWrite {
+    reply: ReplyRaw<fuse_write_out>,
+}
+
+impl Reply for ReplyWrite {
+    fn new(unique: u64, sender: Arc<dyn ReplySender>) -> ReplyWrite {
+        ReplyWrite {
+            reply: Reply::new(unique, sender),
+        }
+    }
+}
+
+impl ReplyWrite {
+    /// Reply to a request with the given open result
+    pub async fn written(self, size: u32) {
+        self.reply.ok(&fuse_write_out { size, padding: 0 }).await;
+    }
+
+    /// Reply to a request with the given error code
+    pub async fn error(self, err: c_int) {
+        self.reply.error(err).await;
+    }
+}
+
+///
+/// Statfs Reply
+///
+#[derive(Debug)]
+pub struct ReplyStatfs {
+    reply: ReplyRaw<fuse_statfs_out>,
+}
+
+impl Reply for ReplyStatfs {
+    fn new(unique: u64, sender: Arc<dyn ReplySender>) -> ReplyStatfs {
+        ReplyStatfs {
+            reply: Reply::new(unique, sender),
+        }
+    }
+}
+
+impl ReplyStatfs {
+    /// Reply to a request with the given open result
+    #[allow(clippy::too_many_arguments)]
+    pub async fn statfs(
+        self,
+        blocks: u64,
+        bfree: u64,
+        bavail: u64,
+        files: u64,
+        ffree: u64,
+        bsize: u32,
+        namelen: u32,
+        frsize: u32,
+    ) {
+        self.reply
+            .ok(&fuse_statfs_out {
+                st: fuse_kstatfs {
+                    blocks,
+                    bfree,
+                    bavail,
+                    files,
+                    ffree,
+                    bsize,
+                    namelen,
+                    frsize,
+                    padding: 0,
+                    spare: [0; 6],
+                },
+            })
+            .await;
+    }
+
+    /// Reply to a request with the given error code
+    pub async fn error(self, err: c_int) {
+        self.reply.error(err).await;
+    }
+}
+
+///
+/// Create reply
+///
+#[derive(Debug)]
+pub struct ReplyCreate {
+    reply: ReplyRaw<fuse_create_out>,
+}
+
+impl Reply for ReplyCreate {
+    fn new(unique: u64, sender: Arc<dyn ReplySender>) -> ReplyCreate {
+        ReplyCreate {
+            reply: Reply::new(unique, sender),
+        }
+    }
+}
+
+impl ReplyCreate {
+    /// Reply to a request with the given entry
+    pub async fn created(
+        self,
+        ttl: &Duration,
+        attr: &FileAttr,
+        generation: u64,
+        fh: u64,
+        flags: u32,
+    ) {
+        self.reply
+            .ok(&fuse_create_out(
+                fuse_entry_out {
+                    nodeid: attr.ino,
+                    generation,
+                    entry_valid: ttl.as_secs(),
+                    attr_valid: ttl.as_secs(),
+                    entry_valid_nsec: ttl.subsec_nanos(),
+                    attr_valid_nsec: ttl.subsec_nanos(),
+                    attr: fuse_attr_from_attr(attr),
+                },
+                fuse_open_out {
+                    fh,
+                    open_flags: flags,
+                    padding: 0,
+                },
+            ))
+            .await;
+    }
+
+    /// Reply to a request with the given error code
+    pub async fn error(self, err: c_int) {
+        self.reply.error(err).await;
+    }
+}
+
+///
+/// Lock Reply
+///
+#[derive(Debug)]
+pub struct ReplyLock {
+    reply: ReplyRaw<fuse_lk_out>,
+}
+
+impl Reply for ReplyLock {
+    fn new(unique: u64, sender: Arc<dyn ReplySender>) -> ReplyLock {
+        ReplyLock {
+            reply: Reply::new(unique, sender),
+        }
+    }
+}
+
+impl ReplyLock {
+    /// Reply to a request with the given open result
+    pub async fn locked(self, start: u64, end: u64, typ: i32, pid: u32) {
+        self.reply
+            .ok(&fuse_lk_out {
+                lk: fuse_file_lock {
+                    start,
+                    end,
+                    typ,
+                    pid,
+                },
+            })
+            .await;
+    }
+
+    /// Reply to a request with the given error code
+    pub async fn error(self, err: c_int) {
+        self.reply.error(err).await;
+    }
+}
+
+///
+/// Bmap Reply
+///
+#[derive(Debug)]
+pub struct ReplyBmap {
+    reply: ReplyRaw<fuse_bmap_out>,
+}
+
+impl Reply for ReplyBmap {
+    fn new(unique: u64, sender: Arc<dyn ReplySender>) -> ReplyBmap {
+        ReplyBmap {
+            reply: Reply::new(unique, sender),
+        }
+    }
+}
+
+impl ReplyBmap {
+    /// Reply to a request with the given open result
+    pub async fn bmap(self, block: u64) {
+        self.reply.ok(&fuse_bmap_out { block }).await;
+    }
+
+    /// Reply to a request with the given error code
+    pub async fn error(self, err: c_int) {
+        self.reply.error(err).await;
+    }
+}
+
+///
+/// Ioctl Reply
+///
+#[derive(Debug)]
+pub struct ReplyIoctl {
+    reply: ReplyRaw<fuse_ioctl_out>,
+}
+
+impl Reply for ReplyIoctl {
+    fn new(unique: u64, sender: Arc<dyn ReplySender>) -> ReplyIoctl {
+        ReplyIoctl {
+            reply: Reply::new(unique, sender),
+        }
+    }
+}
+
+impl ReplyIoctl {
+    /// Reply to a request with the given open result
+    pub async fn ioctl(mut self, result: i32, data: &[u8]) {
+        let header = fuse_ioctl_out {
+            result,
+            // these fields are only needed for unrestricted ioctls
+            flags: 0,
+            in_iovs: 1,
+            out_iovs: if !data.is_empty() { 1 } else { 0 },
+        };
+
+        if !data.is_empty() {
+            self.reply.send(0, &[header.as_bytes(), data]).await;
+        } else {
+            self.reply.send(0, &[header.as_bytes()]).await;
+        }
+    }
+
+    /// Reply to a request with the given error code
+    pub async fn error(self, err: c_int) {
+        self.reply.error(err).await;
+    }
+}
+
+///
+/// Directory reply
+///
+#[derive(Debug)]
+pub struct ReplyDirectory {
+    reply: ReplyRaw<()>,
+    data: Vec<u8>,
+}
+
+impl ReplyDirectory {
+    /// Creates a new ReplyDirectory with a specified buffer size.
+    pub fn new(unique: u64, sender: Arc<dyn ReplySender>, size: usize) -> ReplyDirectory {
+        ReplyDirectory {
+            reply: Reply::new(unique, sender),
+            data: Vec::with_capacity(size),
+        }
+    }
+
+    /// Add an entry to the directory reply buffer. Returns true if the buffer is full.
+    /// A transparent offset value can be provided for each entry. The kernel uses these
+    /// value to request the next entries in further readdir calls
+    #[must_use]
+    pub fn add<T: AsRef<OsStr>>(&mut self, ino: u64, offset: i64, kind: FileType, name: T) -> bool {
+        let name = name.as_ref().as_bytes();
+        let entlen = mem::size_of::<fuse_dirent>() + name.len();
+        let entsize = (entlen + mem::size_of::<u64>() - 1) & !(mem::size_of::<u64>() - 1); // 64bit align
+        if self.data.len() + entsize > self.data.capacity() {
+            return true;
+        }
+        let header = fuse_dirent {
+            ino,
+            off: offset,
+            namelen: name.len().try_into().expect("Name too long"),
+            typ: mode_from_kind_and_perm(kind, 0) >> 12,
+        };
+        self.data.extend_from_slice(header.as_bytes());
+        self.data.extend_from_slice(name);
+        let padlen = entsize - entlen;
+        self.data.extend_from_slice(&b"\0\0\0\0\0\0\0\0"[..padlen]);
+        false
+    }
+
+    /// Reply to a request with the filled directory buffer
+    pub async fn ok(mut self) {
+        self.reply.send(0, &[&self.data]).await;
+    }
+
+    /// Reply to a request with the given error code
+    pub async fn error(self, err: c_int) {
+        self.reply.error(err).await;
+    }
+}
+
+///
+/// DirectoryPlus reply
+///
+#[derive(Debug)]
+pub struct ReplyDirectoryPlus {
+    reply: ReplyRaw<()>,
+    data: Vec<u8>,
+}
+
+impl ReplyDirectoryPlus {
+    /// Creates a new ReplyDirectory with a specified buffer size.
+    pub fn new(unique: u64, sender: Arc<dyn ReplySender>, size: usize) -> ReplyDirectoryPlus {
+        ReplyDirectoryPlus {
+            reply: Reply::new(unique, sender),
+            data: Vec::with_capacity(size),
+        }
+    }
+
+    /// Add an entry to the directory reply buffer. Returns true if the buffer is full.
+    /// A transparent offset value can be provided for each entry. The kernel uses these
+    /// value to request the next entries in further readdir calls
+    pub fn add<T: AsRef<OsStr>>(
+        &mut self,
+        ino: u64,
+        offset: i64,
+        name: T,
+        ttl: &Duration,
+        attr: &FileAttr,
+        generation: u64,
+    ) -> bool {
+        let name = name.as_ref().as_bytes();
+        let entlen = mem::size_of::<fuse_direntplus>() + name.len();
+        let entsize = (entlen + mem::size_of::<u64>() - 1) & !(mem::size_of::<u64>() - 1); // 64bit align
+        let padlen = entsize - entlen;
+        if self.data.len() + entsize > self.data.capacity() {
+            return true;
+        }
+        let direntplus = fuse_direntplus {
+            entry_out: fuse_entry_out {
+                nodeid: attr.ino,
+                generation,
+                entry_valid: ttl.as_secs(),
+                attr_valid: ttl.as_secs(),
+                entry_valid_nsec: ttl.subsec_nanos(),
+                attr_valid_nsec: ttl.subsec_nanos(),
+                attr: fuse_attr_from_attr(attr),
+            },
+            dirent: fuse_dirent {
+                ino,
+                off: offset,
+                namelen: name.len().try_into().expect("Name too long"),
+                typ: mode_from_kind_and_perm(attr.kind, 0) >> 12,
+            },
+        };
+        self.data.extend_from_slice(direntplus.as_bytes());
+        self.data.extend_from_slice(name);
+        self.data.extend_from_slice(&b"\0\0\0\0\0\0\0\0"[..padlen]);
+        false
+    }
+
+    /// Reply to a request with the filled directory buffer
+    pub async fn ok(mut self) {
+        self.reply.send(0, &[&self.data]).await;
+    }
+
+    /// Reply to a request with the given error code
+    pub async fn error(self, err: c_int) {
+        self.reply.error(err).await;
+    }
+}
+
+///
+/// Xattr reply
+///
+#[derive(Debug)]
+pub struct ReplyXattr {
+    reply: ReplyRaw<fuse_getxattr_out>,
+}
+
+impl Reply for ReplyXattr {
+    fn new(unique: u64, sender: Arc<dyn ReplySender>) -> ReplyXattr {
+        ReplyXattr {
+            reply: Reply::new(unique, sender),
+        }
+    }
+}
+
+impl ReplyXattr {
+    /// Reply to a request with the size of the xattr.
+    pub async fn size(self, size: u32) {
+        self.reply.ok(&fuse_getxattr_out { size, padding: 0 }).await;
+    }
+
+    /// Reply to a request with the data in the xattr.
+    pub async fn data(mut self, data: &[u8]) {
+        self.reply.send(0, &[data]).await;
+    }
+
+    /// Reply to a request with the given error code.
+    pub async fn error(self, err: c_int) {
+        self.reply.error(err).await;
+    }
+}
+
+///
+/// Lseek Reply
+///
+#[derive(Debug)]
+pub struct ReplyLseek {
+    reply: ReplyRaw<fuse_lseek_out>,
+}
+
+impl Reply for ReplyLseek {
+    fn new(unique: u64, sender: Arc<dyn ReplySender>) -> ReplyLseek {
+        ReplyLseek {
+            reply: Reply::new(unique, sender),
+        }
+    }
+}
+
+impl ReplyLseek {
+    /// Reply to a request with seeked offset
+    pub async fn offset(self, offset: i64) {
+        self.reply.ok(&fuse_lseek_out { offset }).await;
+    }
+
+    /// Reply to a request with the given error code
+    pub async fn error(self, err: c_int) {
+        self.reply.error(err).await;
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use futures_await_test::async_test;
+
+    use super::AsBytes;
+
+    #[cfg(target_os = "macos")]
+    use super::ReplyXTimes;
+    use super::ReplyXattr;
+    use super::{Reply, ReplyAttr, ReplyData, ReplyEmpty, ReplyEntry, ReplyOpen, ReplyRaw};
+    use super::{ReplyBmap, ReplyCreate, ReplyDirectory, ReplyLock, ReplyStatfs, ReplyWrite};
+    use crate::{FileAttr, FileType};
+    use std::{
+        sync::Arc,
+        time::{Duration, UNIX_EPOCH},
+    };
+
+    #[allow(dead_code)]
+    #[derive(Debug, AsBytes)]
+    #[repr(C)]
+    struct Data {
+        a: u8,
+        b: u8,
+        c: u16,
+    }
+
+    #[test]
+    fn serialize_empty() {
+        assert!(().as_bytes().is_empty());
+    }
+
+    #[test]
+    fn serialize_slice() {
+        let data: [u8; 4] = [0x12, 0x34, 0x56, 0x78];
+        assert_eq!(data.as_bytes(), [0x12, 0x34, 0x56, 0x78]);
+    }
+
+    #[test]
+    fn serialize_struct() {
+        let data = Data {
+            a: 0x12,
+            b: 0x34,
+            c: 0x5678,
+        };
+        assert_eq!(data.as_bytes(), [0x12, 0x34, 0x78, 0x56]);
+    }
+
+    struct AssertSender {
+        expected: Vec<Vec<u8>>,
+    }
+
+    #[async_trait::async_trait]
+    impl super::ReplySender for AssertSender {
+        async fn send(&self, data: &[&[u8]]) {
+            assert_eq!(self.expected, data);
+        }
+    }
+
+    #[async_test]
+    async fn reply_raw() {
+        let data = Data {
+            a: 0x12,
+            b: 0x34,
+            c: 0x5678,
+        };
+        let sender = Arc::new(AssertSender {
+            expected: vec![
+                vec![
+                    0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xef, 0xbe, 0xad, 0xde, 0x00,
+                    0x00, 0x00, 0x00,
+                ],
+                vec![0x12, 0x34, 0x78, 0x56],
+            ],
+        });
+        let reply: ReplyRaw<Data> = Reply::new(0xdeadbeef, sender);
+        reply.ok(&data).await;
+    }
+
+    #[async_test]
+    async fn reply_error() {
+        let sender = Arc::new(AssertSender {
+            expected: vec![vec![
+                0x10, 0x00, 0x00, 0x00, 0xbe, 0xff, 0xff, 0xff, 0xef, 0xbe, 0xad, 0xde, 0x00, 0x00,
+                0x00, 0x00,
+            ]],
+        });
+        let reply: ReplyRaw<Data> = Reply::new(0xdeadbeef, sender);
+        reply.error(66).await;
+    }
+
+    #[async_test]
+    async fn reply_empty() {
+        let sender = Arc::new(AssertSender {
+            expected: vec![vec![
+                0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xef, 0xbe, 0xad, 0xde, 0x00, 0x00,
+                0x00, 0x00,
+            ]],
+        });
+        let reply: ReplyEmpty = Reply::new(0xdeadbeef, sender);
+        reply.ok().await;
+    }
+
+    #[async_test]
+    async fn reply_data() {
+        let sender = Arc::new(AssertSender {
+            expected: vec![
+                vec![
+                    0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xef, 0xbe, 0xad, 0xde, 0x00,
+                    0x00, 0x00, 0x00,
+                ],
+                vec![0xde, 0xad, 0xbe, 0xef],
+            ],
+        });
+        let reply: ReplyData = Reply::new(0xdeadbeef, sender);
+        reply.data(&[0xde, 0xad, 0xbe, 0xef]).await;
+    }
+
+    #[async_test]
+    async fn reply_entry() {
+        let mut expected = if cfg!(target_os = "macos") {
+            vec![
+                vec![
+                    0x98, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xef, 0xbe, 0xad, 0xde, 0x00,
+                    0x00, 0x00, 0x00,
+                ],
+                vec![
+                    0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xaa, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x65, 0x87, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x65, 0x87,
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x21, 0x43, 0x00, 0x00, 0x21, 0x43, 0x00,
+                    0x00, 0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x22, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x33, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34,
+                    0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34, 0x12, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x78, 0x56, 0x00, 0x00, 0x78, 0x56, 0x00, 0x00,
+                    0x78, 0x56, 0x00, 0x00, 0x78, 0x56, 0x00, 0x00, 0xa4, 0x81, 0x00, 0x00, 0x55,
+                    0x00, 0x00, 0x00, 0x66, 0x00, 0x00, 0x00, 0x77, 0x00, 0x00, 0x00, 0x88, 0x00,
+                    0x00, 0x00, 0x99, 0x00, 0x00, 0x00,
+                ],
+            ]
+        } else {
+            vec![
+                vec![
+                    0x88, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xef, 0xbe, 0xad, 0xde, 0x00,
+                    0x00, 0x00, 0x00,
+                ],
+                vec![
+                    0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xaa, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x65, 0x87, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x65, 0x87,
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x21, 0x43, 0x00, 0x00, 0x21, 0x43, 0x00,
+                    0x00, 0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x22, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x33, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34,
+                    0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x78, 0x56, 0x00,
+                    0x00, 0x78, 0x56, 0x00, 0x00, 0x78, 0x56, 0x00, 0x00, 0xa4, 0x81, 0x00, 0x00,
+                    0x55, 0x00, 0x00, 0x00, 0x66, 0x00, 0x00, 0x00, 0x77, 0x00, 0x00, 0x00, 0x88,
+                    0x00, 0x00, 0x00,
+                ],
+            ]
+        };
+
+        if cfg!(feature = "abi-7-9") {
+            expected[1].extend(vec![0xbb, 0x00, 0x00, 0x00, 0xcc, 0x00, 0x00, 0x00]);
+        }
+        expected[0][0] = (expected[0].len() + expected[1].len()) as u8;
+
+        let sender = Arc::new(AssertSender { expected });
+        let reply: ReplyEntry = Reply::new(0xdeadbeef, sender);
+        let time = UNIX_EPOCH + Duration::new(0x1234, 0x5678);
+        let ttl = Duration::new(0x8765, 0x4321);
+        let attr = FileAttr {
+            ino: 0x11,
+            size: 0x22,
+            blocks: 0x33,
+            atime: time,
+            mtime: time,
+            ctime: time,
+            crtime: time,
+            kind: FileType::RegularFile,
+            perm: 0o644,
+            nlink: 0x55,
+            uid: 0x66,
+            gid: 0x77,
+            rdev: 0x88,
+            flags: 0x99,
+            blksize: 0xbb,
+            padding: 0xcc,
+        };
+        reply.entry(&ttl, &attr, 0xaa).await;
+    }
+
+    #[async_test]
+    async fn reply_attr() {
+        let mut expected = if cfg!(target_os = "macos") {
+            vec![
+                vec![
+                    0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xef, 0xbe, 0xad, 0xde, 0x00,
+                    0x00, 0x00, 0x00,
+                ],
+                vec![
+                    0x65, 0x87, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x21, 0x43, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x22, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x33, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34, 0x12, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34,
+                    0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x78, 0x56, 0x00, 0x00, 0x78, 0x56,
+                    0x00, 0x00, 0x78, 0x56, 0x00, 0x00, 0x78, 0x56, 0x00, 0x00, 0xa4, 0x81, 0x00,
+                    0x00, 0x55, 0x00, 0x00, 0x00, 0x66, 0x00, 0x00, 0x00, 0x77, 0x00, 0x00, 0x00,
+                    0x88, 0x00, 0x00, 0x00, 0x99, 0x00, 0x00, 0x00,
+                ],
+            ]
+        } else {
+            vec![
+                vec![
+                    0x70, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xef, 0xbe, 0xad, 0xde, 0x00,
+                    0x00, 0x00, 0x00,
+                ],
+                vec![
+                    0x65, 0x87, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x21, 0x43, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x22, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x33, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34, 0x12, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x78,
+                    0x56, 0x00, 0x00, 0x78, 0x56, 0x00, 0x00, 0x78, 0x56, 0x00, 0x00, 0xa4, 0x81,
+                    0x00, 0x00, 0x55, 0x00, 0x00, 0x00, 0x66, 0x00, 0x00, 0x00, 0x77, 0x00, 0x00,
+                    0x00, 0x88, 0x00, 0x00, 0x00,
+                ],
+            ]
+        };
+
+        if cfg!(feature = "abi-7-9") {
+            expected[1].extend(vec![0xbb, 0x00, 0x00, 0x00, 0xcc, 0x00, 0x00, 0x00]);
+        }
+        expected[0][0] = (expected[0].len() + expected[1].len()) as u8;
+
+        let sender = Arc::new(AssertSender { expected });
+        let reply: ReplyAttr = Reply::new(0xdeadbeef, sender);
+        let time = UNIX_EPOCH + Duration::new(0x1234, 0x5678);
+        let ttl = Duration::new(0x8765, 0x4321);
+        let attr = FileAttr {
+            ino: 0x11,
+            size: 0x22,
+            blocks: 0x33,
+            atime: time,
+            mtime: time,
+            ctime: time,
+            crtime: time,
+            kind: FileType::RegularFile,
+            perm: 0o644,
+            nlink: 0x55,
+            uid: 0x66,
+            gid: 0x77,
+            rdev: 0x88,
+            flags: 0x99,
+            blksize: 0xbb,
+            padding: 0xcc,
+        };
+        reply.attr(&ttl, &attr).await;
+    }
+
+    #[async_test]
+    #[cfg(target_os = "macos")]
+    async fn reply_xtimes() {
+        let sender = Arc::new(AssertSender {
+            expected: vec![
+                vec![
+                    0x28, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xef, 0xbe, 0xad, 0xde, 0x00,
+                    0x00, 0x00, 0x00,
+                ],
+                vec![
+                    0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34, 0x12, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x78, 0x56, 0x00, 0x00, 0x78, 0x56, 0x00, 0x00,
+                ],
+            ],
+        });
+        let reply: ReplyXTimes = Reply::new(0xdeadbeef, sender);
+        let time = UNIX_EPOCH + Duration::new(0x1234, 0x5678);
+        reply.xtimes(time, time).await;
+    }
+
+    #[async_test]
+    async fn reply_open() {
+        let sender = Arc::new(AssertSender {
+            expected: vec![
+                vec![
+                    0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xef, 0xbe, 0xad, 0xde, 0x00,
+                    0x00, 0x00, 0x00,
+                ],
+                vec![
+                    0x22, 0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x33, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00,
+                ],
+            ],
+        });
+        let reply: ReplyOpen = Reply::new(0xdeadbeef, sender);
+        reply.opened(0x1122, 0x33).await;
+    }
+
+    #[async_test]
+    async fn reply_write() {
+        let sender = Arc::new(AssertSender {
+            expected: vec![
+                vec![
+                    0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xef, 0xbe, 0xad, 0xde, 0x00,
+                    0x00, 0x00, 0x00,
+                ],
+                vec![0x22, 0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            ],
+        });
+        let reply: ReplyWrite = Reply::new(0xdeadbeef, sender);
+        reply.written(0x1122).await;
+    }
+
+    #[async_test]
+    async fn reply_statfs() {
+        let sender = Arc::new(AssertSender {
+            expected: vec![
+                vec![
+                    0x60, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xef, 0xbe, 0xad, 0xde, 0x00,
+                    0x00, 0x00, 0x00,
+                ],
+                vec![
+                    0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x22, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x33, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x44, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x55, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x66, 0x00, 0x00, 0x00, 0x77, 0x00, 0x00, 0x00, 0x88, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00,
+                ],
+            ],
+        });
+        let reply: ReplyStatfs = Reply::new(0xdeadbeef, sender);
+        reply
+            .statfs(0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88)
+            .await;
+    }
+
+    #[async_test]
+    async fn reply_create() {
+        let mut expected = if cfg!(target_os = "macos") {
+            vec![
+                vec![
+                    0xa8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xef, 0xbe, 0xad, 0xde, 0x00,
+                    0x00, 0x00, 0x00,
+                ],
+                vec![
+                    0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xaa, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x65, 0x87, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x65, 0x87,
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x21, 0x43, 0x00, 0x00, 0x21, 0x43, 0x00,
+                    0x00, 0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x22, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x33, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34,
+                    0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34, 0x12, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x78, 0x56, 0x00, 0x00, 0x78, 0x56, 0x00, 0x00,
+                    0x78, 0x56, 0x00, 0x00, 0x78, 0x56, 0x00, 0x00, 0xa4, 0x81, 0x00, 0x00, 0x55,
+                    0x00, 0x00, 0x00, 0x66, 0x00, 0x00, 0x00, 0x77, 0x00, 0x00, 0x00, 0x88, 0x00,
+                    0x00, 0x00, 0x99, 0x00, 0x00, 0x00, 0xbb, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0xcc, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                ],
+            ]
+        } else {
+            vec![
+                vec![
+                    0x98, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xef, 0xbe, 0xad, 0xde, 0x00,
+                    0x00, 0x00, 0x00,
+                ],
+                vec![
+                    0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xaa, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x65, 0x87, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x65, 0x87,
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x21, 0x43, 0x00, 0x00, 0x21, 0x43, 0x00,
+                    0x00, 0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x22, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x33, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34,
+                    0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x78, 0x56, 0x00,
+                    0x00, 0x78, 0x56, 0x00, 0x00, 0x78, 0x56, 0x00, 0x00, 0xa4, 0x81, 0x00, 0x00,
+                    0x55, 0x00, 0x00, 0x00, 0x66, 0x00, 0x00, 0x00, 0x77, 0x00, 0x00, 0x00, 0x88,
+                    0x00, 0x00, 0x00, 0xbb, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xcc, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                ],
+            ]
+        };
+
+        if cfg!(feature = "abi-7-9") {
+            let insert_at = expected[1].len() - 16;
+            expected[1].splice(
+                insert_at..insert_at,
+                vec![0xdd, 0x00, 0x00, 0x00, 0xee, 0x00, 0x00, 0x00],
+            );
+        }
+        expected[0][0] = (expected[0].len() + expected[1].len()) as u8;
+
+        let sender = Arc::new(AssertSender { expected });
+        let reply: ReplyCreate = Reply::new(0xdeadbeef, sender);
+        let time = UNIX_EPOCH + Duration::new(0x1234, 0x5678);
+        let ttl = Duration::new(0x8765, 0x4321);
+        let attr = FileAttr {
+            ino: 0x11,
+            size: 0x22,
+            blocks: 0x33,
+            atime: time,
+            mtime: time,
+            ctime: time,
+            crtime: time,
+            kind: FileType::RegularFile,
+            perm: 0o644,
+            nlink: 0x55,
+            uid: 0x66,
+            gid: 0x77,
+            rdev: 0x88,
+            flags: 0x99,
+            blksize: 0xdd,
+            padding: 0xee,
+        };
+        reply.created(&ttl, &attr, 0xaa, 0xbb, 0xcc).await;
+    }
+
+    #[async_test]
+    async fn reply_lock() {
+        let sender = Arc::new(AssertSender {
+            expected: vec![
+                vec![
+                    0x28, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xef, 0xbe, 0xad, 0xde, 0x00,
+                    0x00, 0x00, 0x00,
+                ],
+                vec![
+                    0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x22, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x33, 0x00, 0x00, 0x00, 0x44, 0x00, 0x00, 0x00,
+                ],
+            ],
+        });
+        let reply: ReplyLock = Reply::new(0xdeadbeef, sender);
+        reply.locked(0x11, 0x22, 0x33, 0x44).await;
+    }
+
+    #[async_test]
+    async fn reply_bmap() {
+        let sender = Arc::new(AssertSender {
+            expected: vec![
+                vec![
+                    0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xef, 0xbe, 0xad, 0xde, 0x00,
+                    0x00, 0x00, 0x00,
+                ],
+                vec![0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            ],
+        });
+        let reply: ReplyBmap = Reply::new(0xdeadbeef, sender);
+        reply.bmap(0x1234).await;
+    }
+
+    #[async_test]
+    async fn reply_directory() {
+        let sender = Arc::new(AssertSender {
+            expected: vec![
+                vec![
+                    0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xef, 0xbe, 0xad, 0xde, 0x00,
+                    0x00, 0x00, 0x00,
+                ],
+                vec![
+                    0xbb, 0xaa, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x68, 0x65,
+                    0x6c, 0x6c, 0x6f, 0x00, 0x00, 0x00, 0xdd, 0xcc, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00,
+                    0x08, 0x00, 0x00, 0x00, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x2e, 0x72, 0x73,
+                ],
+            ],
+        });
+        let mut reply = ReplyDirectory::new(0xdeadbeef, sender, 4096);
+        assert!(!reply.add(0xaabb, 1, FileType::Directory, "hello"));
+        assert!(!reply.add(0xccdd, 2, FileType::RegularFile, "world.rs"));
+        reply.ok().await;
+    }
+
+    #[async_test]
+    async fn reply_xattr_size() {
+        let sender = Arc::new(AssertSender {
+            expected: vec![
+                vec![
+                    0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xEF, 0xBE, 0xAD, 0xDE, 0x00,
+                    0x00, 0x00, 0x00,
+                ],
+                vec![0x78, 0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00],
+            ],
+        });
+        let reply = ReplyXattr::new(0xdeadbeef, sender);
+        reply.size(0x12345678).await;
+    }
+
+    #[async_test]
+    async fn reply_xattr_data() {
+        let sender = Arc::new(AssertSender {
+            expected: vec![
+                vec![
+                    0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xEF, 0xBE, 0xAD, 0xDE, 0x00,
+                    0x00, 0x00, 0x00,
+                ],
+                vec![0x11, 0x22, 0x33, 0x44],
+            ],
+        });
+        let reply = ReplyXattr::new(0xdeadbeef, sender);
+        reply.data(&[0x11, 0x22, 0x33, 0x44]).await;
+    }
+}

--- a/src/async_api/reply.rs
+++ b/src/async_api/reply.rs
@@ -76,68 +76,6 @@ fn mode_from_kind_and_perm(kind: FileType, perm: u16) -> u32 {
         | perm as u32
 }
 
-/// Returns a fuse_attr from FileAttr
-#[cfg(target_os = "macos")]
-fn fuse_attr_from_attr(attr: &FileAttr) -> fuse_attr {
-    let (atime_secs, atime_nanos) = time_from_system_time(&attr.atime);
-    let (mtime_secs, mtime_nanos) = time_from_system_time(&attr.mtime);
-    let (ctime_secs, ctime_nanos) = time_from_system_time(&attr.ctime);
-    let (crtime_secs, crtime_nanos) = time_from_system_time(&attr.crtime);
-
-    fuse_attr {
-        ino: attr.ino,
-        size: attr.size,
-        blocks: attr.blocks,
-        atime: atime_secs,
-        mtime: mtime_secs,
-        ctime: ctime_secs,
-        crtime: crtime_secs as u64,
-        atimensec: atime_nanos,
-        mtimensec: mtime_nanos,
-        ctimensec: ctime_nanos,
-        crtimensec: crtime_nanos,
-        mode: mode_from_kind_and_perm(attr.kind, attr.perm),
-        nlink: attr.nlink,
-        uid: attr.uid,
-        gid: attr.gid,
-        rdev: attr.rdev,
-        flags: attr.flags,
-        #[cfg(feature = "abi-7-9")]
-        blksize: attr.blksize,
-        #[cfg(feature = "abi-7-9")]
-        padding: attr.padding,
-    }
-}
-
-/// Returns a fuse_attr from FileAttr
-#[cfg(not(target_os = "macos"))]
-fn fuse_attr_from_attr(attr: &FileAttr) -> fuse_attr {
-    let (atime_secs, atime_nanos) = time_from_system_time(&attr.atime);
-    let (mtime_secs, mtime_nanos) = time_from_system_time(&attr.mtime);
-    let (ctime_secs, ctime_nanos) = time_from_system_time(&attr.ctime);
-
-    fuse_attr {
-        ino: attr.ino,
-        size: attr.size,
-        blocks: attr.blocks,
-        atime: atime_secs,
-        mtime: mtime_secs,
-        ctime: ctime_secs,
-        atimensec: atime_nanos,
-        mtimensec: mtime_nanos,
-        ctimensec: ctime_nanos,
-        mode: mode_from_kind_and_perm(attr.kind, attr.perm),
-        nlink: attr.nlink,
-        uid: attr.uid,
-        gid: attr.gid,
-        rdev: attr.rdev,
-        #[cfg(feature = "abi-7-9")]
-        blksize: attr.blksize,
-        #[cfg(feature = "abi-7-9")]
-        padding: attr.padding,
-    }
-}
-
 ///
 /// Raw reply
 ///
@@ -287,7 +225,7 @@ impl ReplyEntry {
                 attr_valid: ttl.as_secs(),
                 entry_valid_nsec: ttl.subsec_nanos(),
                 attr_valid_nsec: ttl.subsec_nanos(),
-                attr: fuse_attr_from_attr(attr),
+                attr: crate::reply::fuse_attr_from_attr(attr),
             })
             .await;
     }
@@ -322,7 +260,7 @@ impl ReplyAttr {
                 attr_valid: ttl.as_secs(),
                 attr_valid_nsec: ttl.subsec_nanos(),
                 dummy: 0,
-                attr: fuse_attr_from_attr(attr),
+                attr: crate::reply::fuse_attr_from_attr(attr),
             })
             .await
     }
@@ -524,7 +462,7 @@ impl ReplyCreate {
                     attr_valid: ttl.as_secs(),
                     entry_valid_nsec: ttl.subsec_nanos(),
                     attr_valid_nsec: ttl.subsec_nanos(),
-                    attr: fuse_attr_from_attr(attr),
+                    attr: crate::reply::fuse_attr_from_attr(attr),
                 },
                 fuse_open_out {
                     fh,
@@ -744,7 +682,7 @@ impl ReplyDirectoryPlus {
                 attr_valid: ttl.as_secs(),
                 entry_valid_nsec: ttl.subsec_nanos(),
                 attr_valid_nsec: ttl.subsec_nanos(),
-                attr: fuse_attr_from_attr(attr),
+                attr: crate::reply::fuse_attr_from_attr(attr),
             },
             dirent: fuse_dirent {
                 ino,

--- a/src/async_api/request.rs
+++ b/src/async_api/request.rs
@@ -1,0 +1,723 @@
+//! Filesystem operation request
+//!
+//! A request represents information about a filesystem operation the kernel driver wants us to
+//! perform.
+//!
+//! TODO: This module is meant to go away soon in favor of `ll::Request`.
+
+#[cfg(feature = "async_impl")]
+use crate::async_api::ActiveSession;
+#[cfg(feature = "async_impl")]
+use crate::ll::fuse_abi as abi;
+#[cfg(feature = "async_impl")]
+use libc::{EIO, ENOSYS, EPROTO};
+use log::error;
+#[cfg(feature = "async_impl")]
+use log::{debug, warn};
+
+use std::convert::TryFrom;
+
+#[cfg(all(feature = "abi-7-28", feature = "async_impl"))]
+use std::convert::TryInto;
+
+#[cfg(feature = "async_impl")]
+use std::path::Path;
+
+#[cfg(feature = "async_impl")]
+use std::sync::Arc;
+
+#[cfg(feature = "abi-7-21")]
+use crate::async_api::reply::ReplyDirectoryPlus;
+
+#[cfg(feature = "async_impl")]
+use crate::async_api::reply::{Reply, ReplyDirectory, ReplyEmpty, ReplyRaw};
+#[cfg(feature = "async_impl")]
+use crate::async_api::Filesystem;
+use crate::ll;
+
+#[cfg(feature = "async_impl")]
+use crate::KernelConfig;
+
+#[cfg(feature = "async_impl")]
+use super::reply::ReplySender;
+
+/// Request data structure
+#[derive(Debug)]
+pub struct Request<'a> {
+    /// Request raw data
+    pub data: &'a [u8],
+    /// Parsed request
+    pub request: ll::Request<'a>,
+}
+
+impl<'a> Request<'a> {
+    /// Create a new request from the given data
+    pub fn new(data: &'a [u8]) -> Option<Request<'a>> {
+        let request = match ll::Request::try_from(data) {
+            Ok(request) => request,
+            Err(err) => {
+                // FIXME: Reply with ENOSYS?
+                error!("{}", err);
+                return None;
+            }
+        };
+
+        Some(Self { data, request })
+    }
+
+    #[cfg(feature = "async_impl")]
+    pub(in crate::async_api) async fn dispatch_init(
+        &self,
+        se: &Arc<dyn ActiveSession>,
+        filesystem: &Arc<dyn Filesystem>,
+        sender: Arc<dyn ReplySender>,
+    ) {
+        debug!("{}", self.request);
+        match self.request.operation() {
+            // Filesystem initialization
+            ll::Operation::Init(x) => {
+                let reply: ReplyRaw<abi::fuse_init_out> = self.reply(&sender);
+                // We don't support ABI versions before 7.6
+                let v = x.version();
+                if v < ll::Version(7, 6) {
+                    error!("Unsupported FUSE ABI version {}", v);
+                    reply.error(EPROTO).await;
+                    return;
+                }
+
+                se.initialize(&x.version()).await;
+
+                let mut config = KernelConfig::new(x.capabilities(), x.max_readahead());
+                // Call filesystem init method and give it a chance to return an error
+                let res = filesystem.init(self, &mut config).await;
+                if let Err(err) = res {
+                    reply.error(err).await;
+                    return;
+                }
+                // Reply with our desired version and settings. If the kernel supports a
+                // larger major version, it'll re-send a matching init message. If it
+                // supports only lower major versions, we replied with an error above.
+                let init = abi::fuse_init_out {
+                    major: abi::FUSE_KERNEL_VERSION,
+                    minor: abi::FUSE_KERNEL_MINOR_VERSION,
+                    max_readahead: config.max_readahead,
+                    flags: x.capabilities() & config.requested, // use requested features and reported as capable
+                    #[cfg(not(feature = "abi-7-13"))]
+                    unused: 0,
+                    #[cfg(feature = "abi-7-13")]
+                    max_background: config.max_background,
+                    #[cfg(feature = "abi-7-13")]
+                    congestion_threshold: config.congestion_threshold(),
+                    max_write: config.max_write,
+                    #[cfg(feature = "abi-7-23")]
+                    time_gran: config.time_gran.as_nanos() as u32,
+                    #[cfg(all(feature = "abi-7-23", not(feature = "abi-7-28")))]
+                    reserved: [0; 9],
+                    #[cfg(feature = "abi-7-28")]
+                    max_pages: config.max_pages(),
+                    #[cfg(feature = "abi-7-28")]
+                    unused2: 0,
+                    #[cfg(feature = "abi-7-28")]
+                    reserved: [0; 8],
+                };
+                debug!(
+                    "INIT response: ABI {}.{}, flags {:#x}, max readahead {}, max write {}",
+                    init.major, init.minor, init.flags, init.max_readahead, init.max_write
+                );
+                reply.ok(&init).await;
+            }
+            // Any operation is invalid before initialization
+            _ => {
+                warn!("Ignoring FUSE operation before init: {}", self.request);
+                self.reply::<ReplyEmpty>(&sender).error(EIO).await;
+            }
+        }
+    }
+
+    /// Dispatch request to the given filesystem.
+    /// This calls the appropriate filesystem operation method for the
+    /// request and sends back the returned reply to the kernel
+    #[cfg(feature = "async_impl")]
+    pub(in crate::async_api) async fn dispatch(
+        &self,
+        active_session: &Arc<dyn ActiveSession>,
+        filesystem: Arc<dyn Filesystem>,
+        ch: Arc<dyn ReplySender>,
+    ) -> std::io::Result<()> {
+        debug!("{}", self.request);
+
+        match self.request.operation() {
+            // Filesystem initialization
+            ll::Operation::Init(_) => {
+                warn!(
+                    "Already initialized, got init after init init: {}",
+                    self.request
+                );
+                self.reply::<ReplyEmpty>(&ch).error(EIO).await;
+            }
+
+            ll::Operation::Interrupt(_) => {
+                // TODO: handle FUSE_INTERRUPT
+                self.reply::<ReplyEmpty>(&ch).error(ENOSYS).await;
+            }
+
+            ll::Operation::Lookup(x) => {
+                filesystem
+                    .lookup(
+                        self,
+                        self.request.nodeid().into(),
+                        &x.name(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::Forget(x) => {
+                filesystem
+                    .forget(self, self.request.nodeid().into(), x.nlookup())
+                    .await; // no reply
+            }
+            ll::Operation::GetAttr(_) => {
+                filesystem
+                    .getattr(self, self.request.nodeid().into(), self.reply(&ch))
+                    .await;
+            }
+            ll::Operation::SetAttr(x) => {
+                filesystem
+                    .setattr(
+                        self,
+                        self.request.nodeid().into(),
+                        x.mode(),
+                        x.uid(),
+                        x.gid(),
+                        x.size(),
+                        x.atime(),
+                        x.mtime(),
+                        x.ctime(),
+                        x.file_handle().map(|fh| fh.into()),
+                        x.crtime(),
+                        x.chgtime(),
+                        x.bkuptime(),
+                        x.flags(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::ReadLink(_) => {
+                filesystem
+                    .readlink(self, self.request.nodeid().into(), self.reply(&ch))
+                    .await;
+            }
+            ll::Operation::MkNod(x) => {
+                filesystem
+                    .mknod(
+                        self,
+                        self.request.nodeid().into(),
+                        &x.name(),
+                        x.mode(),
+                        x.umask(),
+                        x.rdev(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::MkDir(x) => {
+                filesystem
+                    .mkdir(
+                        self,
+                        self.request.nodeid().into(),
+                        x.name(),
+                        x.mode(),
+                        x.umask(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::Unlink(x) => {
+                filesystem
+                    .unlink(
+                        self,
+                        self.request.nodeid().into(),
+                        x.name(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::RmDir(x) => {
+                filesystem
+                    .rmdir(
+                        self,
+                        self.request.nodeid().into(),
+                        x.name(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::SymLink(x) => {
+                filesystem
+                    .symlink(
+                        self,
+                        self.request.nodeid().into(),
+                        x.target(),
+                        &Path::new(x.link()),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::Rename(x) => {
+                filesystem
+                    .rename(
+                        self,
+                        self.request.nodeid().into(),
+                        x.from().name,
+                        x.to().dir.into(),
+                        x.to().name,
+                        0,
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::Link(x) => {
+                filesystem
+                    .link(
+                        self,
+                        x.inode_no().into(),
+                        self.request.nodeid().into(),
+                        x.to().name,
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::Open(x) => {
+                filesystem
+                    .open(
+                        self,
+                        self.request.nodeid().into(),
+                        x.flags(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::Read(x) => {
+                filesystem
+                    .read(
+                        self,
+                        self.request.nodeid().into(),
+                        x.file_handle().into(),
+                        x.offset(),
+                        x.size(),
+                        x.flags(),
+                        x.lock_owner().map(|l| l.into()),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::Write(x) => {
+                filesystem
+                    .write(
+                        self,
+                        self.request.nodeid().into(),
+                        x.file_handle().into(),
+                        x.offset(),
+                        x.data(),
+                        x.write_flags(),
+                        x.flags(),
+                        x.lock_owner().map(|l| l.into()),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::Flush(x) => {
+                filesystem
+                    .flush(
+                        self,
+                        self.request.nodeid().into(),
+                        x.file_handle().into(),
+                        x.lock_owner().into(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::Release(x) => {
+                filesystem
+                    .release(
+                        self,
+                        self.request.nodeid().into(),
+                        x.file_handle().into(),
+                        x.flags(),
+                        x.lock_owner().map(|x| x.into()),
+                        x.flush(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::FSync(x) => {
+                filesystem
+                    .fsync(
+                        self,
+                        self.request.nodeid().into(),
+                        x.file_handle().into(),
+                        x.fdatasync(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::OpenDir(x) => {
+                filesystem
+                    .opendir(
+                        self,
+                        self.request.nodeid().into(),
+                        x.flags(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::ReadDir(x) => {
+                filesystem
+                    .readdir(
+                        self,
+                        self.request.nodeid().into(),
+                        x.file_handle().into(),
+                        x.offset(),
+                        ReplyDirectory::new(
+                            self.request.unique().into(),
+                            ch.clone(),
+                            x.size() as usize,
+                        ),
+                    )
+                    .await;
+            }
+            ll::Operation::ReleaseDir(x) => {
+                filesystem
+                    .releasedir(
+                        self,
+                        self.request.nodeid().into(),
+                        x.file_handle().into(),
+                        x.flags(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::FSyncDir(x) => {
+                filesystem
+                    .fsyncdir(
+                        self,
+                        self.request.nodeid().into(),
+                        x.file_handle().into(),
+                        x.fdatasync(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::StatFs(_) => {
+                filesystem
+                    .statfs(self, self.request.nodeid().into(), self.reply(&ch))
+                    .await;
+            }
+            ll::Operation::SetXAttr(x) => {
+                filesystem
+                    .setxattr(
+                        self,
+                        self.request.nodeid().into(),
+                        x.name(),
+                        x.value(),
+                        x.flags(),
+                        x.position(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::GetXAttr(x) => {
+                filesystem
+                    .getxattr(
+                        self,
+                        self.request.nodeid().into(),
+                        x.name(),
+                        x.size(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::ListXAttr(x) => {
+                filesystem
+                    .listxattr(
+                        self,
+                        self.request.nodeid().into(),
+                        x.size(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::RemoveXAttr(x) => {
+                filesystem
+                    .removexattr(
+                        self,
+                        self.request.nodeid().into(),
+                        x.name(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::Access(x) => {
+                filesystem
+                    .access(
+                        self,
+                        self.request.nodeid().into(),
+                        x.mask(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::Create(x) => {
+                filesystem
+                    .create(
+                        self,
+                        self.request.nodeid().into(),
+                        x.name(),
+                        x.mode(),
+                        x.umask(),
+                        x.flags(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::GetLk(x) => {
+                filesystem
+                    .getlk(
+                        self,
+                        self.request.nodeid().into(),
+                        x.file_handle().into(),
+                        x.lock_owner().into(),
+                        x.lock().range.0,
+                        x.lock().range.1,
+                        x.lock().typ,
+                        x.lock().pid,
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::SetLk(x) => {
+                filesystem
+                    .setlk(
+                        self,
+                        self.request.nodeid().into(),
+                        x.file_handle().into(),
+                        x.lock_owner().into(),
+                        x.lock().range.0,
+                        x.lock().range.1,
+                        x.lock().typ,
+                        x.lock().pid,
+                        false,
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::SetLkW(x) => {
+                filesystem
+                    .setlk(
+                        self,
+                        self.request.nodeid().into(),
+                        x.file_handle().into(),
+                        x.lock_owner().into(),
+                        x.lock().range.0,
+                        x.lock().range.1,
+                        x.lock().typ,
+                        x.lock().pid,
+                        true,
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            ll::Operation::BMap(x) => {
+                filesystem
+                    .bmap(
+                        self,
+                        self.request.nodeid().into(),
+                        x.block_size(),
+                        x.block(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+
+            #[cfg(feature = "abi-7-11")]
+            ll::Operation::IoCtl(x) => {
+                if x.unrestricted() {
+                    self.reply::<ReplyEmpty>(&ch).error(ENOSYS).await;
+                } else {
+                    filesystem
+                        .ioctl(
+                            self,
+                            self.request.nodeid().into(),
+                            x.file_handle().into(),
+                            x.flags(),
+                            x.command(),
+                            x.in_data(),
+                            x.out_size(),
+                            self.reply(&ch),
+                        )
+                        .await;
+                }
+            }
+            #[cfg(feature = "abi-7-11")]
+            ll::Operation::Poll(_) => {
+                // TODO: handle FUSE_POLL
+                self.reply::<ReplyEmpty>(&ch).error(ENOSYS).await;
+            }
+            #[cfg(feature = "abi-7-15")]
+            ll::Operation::NotifyReply(_) => {
+                // TODO: handle FUSE_NOTIFY_REPLY
+                self.reply::<ReplyEmpty>(&ch).error(ENOSYS).await;
+            }
+            #[cfg(feature = "abi-7-16")]
+            ll::Operation::BatchForget(x) => {
+                filesystem.batch_forget(self, x.nodes()).await; // no reply
+            }
+            #[cfg(feature = "abi-7-19")]
+            ll::Operation::FAllocate(x) => {
+                filesystem
+                    .fallocate(
+                        self,
+                        self.request.nodeid().into(),
+                        x.file_handle().into(),
+                        x.offset(),
+                        x.len(),
+                        x.mode(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            #[cfg(feature = "abi-7-21")]
+            ll::Operation::ReadDirPlus(x) => {
+                filesystem
+                    .readdirplus(
+                        self,
+                        self.request.nodeid().into(),
+                        x.file_handle().into(),
+                        x.offset(),
+                        ReplyDirectoryPlus::new(
+                            self.request.unique().into(),
+                            ch.clone(),
+                            x.size() as usize,
+                        ),
+                    )
+                    .await;
+            }
+            #[cfg(feature = "abi-7-23")]
+            ll::Operation::Rename2(x) => {
+                filesystem
+                    .rename(
+                        self,
+                        x.from().dir.into(),
+                        x.from().name,
+                        x.to().dir.into(),
+                        x.to().name,
+                        x.flags(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            #[cfg(feature = "abi-7-24")]
+            ll::Operation::Lseek(x) => {
+                filesystem
+                    .lseek(
+                        self,
+                        self.request.nodeid().into(),
+                        x.file_handle().into(),
+                        x.offset(),
+                        x.whence(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            #[cfg(feature = "abi-7-28")]
+            ll::Operation::CopyFileRange(x) => {
+                let (i, o) = (x.input(), x.output());
+                filesystem
+                    .copy_file_range(
+                        self,
+                        i.inode.into(),
+                        i.file_handle.into(),
+                        i.offset,
+                        o.inode.into(),
+                        o.file_handle.into(),
+                        o.offset,
+                        x.len(),
+                        x.flags().try_into().unwrap(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+            #[cfg(target_os = "macos")]
+            ll::Operation::SetVolName(x) => {
+                filesystem.setvolname(self, x.name(), self.reply(&ch)).await;
+            }
+            #[cfg(target_os = "macos")]
+            ll::Operation::GetXTimes(_) => {
+                filesystem
+                    .getxtimes(self, self.request.nodeid().into(), self.reply(&ch))
+                    .await;
+            }
+            #[cfg(target_os = "macos")]
+            ll::Operation::Exchange(x) => {
+                filesystem
+                    .exchange(
+                        self,
+                        x.from().dir.into(),
+                        x.from().name,
+                        x.to().dir.into(),
+                        x.to().name,
+                        x.options(),
+                        self.reply(&ch),
+                    )
+                    .await;
+            }
+
+            #[cfg(feature = "abi-7-12")]
+            ll::Operation::CuseInit(_) => {
+                // TODO: handle CUSE_INIT
+                self.reply::<ReplyEmpty>(&ch).error(ENOSYS).await;
+            }
+
+            ll::Operation::Destroy(_) => {
+                active_session.destroy().await;
+                self.reply::<ReplyEmpty>(&ch).ok().await;
+            }
+        }
+        Ok(())
+    }
+
+    /// Create a reply object for this request that can be passed to the filesystem
+    /// implementation and makes sure that a request is replied exactly once
+    #[cfg(feature = "async_impl")]
+    fn reply<T: Reply>(&self, ch: &Arc<dyn ReplySender>) -> T {
+        Reply::new(self.request.unique().into(), ch.clone())
+    }
+
+    /// Returns the unique identifier of this request
+    #[inline]
+    #[allow(dead_code)]
+    pub fn unique(&self) -> u64 {
+        self.request.unique().into()
+    }
+
+    /// Returns the uid of this request
+    #[inline]
+    #[allow(dead_code)]
+    pub fn uid(&self) -> u32 {
+        self.request.uid()
+    }
+
+    /// Returns the gid of this request
+    #[inline]
+    #[allow(dead_code)]
+    pub fn gid(&self) -> u32 {
+        self.request.gid()
+    }
+
+    /// Returns the pid of this request
+    #[inline]
+    #[allow(dead_code)]
+    pub fn pid(&self) -> u32 {
+        self.request.pid()
+    }
+}

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -29,7 +29,7 @@ use crate::MountOption;
 /// Helper function to provide options as a fuse_args struct
 /// (which contains an argc count and an argv pointer)
 #[cfg(any(feature = "libfuse", test))]
-fn with_fuse_args<T, F: FnOnce(&fuse_args) -> T>(options: &[&OsStr], f: F) -> T {
+pub(in crate) fn with_fuse_args<T, F: FnOnce(&fuse_args) -> T>(options: &[&OsStr], f: F) -> T {
     let mut args = vec![CString::new("rust-fuse").unwrap()];
     args.extend(options.iter().map(|s| CString::new(s.as_bytes()).unwrap()));
     let argptrs: Vec<_> = args.iter().map(|s| s.as_ptr()).collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ use std::cmp::max;
 #[cfg(feature = "abi-7-13")]
 use std::cmp::min;
 
+#[cfg(feature = "async_api")]
 pub mod async_api;
 mod channel;
 mod fuse_sys;

--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -1338,7 +1338,7 @@ impl<'a> fmt::Display for Operation<'a> {
             #[cfg(feature = "abi-7-11")]
             Operation::Poll(x) => write!(f, "POLL fh {:?}", x.file_handle()),
             #[cfg(feature = "abi-7-15")]
-            Operation::NotifyReply(x) => write!(f, "NOTIFYREPLY"),
+            Operation::NotifyReply(_x) => write!(f, "NOTIFYREPLY"),
             #[cfg(feature = "abi-7-16")]
             Operation::BatchForget(x) => write!(f, "BATCHFORGET nodes {:?}", x.nodes()),
             #[cfg(feature = "abi-7-19")]
@@ -1384,7 +1384,7 @@ impl<'a> fmt::Display for Operation<'a> {
             ),
 
             #[cfg(feature = "abi-7-12")]
-            Operation::CuseInit(x) => write!(f, "CUSE_INIT"),
+            Operation::CuseInit(_x) => write!(f, "CUSE_INIT"),
         }
     }
 }

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -44,7 +44,7 @@ pub trait Reply {
     fn new<S: ReplySender>(unique: u64, sender: S) -> Self;
 }
 
-fn time_from_system_time(system_time: &SystemTime) -> (i64, u32) {
+pub(in crate) fn time_from_system_time(system_time: &SystemTime) -> (i64, u32) {
     // Convert to signed 64-bit time with epoch at 0
     match system_time.duration_since(UNIX_EPOCH) {
         Ok(duration) => (duration.as_secs() as i64, duration.subsec_nanos()),
@@ -59,7 +59,7 @@ fn time_from_system_time(system_time: &SystemTime) -> (i64, u32) {
 // But others like macOS x86_64 have mode_t = u16, requiring a typecast.  So, just silence lint.
 #[allow(trivial_numeric_casts)]
 /// Returns the mode for a given file kind and permission
-fn mode_from_kind_and_perm(kind: FileType, perm: u16) -> u32 {
+pub(in crate) fn mode_from_kind_and_perm(kind: FileType, perm: u16) -> u32 {
     (match kind {
         FileType::NamedPipe => S_IFIFO,
         FileType::CharDevice => S_IFCHR,

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -74,7 +74,7 @@ fn mode_from_kind_and_perm(kind: FileType, perm: u16) -> u32 {
 
 /// Returns a fuse_attr from FileAttr
 #[cfg(target_os = "macos")]
-fn fuse_attr_from_attr(attr: &FileAttr) -> fuse_attr {
+pub(in crate) fn fuse_attr_from_attr(attr: &FileAttr) -> fuse_attr {
     let (atime_secs, atime_nanos) = time_from_system_time(&attr.atime);
     let (mtime_secs, mtime_nanos) = time_from_system_time(&attr.mtime);
     let (ctime_secs, ctime_nanos) = time_from_system_time(&attr.ctime);
@@ -107,7 +107,7 @@ fn fuse_attr_from_attr(attr: &FileAttr) -> fuse_attr {
 
 /// Returns a fuse_attr from FileAttr
 #[cfg(not(target_os = "macos"))]
-fn fuse_attr_from_attr(attr: &FileAttr) -> fuse_attr {
+pub(in crate) fn fuse_attr_from_attr(attr: &FileAttr) -> fuse_attr {
     let (atime_secs, atime_nanos) = time_from_system_time(&attr.atime);
     let (mtime_secs, mtime_nanos) = time_from_system_time(&attr.mtime);
     let (ctime_secs, ctime_nanos) = time_from_system_time(&attr.ctime);

--- a/src/session.rs
+++ b/src/session.rs
@@ -28,7 +28,7 @@ pub const MAX_WRITE_SIZE: usize = 16 * 1024 * 1024;
 
 /// Size of the buffer for reading a request from the kernel. Since the kernel may send
 /// up to MAX_WRITE_SIZE bytes in a write request, we use that value plus some extra space.
-const BUFFER_SIZE: usize = MAX_WRITE_SIZE + 4096;
+pub(in crate) const BUFFER_SIZE: usize = MAX_WRITE_SIZE + 4096;
 
 /// The session data structure
 #[derive(Debug)]


### PR DESCRIPTION
This is the API boundary core, without an actual impl.

The test updates here cover the reply.rs async version.


Future PR's needed:

1) Make integration tests support multiple impls
2) Add async examples (1 per PR)
2) Add tokio impl, and update examples to use it


While these are inflight building with all flags enabled will see some unused code. But normal build flags should see no unused code warnings. 
