### PR TITLE
Remove outdated Safety comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -997,11 +997,6 @@ pub fn mount2<FS: Filesystem, P: AsRef<Path>>(
 /// and therefore returns immediately. The returned handle should be stored
 /// to reference the mounted filesystem. If it's dropped, the filesystem will
 /// be unmounted.
-///
-/// # Safety
-///
-/// This interface is inherently unsafe if the BackgroundSession is allowed to leak without being
-/// dropped. See rust-lang/rust#24292 for more details.
 pub fn spawn_mount<'a, FS: Filesystem + Send + 'static + 'a, P: AsRef<Path>>(
     filesystem: FS,
     mountpoint: P,


### PR DESCRIPTION
spawn_mount() was made safe in f20051e6bdbe809c13e0d41ef5e2592df84b5b53,
but the associated Safety comment was not removed

Fixes #195 