### PR TITLE
Fix forget & batch_forget when access is restricted

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -85,6 +85,8 @@ impl<'a> Request<'a> {
                     | ll::Operation::Read(_)
                     | ll::Operation::ReadDir(_)
                     | ll::Operation::ReadDirPlus(_)
+                    | ll::Operation::BatchForget(_)
+                    | ll::Operation::Forget(_)
                     | ll::Operation::Write(_)
                     | ll::Operation::FSync(_)
                     | ll::Operation::FSyncDir(_)
@@ -95,7 +97,7 @@ impl<'a> Request<'a> {
                     }
                 }
             }
-            #[cfg(not(feature = "abi-7-21"))]
+            #[cfg(all(feature = "abi-7-16", not(feature = "abi-7-21")))]
             {
                 match op {
                     // Only allow operations that the kernel may issue without a uid set
@@ -103,6 +105,27 @@ impl<'a> Request<'a> {
                     | ll::Operation::Destroy(_)
                     | ll::Operation::Read(_)
                     | ll::Operation::ReadDir(_)
+                    | ll::Operation::BatchForget(_)
+                    | ll::Operation::Forget(_)
+                    | ll::Operation::Write(_)
+                    | ll::Operation::FSync(_)
+                    | ll::Operation::FSyncDir(_)
+                    | ll::Operation::Release(_)
+                    | ll::Operation::ReleaseDir(_) => {}
+                    _ => {
+                        return Err(Errno::EACCES);
+                    }
+                }
+            }
+            #[cfg(not(feature = "abi-7-16"))]
+            {
+                match op {
+                    // Only allow operations that the kernel may issue without a uid set
+                    ll::Operation::Init(_)
+                    | ll::Operation::Destroy(_)
+                    | ll::Operation::Read(_)
+                    | ll::Operation::ReadDir(_)
+                    | ll::Operation::Forget(_)
                     | ll::Operation::Write(_)
                     | ll::Operation::FSync(_)
                     | ll::Operation::FSyncDir(_)


### PR DESCRIPTION
These would fail when neither of allow_root or allow_other were set

Fixes #173 