### PR TITLE
Add 'ensure_last_os_error()', fixes #176

### DIFF
--- a/src/mnt/fuse3.rs
+++ b/src/mnt/fuse3.rs
@@ -2,7 +2,7 @@ use super::fuse3_sys::{
     fuse_session_destroy, fuse_session_fd, fuse_session_mount, fuse_session_new,
     fuse_session_unmount,
 };
-use super::{with_fuse_args, MountOption};
+use super::{ensure_last_os_error, with_fuse_args, MountOption};
 use std::{
     ffi::{c_void, CString},
     fs::File,
@@ -28,7 +28,7 @@ impl Mount {
             let mount = Mount { fuse_session };
             let result = unsafe { fuse_session_mount(mount.fuse_session, mnt.as_ptr()) };
             if result != 0 {
-                return Err(io::Error::last_os_error());
+                return Err(ensure_last_os_error());
             }
             let fd = unsafe { fuse_session_fd(mount.fuse_session) };
             if fd < 0 {

--- a/src/mnt/mod.rs
+++ b/src/mnt/mod.rs
@@ -19,7 +19,6 @@ pub mod mount_options;
 use fuse2_sys::fuse_args;
 #[cfg(any(test, not(feature = "libfuse")))]
 use std::fs::File;
-#[cfg(any(test, not(feature = "libfuse3")))]
 use std::io;
 
 #[cfg(any(feature = "libfuse", test))]
@@ -115,6 +114,15 @@ fn is_mounted(fuse_device: &File) -> bool {
             }
             _ => unreachable!(),
         };
+    }
+}
+
+/// Ensures that an os error is never 0/Success
+fn ensure_last_os_error() -> io::Error {
+    let err = io::Error::last_os_error();
+    match err.raw_os_error() {
+        Some(0) => io::Error::new(io::ErrorKind::Other, "Unspecified Error"),
+        _ => err,
     }
 }
 


### PR DESCRIPTION
Under some conditions 'fuse_session_mount()' may return -1 to indicate an error but does not
set errno. 'io::Error::last_os_error()' will then be equivalent to 'Err(Success)' which is
somewhat surprising.

'ensure_last_os_error()' translates (only) these into an 'Error(Other, "Unspecified
Error")'. Programs can thus rely to get an at least descriptive error.