### PR TITLE
Fix crash in simplefs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 !./pjdfs.sh
 !./xfstests.sh
 !./mount_tests.sh
+!./simplefs_tests.sh

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ mount_tests:
 	docker build -t fuser:mount_tests -f mount_tests.Dockerfile .
 	# Additional permissions are needed to be able to mount FUSE
 	docker run --rm -$(INTERACTIVE)t --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined \
+	 fuser:mount_tests bash -c "cd /code/fuser && bash ./simplefs_tests.sh"
+	docker run --rm -$(INTERACTIVE)t --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined \
 	 fuser:mount_tests bash -c "cd /code/fuser && bash ./mount_tests.sh"
 
 test: pre mount_tests pjdfs_tests xfstests

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1744,7 +1744,7 @@ impl Filesystem for SimpleFS {
         let inode = self.allocate_next_inode();
         let attrs = InodeAttributes {
             inode,
-            open_file_handles: 0,
+            open_file_handles: 1,
             size: 0,
             last_accessed: time_now(),
             last_modified: time_now(),

--- a/simplefs_tests.sh
+++ b/simplefs_tests.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -x
+
+exit_handler() {
+    exit "${TEST_EXIT_STATUS:-1}"
+}
+trap exit_handler TERM
+trap 'kill $(jobs -p); exit $TEST_EXIT_STATUS' INT EXIT
+
+export RUST_BACKTRACE=1
+
+NC="\e[39m"
+GREEN="\e[32m"
+RED="\e[31m"
+
+apt update
+apt install -y fuse3
+echo 'user_allow_other' >> /etc/fuse.conf
+
+DATA_DIR=$(mktemp --directory)
+DIR=$(mktemp --directory)
+cargo build --example simple --no-default-features > /dev/null 2>&1
+cargo run --example simple --no-default-features -- -vvv --data-dir $DATA_DIR --mount-point $DIR 2>&1 &
+FUSE_PID=$!
+sleep 2
+
+echo "mounting at $DIR"
+# Make sure FUSE was successfully mounted
+mount | grep fuser || exit 1
+
+if touch $DIR/a && touch $DIR/b; then
+    echo -e "$GREEN OK touch file $NC"
+else
+    echo -e "$RED FAILED touch file $NC"
+    export TEST_EXIT_STATUS=1
+    exit 1
+fi
+
+umount $DIR
+
+kill $FUSE_PID
+wait $FUSE_PID
+
+
+export TEST_EXIT_STATUS=0


### PR DESCRIPTION
file handle reference count was wrong when create() was called.

Fixes #168 