### PR TITLE
Warning and comment to clarify AutoUnmount behavior

### DIFF
--- a/src/mnt/mount_options.rs
+++ b/src/mnt/mount_options.rs
@@ -22,6 +22,8 @@ pub enum MountOption {
     /// Allow the root user to access this filesystem, in addition to the user who mounted it
     AllowRoot,
     /// Automatically unmount when the mounting process exits
+    /// 
+    /// `AutoUnmount` requires `AllowOther` or `AllowRoot`. If `AutoUnmount` is set and neither `Allow...` is set, then `AllowOther` will be automatically added to the options. If the FUSE configuration doesn't permit `AllowOther`, this will cause an `EFAULT` error and mounting will fail.
     AutoUnmount,
     /// Enable permission checking in the kernel
     DefaultPermissions,

--- a/src/session.rs
+++ b/src/session.rs
@@ -6,7 +6,7 @@
 //! for filesystem operations under its mount point.
 
 use libc::{EAGAIN, EINTR, ENODEV, ENOENT};
-use log::info;
+use log::{info,warn};
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::thread::{self, JoinHandle};
@@ -75,6 +75,7 @@ impl<FS: Filesystem> Session<FS> {
             && !(options.contains(&MountOption::AllowRoot)
                 || options.contains(&MountOption::AllowOther))
         {
+            warn!("Given auto_unmount without allow_root or allow_other; adding allow_other");
             let mut modified_options = options.to_vec();
             modified_options.push(MountOption::AllowOther);
             Mount::new(mountpoint, &modified_options)?


### PR DESCRIPTION
I was caught out by a change in how options are treated in 0.9.1: if you set `AutoUnmount` and neither `AllowRoot` or `AllowOther` are set, then `AllowOther` is getting automatically added. If your `/etc/fuse.conf` doesn't permit `AllowOther`, the mount will fail without much information. See the latter half of #153, after it was closed.

This PR adds a warning when `AllowOther` is added and a comment to the options datatype, in the hopes of saving others some trouble.