### PR TITLE
Add pure rust mount on Macos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # FUSE for Rust - Changelog
 
 ## 0.10.0 - UNRELEASED
+* Add support for building without libfuse on Macos
 
 ## 0.9.1 - 2021-09-07
 * `forget` and `batch_forget` no longer require that `AllowRoot` be set

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,9 @@
 fn main() {
-    #[cfg(all(not(feature = "libfuse"), not(target_os = "linux"), not(target_os = "macos")))]
+    #[cfg(all(
+        not(feature = "libfuse"),
+        not(target_os = "linux"),
+        not(target_os = "macos"),
+    ))]
     unimplemented!("Building without libfuse is only supported on Linux or Macos");
 
     #[cfg(feature = "libfuse")]

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
 fn main() {
-    #[cfg(all(not(feature = "libfuse"), not(target_os = "linux")))]
-    unimplemented!("Building without libfuse is only supported on Linux");
+    #[cfg(all(not(feature = "libfuse"), not(target_os = "linux"), not(target_os = "macos")))]
+    unimplemented!("Building without libfuse is only supported on Linux or Macos");
 
     #[cfg(feature = "libfuse")]
     {

--- a/src/mnt/fuse_pure.rs
+++ b/src/mnt/fuse_pure.rs
@@ -130,8 +130,16 @@ fn fuse_unmount_pure(mountpoint: &CStr) {
         .arg(OsStr::new(&mountpoint.to_string_lossy().into_owned()));
 
     if let Ok(output) = builder.output() {
-        debug!("{}: {}", FUSE_PROGRAM_NAME, String::from_utf8_lossy(&output.stdout));
-        debug!("{}: {}", FUSE_PROGRAM_NAME, String::from_utf8_lossy(&output.stderr));
+        debug!(
+            "{}: {}",
+            FUSE_PROGRAM_NAME,
+            String::from_utf8_lossy(&output.stdout)
+        );
+        debug!(
+            "{}: {}",
+            FUSE_PROGRAM_NAME,
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 }
 
@@ -158,7 +166,7 @@ fn detect_fuse_program() -> String {
 
 #[cfg(target_os = "macos")]
 fn detect_fuse_program() -> String {
-    return "/Library/Filesystems/macfuse.fs/Contents/Resources/mount_macfuse".to_string()
+    "/Library/Filesystems/macfuse.fs/Contents/Resources/mount_macfuse".to_string()
 }
 
 fn receive_fuse_message(socket: &UnixStream) -> Result<File, Error> {
@@ -291,7 +299,11 @@ fn fuse_mount(
             }
             let mut buf = vec![0; 64 * 1024];
             if let Ok(len) = stdout.read(&mut buf) {
-                debug!("{}: {}", FUSE_PROGRAM_NAME, String::from_utf8_lossy(&buf[..len]));
+                debug!(
+                    "{}: {}",
+                    FUSE_PROGRAM_NAME,
+                    String::from_utf8_lossy(&buf[..len])
+                );
             }
         }
         if let Some(mut stderr) = fuse_child.stderr {
@@ -303,7 +315,11 @@ fn fuse_mount(
             }
             let mut buf = vec![0; 64 * 1024];
             if let Ok(len) = stderr.read(&mut buf) {
-                debug!("{}: {}", FUSE_PROGRAM_NAME, String::from_utf8_lossy(&buf[..len]));
+                debug!(
+                    "{}: {}",
+                    FUSE_PROGRAM_NAME,
+                    String::from_utf8_lossy(&buf[..len])
+                );
             }
         }
     }

--- a/src/mnt/fuse_pure.rs
+++ b/src/mnt/fuse_pure.rs
@@ -27,7 +27,7 @@ use std::{mem, ptr};
 const FUSE_PROGRAM_NAME: &str = "fusermount";
 
 #[cfg(target_os = "macos")]
-const FUSE_PROGRAM_NAME: &str = "macfuse";
+const FUSE_PROGRAM_NAME: &str = "mount_macfuse";
 
 #[derive(Debug)]
 pub struct Mount {


### PR DESCRIPTION
Thankfully, only the kernel module part of macfuse is closed source. The [libfuse](https://github.com/osxfuse/fuse) part is still open source, which allowed to do this relatively easily. 
I do want to note, this is not exactly what libfuse does at this point in time, I did not accommodate the changes introduced in [this commit](https://github.com/osxfuse/fuse/commit/c6a59bed40bb526c113f861ed49a78b5f224805a). This should still work for reasons of backwards compatibility of libfuse itself.