### PR TITLE
Ensure that Filesystem.destroy() is always called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.9.0 - UNRELEASED
 * Ensure that `Filesystem::destroy` is always called
+* Remove request parameter to `Filesystem::destroy`
 
 ## 0.8.0 - 2021-06-11
 * Deprecate `mount()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # FUSE for Rust - Changelog
 
-## 0.8.0 - UNRELEASED
+## 0.9.0 - UNRELEASED
+* Ensure that `Filesystem::destroy` is always called
+
+## 0.8.0 - 2021-06-11
 * Deprecate `mount()`
 * Remove `FileAttr.padding`. This field was added by mistake, and does nothing
 * Fix crash when receiving an unknown FUSE operation type

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -451,8 +451,6 @@ impl Filesystem for SimpleFS {
         Ok(())
     }
 
-    fn destroy(&mut self, _req: Option<&Request>) {}
-
     fn lookup(&mut self, req: &Request, parent: u64, name: &OsStr, reply: ReplyEntry) {
         if name.len() > MAX_NAME_LENGTH as usize {
             reply.error(libc::ENAMETOOLONG);

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -451,7 +451,7 @@ impl Filesystem for SimpleFS {
         Ok(())
     }
 
-    fn destroy(&mut self, _req: &Request) {}
+    fn destroy(&mut self, _req: Option<&Request>) {}
 
     fn lookup(&mut self, req: &Request, parent: u64, name: &OsStr, reply: ReplyEntry) {
         if name.len() > MAX_NAME_LENGTH as usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,7 +292,7 @@ pub trait Filesystem {
 
     /// Clean up filesystem.
     /// Called on filesystem exit.
-    fn destroy(&mut self, _req: &Request<'_>) {}
+    fn destroy(&mut self, _req: Option<&Request<'_>>) {}
 
     /// Look up a directory entry by name and get its attributes.
     fn lookup(&mut self, _req: &Request<'_>, _parent: u64, _name: &OsStr, reply: ReplyEntry) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,7 +292,7 @@ pub trait Filesystem {
 
     /// Clean up filesystem.
     /// Called on filesystem exit.
-    fn destroy(&mut self, _req: Option<&Request<'_>>) {}
+    fn destroy(&mut self) {}
 
     /// Look up a directory entry by name and get its attributes.
     fn lookup(&mut self, _req: &Request<'_>, _parent: u64, _name: &OsStr, reply: ReplyEntry) {

--- a/src/request.rs
+++ b/src/request.rs
@@ -34,7 +34,7 @@ pub struct Request<'a> {
 
 impl<'a> Request<'a> {
     /// Create a new request from the given data
-    pub fn new(ch: ChannelSender, data: &'a [u8]) -> Option<Request<'a>> {
+    pub(crate) fn new(ch: ChannelSender, data: &'a [u8]) -> Option<Request<'a>> {
         let request = match ll::AnyRequest::try_from(data) {
             Ok(request) => request,
             Err(err) => {
@@ -49,7 +49,7 @@ impl<'a> Request<'a> {
     /// Dispatch request to the given filesystem.
     /// This calls the appropriate filesystem operation method for the
     /// request and sends back the returned reply to the kernel
-    pub fn dispatch<FS: Filesystem>(&self, se: &mut Session<FS>) {
+    pub(crate) fn dispatch<FS: Filesystem>(&self, se: &mut Session<FS>) {
         debug!("{}", self.request);
         let unique = self.request.unique();
 
@@ -63,6 +63,7 @@ impl<'a> Request<'a> {
             warn!("Request {:?}: Failed to send reply: {}", unique, err)
         }
     }
+
     fn dispatch_req<FS: Filesystem>(
         &self,
         se: &mut Session<FS>,

--- a/src/request.rs
+++ b/src/request.rs
@@ -109,7 +109,7 @@ impl<'a> Request<'a> {
             }
             // Filesystem destroyed
             ll::Operation::Destroy(x) => {
-                se.filesystem.destroy(Some(self));
+                se.filesystem.destroy();
                 se.destroyed = true;
                 return Ok(Some(x.reply()));
             }

--- a/src/request.rs
+++ b/src/request.rs
@@ -108,7 +108,7 @@ impl<'a> Request<'a> {
             }
             // Filesystem destroyed
             ll::Operation::Destroy(x) => {
-                se.filesystem.destroy(self);
+                se.filesystem.destroy(Some(self));
                 se.destroyed = true;
                 return Ok(Some(x.reply()));
             }

--- a/src/session.rs
+++ b/src/session.rs
@@ -113,6 +113,7 @@ impl<FS: Filesystem> Session<FS> {
         }
         Ok(())
     }
+
     /// Unmount the filesystem
     pub fn unmount(&mut self) {
         drop(std::mem::take(&mut self.mount));
@@ -137,6 +138,10 @@ impl<FS: 'static + Filesystem + Send> Session<FS> {
 
 impl<FS: Filesystem> Drop for Session<FS> {
     fn drop(&mut self) {
+        if !self.destroyed {
+            self.filesystem.destroy(None);
+            self.destroyed = true;
+        }
         info!("Unmounted {}", self.mountpoint().display());
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -139,7 +139,7 @@ impl<FS: 'static + Filesystem + Send> Session<FS> {
 impl<FS: Filesystem> Drop for Session<FS> {
     fn drop(&mut self) {
         if !self.destroyed {
-            self.filesystem.destroy(None);
+            self.filesystem.destroy();
             self.destroyed = true;
         }
         info!("Unmounted {}", self.mountpoint().display());


### PR DESCRIPTION
libfuse uses the same workaround of calling .destroy() if the kernel
never delivers the DESTROY message

Fixes #153 