### PR TITLE
Add in the support in the tests for doing async/tokio tests

### DIFF
--- a/.github/scripts/xfs_inside_docker_tests.sh
+++ b/.github/scripts/xfs_inside_docker_tests.sh
@@ -22,6 +22,7 @@ cd /code/fuser
 cargo build --release --examples --features=abi-7-28
 
 cp target/release/examples/simple /bin/fuser
-
+export TEST_TARGET="$1"
+shift 
 cd /code/fuser
 exec ./xfstests.sh "$@"

--- a/.github/scripts/xfs_inside_docker_tests.sh
+++ b/.github/scripts/xfs_inside_docker_tests.sh
@@ -22,6 +22,7 @@ cd /code/fuser
 cargo build --release --examples --features=abi-7-28
 
 cp target/release/examples/simple /bin/fuser
+# First arg will be the sub type to run, e.g. SYNC
 export TEST_TARGET="$1"
 shift 
 cd /code/fuser

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -9,7 +9,9 @@ jobs:
     strategy:
       matrix:
         test_group: [mount_tests, pjdfs_tests_fuse2, pjdfs_tests_fuse3, pjdfs_tests_pure]
-
+        test_target: [ "SYNC" ]
+    env:
+      TEST_TARGET: "${{ matrix.test_target }}"
     steps:
       - uses: actions/checkout@v2
       - name: Install packages
@@ -44,6 +46,9 @@ jobs:
     strategy:
       matrix:
         test_group: ["generic/0*", "generic/1*", "generic/2*", "generic/3*", "generic/4*", "generic/5*", "generic/6*"]
+        test_target: [ "SYNC" ]
+    env:
+      TEST_TARGET: "${{ matrix.test_target }}"
     steps:
       - uses: actions/checkout@v2
       - name: Setup cache location
@@ -69,6 +74,6 @@ jobs:
           -v "$HOME/docker_data/docker-xfstests:/code/xfstests"
           -v "$GITHUB_WORKSPACE/logs:/code/logs"
           fuser:xfstests
-          bash -c "/code/fuser/.github/scripts/xfs_inside_docker_tests.sh ${{matrix.test_group}}"
+          bash -c "/code/fuser/.github/scripts/xfs_inside_docker_tests.sh ${{matrix.test_target}} ${{matrix.test_group}}"
       - name: Fix permissions
         run: sudo chown -R $USER ~/docker_data

--- a/Makefile
+++ b/Makefile
@@ -23,27 +23,28 @@ xfstests:
 pjdfs_tests: pjdfs_tests_fuse2 pjdfs_tests_fuse3 pjdfs_tests_pure
 
 pjdfs_tests_fuse2:
-	docker build --build-arg BUILD_FEATURES='--features=abi-7-19' -t fuser:pjdfs -f pjdfs.Dockerfile .
+	docker build -t fuser:pjdfs -f pjdfs.Dockerfile .
 	# Additional permissions are needed to be able to mount FUSE
 	docker run --rm -$(INTERACTIVE)t --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined \
-	 -v "$(shell pwd)/logs:/code/logs" fuser:pjdfs bash -c "cd /code/fuser && ./pjdfs.sh"
+	 -v "$(shell pwd)/logs:/code/logs" --env TEST_TARGET=${TEST_TARGET} --env BUILD_FEATURES='--features=abi-7-19' fuser:pjdfs bash -c "cd /code/fuser && ./pjdfs.sh"
 
 pjdfs_tests_fuse3:
-	docker build --build-arg BUILD_FEATURES='--features=abi-7-21' -t fuser:pjdfs -f pjdfs.Dockerfile .
+	docker build  -t fuser:pjdfs -f pjdfs.Dockerfile .
 	# Additional permissions are needed to be able to mount FUSE
 	docker run --rm -$(INTERACTIVE)t --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined \
-	 -v "$(shell pwd)/logs:/code/logs" fuser:pjdfs bash -c "cd /code/fuser && ./pjdfs.sh"
+	 -v "$(shell pwd)/logs:/code/logs" --env TEST_TARGET=${TEST_TARGET} --env BUILD_FEATURES='--features=abi-7-21' fuser:pjdfs bash -c "cd /code/fuser && ./pjdfs.sh"
 
 pjdfs_tests_pure:
