### PR TITLE
Bugfixed support for compilation with musl without libfuse present

### DIFF
--- a/src/mnt/fuse_pure.rs
+++ b/src/mnt/fuse_pure.rs
@@ -149,7 +149,7 @@ fn receive_fusermount_message(socket: &UnixStream) -> Result<File, Error> {
     };
     let cmsg_buffer_len = unsafe { libc::CMSG_SPACE(mem::size_of::<c_int>() as libc::c_uint) };
     let mut cmsg_buffer = vec![0u8; cmsg_buffer_len as usize];
-    let mut message : libc::msghdr;
+    let mut message: libc::msghdr;
     #[cfg(all(target_os = "linux", not(target_env = "musl")))]
     {
         message = libc::msghdr {
@@ -164,7 +164,7 @@ fn receive_fusermount_message(socket: &UnixStream) -> Result<File, Error> {
     }
     #[cfg(all(target_os = "linux", target_env = "musl"))]
     {
-        message = unsafe{std::mem::MaybeUninit::zeroed().assume_init()};
+        message = unsafe { std::mem::MaybeUninit::zeroed().assume_init() };
         message.msg_name = ptr::null_mut();
         message.msg_namelen = 0;
         message.msg_iov = &mut io_vec;


### PR DESCRIPTION
An explanation of the unsafe block:

Musl has a different msghdr structure than glibc. It looks as follows:

    pub struct msghdr {
        pub msg_name: *mut ::c_void,
        pub msg_namelen: ::socklen_t,
        pub msg_iov: *mut ::iovec,
        #[cfg(target_endian = "big")]
        __pad1: ::c_int,
        pub msg_iovlen: ::c_int,
        #[cfg(target_endian = "little")]
        __pad1: ::c_int,
        pub msg_control: *mut ::c_void,
        #[cfg(target_endian = "big")]
        __pad2: ::c_int,
        pub msg_controllen: ::socklen_t,
        #[cfg(target_endian = "little")]
        __pad2: ::c_int,
        pub msg_flags: ::c_int,
    }

The padding fields are necessary due to memory layout, however they are also private, which in conjunction with the lack of constructor means it is impossible to construct a msghdr without resorting to unsafe code. On the other hand the padding guarantees that `[0; size_of::<msghdr>()]` is a valid representation, which is why I resorted to MaybeUninit::zeroed as unsafe constructor.

In addition struct update syntax (`msghdr {..MaybeUninit::zeroed()}`) sadly does not work with private fields, so I had to resort to first constructing a zeroed msghdr and then updating the individual fields.