### PR TITLE
Seperate mounting from serving, and add multithreaded serving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
 name = "bincode"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +81,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "env_logger"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,12 +149,14 @@ version = "0.9.1"
 dependencies = [
  "bincode",
  "clap",
+ "crossbeam-channel",
  "env_logger",
  "libc",
  "log",
  "memchr",
  "page_size",
  "pkg-config",
+ "rayon",
  "serde",
  "smallvec",
  "tempfile",
@@ -133,6 +191,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +216,25 @@ name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
 
 [[package]]
 name = "once_cell"
@@ -240,6 +323,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +382,12 @@ checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,9 +438,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zerocopy"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e59ec1d2457bd6c0dd89b50e7d9d6b0b647809bf3f0a59ac85557046950b7b2"
+checksum = "ae0f717764196a220d8c58500e3a3595e2c9054f95d66267f9fd5f6e74ad0fec"
 dependencies = [
  "byteorder",
  "zerocopy-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,13 @@ license = "MIT"
 travis-ci = { repository = "cberner/fuser" }
 
 [dependencies]
+crossbeam-channel = {version = "0.5", optional = true}
 libc = "0.2.51"
 log = "0.4.6"
 memchr = "2"
 users = "0.11.0"
 page_size = "0.4.2"
+rayon = { version = "1.5", optional = true }
 serde = {version = "1.0.102", features = ["std", "derive"], optional = true}
 smallvec = "1.6.1"
 zerocopy = "0.6"
@@ -40,6 +42,7 @@ pkg-config = {version = "0.3.14", optional = true }
 default = ["libfuse"]
 libfuse = ["pkg-config"]
 serializable = ["serde"]
+mt = ["rayon", "crossbeam-channel"]
 abi-7-9 = []
 abi-7-10 = ["abi-7-9"]
 abi-7-11 = ["abi-7-10"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ users = "0.11.0"
 page_size = "0.4.2"
 serde = {version = "1.0.102", features = ["std", "derive"], optional = true}
 smallvec = "1.6.1"
-zerocopy = "0.5"
+zerocopy = "0.6"
 
 [dev-dependencies]
 env_logger = "0.8"

--- a/Makefile
+++ b/Makefile
@@ -22,19 +22,19 @@ xfstests:
 pjdfs_tests: pjdfs_tests_fuse2 pjdfs_tests_fuse3 pjdfs_tests_pure
 
 pjdfs_tests_fuse2:
-	docker build --build-arg BUILD_FEATURES='--features=abi-7-19' -t fuser:pjdfs -f pjdfs.Dockerfile .
+	docker build --build-arg BUILD_FEATURES='--features=abi-7-19,mt' -t fuser:pjdfs -f pjdfs.Dockerfile .
 	# Additional permissions are needed to be able to mount FUSE
 	docker run --rm -$(INTERACTIVE)t --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined \
 	 -v "$(shell pwd)/logs:/code/logs" fuser:pjdfs bash -c "cd /code/fuser && ./pjdfs.sh"
 
 pjdfs_tests_fuse3:
-	docker build --build-arg BUILD_FEATURES='--features=abi-7-31' -t fuser:pjdfs -f pjdfs.Dockerfile .
+	docker build --build-arg BUILD_FEATURES='--features=abi-7-31,mt' -t fuser:pjdfs -f pjdfs.Dockerfile .
 	# Additional permissions are needed to be able to mount FUSE
 	docker run --rm -$(INTERACTIVE)t --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined \
 	 -v "$(shell pwd)/logs:/code/logs" fuser:pjdfs bash -c "cd /code/fuser && ./pjdfs.sh"
 
 pjdfs_tests_pure:
-	docker build --build-arg BUILD_FEATURES='--no-default-features --features=abi-7-19' -t fuser:pjdfs -f pjdfs.Dockerfile .
+	docker build --build-arg BUILD_FEATURES='--no-default-features --features=abi-7-19,mt' -t fuser:pjdfs -f pjdfs.Dockerfile .
 	# Additional permissions are needed to be able to mount FUSE
 	docker run --rm -$(INTERACTIVE)t --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined \
 	 -v "$(shell pwd)/logs:/code/logs" fuser:pjdfs bash -c "cd /code/fuser && ./pjdfs.sh"

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -143,5 +143,6 @@ fn main() {
     if matches.is_present("allow-root") {
         options.push(MountOption::AllowRoot);
     }
-    fuser::mount2(HelloFS, mountpoint, &options).unwrap();
+    let (chan, _mount) = fuser::mount3(mountpoint, &options).unwrap();
+    fuser::serve_fs_sync_forever(&chan.init().unwrap(), HelloFS).unwrap();
 }

--- a/examples/null.rs
+++ b/examples/null.rs
@@ -8,5 +8,6 @@ impl Filesystem for NullFS {}
 fn main() {
     env_logger::init();
     let mountpoint = env::args_os().nth(1).unwrap();
-    fuser::mount2(NullFS, mountpoint, &[MountOption::AutoUnmount]).unwrap();
+    let (chan, _mount) = fuser::mount3(mountpoint, &[MountOption::AutoUnmount]).unwrap();
+    fuser::serve_fs_sync_forever(&chan.init().unwrap(), NullFS).unwrap();
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -5,7 +5,7 @@ use libc::{c_int, c_void, size_t};
 use crate::reply::ReplySender;
 
 /// A raw communication channel to the FUSE kernel driver
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Channel(Arc<File>);
 
 impl Channel {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ use mnt::mount_options::parse_options_from_args;
 use mnt::Mount;
 #[cfg(feature = "serializable")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "mt")]
+pub use session::serve_fs_mt_forever;
 pub use session::{serve_fs_sync_forever, ChannelInit, ChannelUninit};
 use std::ffi::OsStr;
 use std::io;

--- a/src/ll/argument.rs
+++ b/src/ll/argument.rs
@@ -86,7 +86,7 @@ impl<'a> ArgumentIterator<'a> {
 pub mod tests {
     use std::ops::Deref;
 
-    use super::super::test::AlignedData;
+    use super::super::AlignedData;
     use super::*;
     use zerocopy::FromBytes;
 

--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -855,12 +855,19 @@ pub struct fuse_access_in {
 }
 
 #[repr(C)]
-#[derive(Debug, FromBytes)]
+#[derive(Debug, Copy, Clone, FromBytes)]
 pub struct fuse_init_in {
     pub major: u32,
     pub minor: u32,
     pub max_readahead: u32,
     pub flags: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, FromBytes)]
+pub struct fuse_init_in_msg {
+    pub header: fuse_in_header,
+    pub body: fuse_init_in,
 }
 
 #[repr(C)]
@@ -887,6 +894,13 @@ pub struct fuse_init_out {
     pub unused2: u16,
     #[cfg(feature = "abi-7-28")]
     pub reserved: [u32; 8],
+}
+
+#[repr(C)]
+#[derive(Debug, AsBytes)]
+pub struct fuse_init_out_msg {
+    pub header: fuse_out_header,
+    pub arg: fuse_init_out,
 }
 
 #[cfg(feature = "abi-7-12")]
@@ -1006,7 +1020,7 @@ pub struct fuse_fallocate_in {
 }
 
 #[repr(C)]
-#[derive(Debug, FromBytes)]
+#[derive(Debug, Copy, Clone, FromBytes)]
 pub struct fuse_in_header {
     pub len: u32,
     pub opcode: u32,

--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -5,11 +5,11 @@
 //! interface is versioned and capabilities are exchanged during the initialization (mounting)
 //! of a filesystem.
 //!
-//! OSXFUSE (macOS): https://github.com/osxfuse/fuse/blob/master/include/fuse_kernel.h
+//! OSXFUSE (macOS): <https://github.com/osxfuse/fuse/blob/master/include/fuse_kernel.h>
 //! - supports ABI 7.8 in OSXFUSE 2.x
 //! - supports ABI 7.19 since OSXFUSE 3.0.0
 //!
-//! libfuse (Linux/BSD): https://github.com/libfuse/libfuse/blob/master/include/fuse_kernel.h
+//! libfuse (Linux/BSD): <https://github.com/libfuse/libfuse/blob/master/include/fuse_kernel.h>
 //! - supports ABI 7.8 since FUSE 2.6.0
 //! - supports ABI 7.12 since FUSE 2.8.0
 //! - supports ABI 7.18 since FUSE 2.9.0

--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -264,7 +264,7 @@ macro_rules! impl_request {
     };
 }
 
-mod op {
+pub(crate) mod op {
     use crate::ll::Response;
 
     use super::{
@@ -950,8 +950,8 @@ mod op {
 
     #[derive(Debug)]
     pub struct Init<'a> {
-        header: &'a fuse_in_header,
-        arg: &'a fuse_init_in,
+        pub(crate) header: &'a fuse_in_header,
+        pub(crate) arg: &'a fuse_init_in,
     }
     impl_request!(Init<'a>);
     impl<'a> Init<'a> {
@@ -2161,7 +2161,7 @@ impl<'a> TryFrom<&'a [u8]> for AnyRequest<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::test::AlignedData;
+    use super::super::AlignedData;
     use super::*;
     use std::ffi::OsStr;
 

--- a/src/mnt/fuse_pure.rs
+++ b/src/mnt/fuse_pure.rs
@@ -185,7 +185,10 @@ fn receive_fusermount_message(socket: &UnixStream) -> Result<File, Error> {
         }
         let err = Error::last_os_error();
         if err.kind() != ErrorKind::Interrupted {
-            return Err(err);
+            return Err(io::Error::new(
+                err.kind(),
+                format!("receive_fusermount_message: Error from recvmsg: {}", err),
+            ));
         }
     }
     if result == 0 {

--- a/src/request.rs
+++ b/src/request.rs
@@ -5,6 +5,8 @@
 //!
 //! TODO: This module is meant to go away soon in favor of `ll::Request`.
 
+#[cfg(mt)]
+use crate::ll::request::OwnedRequest;
 use crate::ll::{fuse_abi as abi, Errno, Response};
 use log::{debug, error, warn};
 use std::convert::TryFrom;
@@ -44,6 +46,17 @@ impl<'a> Request<'a> {
         };
 
         Some(Self { ch, data, request })
+    }
+    #[cfg(feature = "mt")]
+    pub(crate) fn from_owned_request(
+        ch: ChannelSender,
+        req: &'a ll::request::OwnedRequest,
+    ) -> Request<'a> {
+        Self {
+            ch,
+            data: req.data(),
+            request: req.as_request(),
+        }
     }
 
     /// Dispatch request to the given filesystem.


### PR DESCRIPTION
The new `mount3` and `serve_fs_sync_forever` APIs allow for more control over the lifecycle of your filesystem. Mounting the filesystem is now separate from the request handling loop. We also apply the typestate pattern to handle filesystem init, rather than having that as part of the request handling loop.

This provides additional flexibility.  We no longer need to implement `BackgroundSession`, users can just as easily call `thread::spawn` themselves.

Example equivalent to `mount2`:

    let fs = MyFS {};
    let (chan, mount) = mount3("/my/mountpoint", &[])?;
    serve_fs_sync_forever(chan.init()?, fs)?;

Example equivalent to `Session...::spawn()`:

    let fs = MyFS {};
    let (chan, mount) = mount3("/my/mountpoint", &[])?;
    thread::spawn(|| serve_fs_sync_forever(chan.init()?, fs)?);

rather than having specific APIs to enable background thread operation.

I've also added `serve_fs_mt_forever` enabling multi-threaded filesystems using rayon.  I'm quite pleased with how its worked out as I've been able to add this without having a separate `Filesystem` trait taking `&self` instead of `&mut self`.

Raising as a PR now for early visibility.

**TODO:**

* [ ] Document the new APIs
* [ ] Finish making "simple" example multithreaded