-	docker build --build-arg BUILD_FEATURES='--no-default-features --features=abi-7-19' -t fuser:pjdfs -f pjdfs.Dockerfile .
+	docker build  -t fuser:pjdfs -f pjdfs.Dockerfile .
 	# Additional permissions are needed to be able to mount FUSE
 	docker run --rm -$(INTERACTIVE)t --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined \
-	 -v "$(shell pwd)/logs:/code/logs" fuser:pjdfs bash -c "cd /code/fuser && ./pjdfs.sh"
+	 -v "$(shell pwd)/logs:/code/logs" --env TEST_TARGET=${TEST_TARGET} --env BUILD_FEATURES='--no-default-features --features=abi-7-19'  fuser:pjdfs bash -c "cd /code/fuser && ./pjdfs.sh"
 
 mount_tests:
 	docker build -t fuser:mount_tests -f mount_tests.Dockerfile .
 	# Additional permissions are needed to be able to mount FUSE
 	docker run --rm -$(INTERACTIVE)t --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined \
+	 --env TEST_TARGET=${TEST_TARGET} \
 	 fuser:mount_tests bash -c "cd /code/fuser && bash ./mount_tests.sh"
 
 test: pre mount_tests pjdfs_tests xfstests

--- a/pjdfs.Dockerfile
+++ b/pjdfs.Dockerfile
@@ -15,8 +15,5 @@ RUN mkdir -p /code/pjdfstest && cd /code && git clone https://github.com/fleetfs
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.47.0
 
 ENV PATH=/root/.cargo/bin:$PATH
-ARG BUILD_FEATURES
 
 ADD . /code/fuser/
-
-RUN cd /code/fuser && cargo build --release --examples $BUILD_FEATURES && cp target/release/examples/simple /bin/fuser

--- a/pjdfs.sh
+++ b/pjdfs.sh
@@ -1,6 +1,25 @@
 #!/usr/bin/env bash
 
-set -ex
+set -eux
+
+
+if [ $TEST_TARGET == "TOKIO" ]; then
+  EXTRA_FEATURES=",async_tokio"
+  EXAMPLE_NAME="simple_async"
+elif [ $TEST_TARGET == "SYNC" ]; then
+  EXTRA_FEATURES=""
+  EXAMPLE_NAME="simple"
+else
+  echo "Invalid/unsupported test target type of $TEST_TARGET"
+  exit 1
+fi
+
+cd /code/fuser
+
+cargo build --release --examples --features $BUILD_FEATURES$EXTRA_FEATURES
+
+cp target/release/examples/$EXAMPLE_NAME /bin/fuser
+
 
 exit_handler() {
     exit "$PJDFS_EXIT_STATUS"

--- a/xfstests.Dockerfile
+++ b/xfstests.Dockerfile
@@ -16,4 +16,3 @@ RUN mkdir -p /code && cd /code && git clone https://github.com/fleetfs/fuse-xfst
 
 ADD . /code/fuser/
 
-RUN cd /code/fuser && cargo build --release --examples --features=abi-7-28 && cp target/release/examples/simple /bin/fuser

--- a/xfstests.sh
+++ b/xfstests.sh
@@ -1,6 +1,25 @@
 #!/usr/bin/env bash
 
-set -ex
+set -eux
+
+if [ $TEST_TARGET == "TOKIO" ]; then
+  EXTRA_FEATURES=",async_tokio"
+  EXAMPLE_NAME="simple_async"
+elif [ $TEST_TARGET == "SYNC" ]; then
+  EXTRA_FEATURES=""
+  EXAMPLE_NAME="simple"
+else
+  echo "Invalid/unsupported test target type of $TEST_TARGET"
+  exit 1
+fi
+
+
+cd /code/fuser
+
+cargo build --release --examples --features=abi-7-28${EXTRA_FEATURES}
+
+cp target/release/examples/$EXAMPLE_NAME /bin/fuser
+
 
 exit_handler() {
     exit "$XFSTESTS_EXIT_STATUS"


### PR DESCRIPTION
This hopefully is a relatively boring PR. We may want to do more cleanups later too.

But:

Moves some setup in the docker stuff from the build to the run, pass in the args via the github config of what to run.


Motivation:

its only a small change from here to enable integration testing for tokio. But since that PR will be bigger figure it would be nice to separate this one out. 
