### PR TITLE
Fix batch_forget support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,8 @@ pub use crate::ll::fuse_abi::FUSE_ROOT_ID;
 pub use crate::ll::{fuse_abi::consts, TimeOrNow};
 use crate::mnt::mount_options::check_option_conflicts;
 use crate::session::MAX_WRITE_SIZE;
+#[cfg(feature = "abi-7-16")]
+pub use ll::fuse_abi::fuse_forget_one;
 pub use mnt::mount_options::MountOption;
 #[cfg(target_os = "macos")]
 pub use reply::ReplyXTimes;
@@ -38,8 +40,6 @@ pub use session::{BackgroundSession, Session};
 use std::cmp::max;
 #[cfg(feature = "abi-7-13")]
 use std::cmp::min;
-#[cfg(feature = "abi-7-16")]
-pub use ll::fuse_abi::fuse_forget_one;
 
 mod channel;
 mod ll;
@@ -313,7 +313,7 @@ pub trait Filesystem {
     /// Like forget, but take multiple forget requests at once for performance. The default
     /// implementation will fallback to forget.
     #[cfg(feature = "abi-7-16")]
-    fn batch_forget(&mut self, req: &Request<'_>, nodes: &[ll::fuse_abi::fuse_forget_one]) {
+    fn batch_forget(&mut self, req: &Request<'_>, nodes: &[fuse_forget_one]) {
         for node in nodes {
             self.forget(req, node.nodeid, node.nlookup);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,8 @@ pub use session::{BackgroundSession, Session};
 use std::cmp::max;
 #[cfg(feature = "abi-7-13")]
 use std::cmp::min;
+#[cfg(feature = "abi-7-16")]
+pub use ll::fuse_abi::fuse_forget_one;
 
 mod channel;
 mod ll;

--- a/src/ll/argument.rs
+++ b/src/ll/argument.rs
@@ -53,8 +53,8 @@ impl<'a> ArgumentIterator<'a> {
     /// Fetch a slice of typed of arguments. Returns `None` if there's not enough data left.
     #[cfg(feature = "abi-7-16")]
     pub fn fetch_slice<T: zerocopy::FromBytes>(&mut self, count: usize) -> Option<&'a [T]> {
-       match zerocopy::LayoutVerified::<_, [T]>::new_slice_from_prefix(self.data, count) {
-           None => {
+        match zerocopy::LayoutVerified::<_, [T]>::new_slice_from_prefix(self.data, count) {
+            None => {
                 if self.data.as_ptr() as usize % core::mem::align_of::<T>() != 0 {
                     // Panic on alignment errors as this is under the control
                     // of the programmer, we can still return None for size
@@ -64,12 +64,12 @@ impl<'a> ArgumentIterator<'a> {
                 } else {
                     None
                 }
-           }
-           Some((x, rest)) => {
-               self.data = rest;
-               Some(x.into_slice())
-           }
-       }
+            }
+            Some((x, rest)) => {
+                self.data = rest;
+                Some(x.into_slice())
+            }
+        }
     }
 
     /// Fetch a (zero-terminated) string (can be non-utf8). Returns `None` if there's not enough

--- a/src/ll/argument.rs
+++ b/src/ll/argument.rs
@@ -50,6 +50,28 @@ impl<'a> ArgumentIterator<'a> {
         }
     }
 
+    /// Fetch a slice of typed of arguments. Returns `None` if there's not enough data left.
+    #[cfg(feature = "abi-7-16")]
+    pub fn fetch_slice<T: zerocopy::FromBytes>(&mut self, count: usize) -> Option<&'a [T]> {
+       match zerocopy::LayoutVerified::<_, [T]>::new_slice_from_prefix(self.data, count) {
+           None => {
+                if self.data.as_ptr() as usize % core::mem::align_of::<T>() != 0 {
+                    // Panic on alignment errors as this is under the control
+                    // of the programmer, we can still return None for size
+                    // failures as this may be caused by insufficient external
+                    // data.
+                    panic!("Data unaligned");
+                } else {
+                    None
+                }
+           }
+           Some((x, rest)) => {
+               self.data = rest;
+               Some(x.into_slice())
+           }
+       }
+    }
+
     /// Fetch a (zero-terminated) string (can be non-utf8). Returns `None` if there's not enough
     /// data left or no zero-termination could be found.
     pub fn fetch_str(&mut self) -> Option<&'a OsStr> {

--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -518,7 +518,7 @@ pub struct fuse_forget_in {
 
 #[cfg(feature = "abi-7-16")]
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, FromBytes)]
 pub struct fuse_forget_one {
     pub nodeid: u64,
     pub nlookup: u64,

--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -1781,7 +1781,7 @@ mod op {
                     arg,
                     nodes: data.fetch_slice(arg.count as usize)?,
                 })
-            },
+            }
             #[cfg(feature = "abi-7-19")]
             fuse_opcode::FUSE_FALLOCATE => Operation::FAllocate(FAllocate {
                 header,

--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -1774,12 +1774,14 @@ mod op {
                 arg: data.fetch_all(),
             }),
             #[cfg(feature = "abi-7-16")]
-            // TODO: parse the nodes
-            fuse_opcode::FUSE_BATCH_FORGET => Operation::BatchForget(BatchForget {
-                header,
-                arg: data.fetch()?,
-                nodes: &[],
-            }),
+            fuse_opcode::FUSE_BATCH_FORGET => {
+                let arg = data.fetch()?;
+                Operation::BatchForget(BatchForget {
+                    header,
+                    arg,
+                    nodes: data.fetch_slice(arg.count as usize)?,
+                })
+            },
             #[cfg(feature = "abi-7-19")]
             fuse_opcode::FUSE_FALLOCATE => Operation::FAllocate(FAllocate {
                 header,


### PR DESCRIPTION
1. fix batch_forget arguments parse
2. expose fuse_forget_one, this allows filesystems implement batch_forget function manually.