### PR TITLE
Added background thread spawn equivalent for mount2.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1015,7 +1015,7 @@ pub fn spawn_mount<'a, FS: Filesystem + Send + 'static + 'a, P: AsRef<Path>>(
 /// and therefore returns immediately. The returned handle should be stored
 /// to reference the mounted filesystem. If it's dropped, the filesystem will
 /// be unmounted.
-/// 
+///
 /// NOTE: This is the corresponding function to mount2.
 pub fn spawn_mount2<'a, FS: Filesystem + Send + 'static + 'a, P: AsRef<Path>>(
     filesystem: FS,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1009,3 +1009,19 @@ pub fn spawn_mount<'a, FS: Filesystem + Send + 'static + 'a, P: AsRef<Path>>(
     let options = options.ok_or(ErrorKind::InvalidData)?;
     Session::new(filesystem, mountpoint.as_ref(), options.as_ref()).and_then(|se| se.spawn())
 }
+
+/// Mount the given filesystem to the given mountpoint. This function spawns
+/// a background thread to handle filesystem operations while being mounted
+/// and therefore returns immediately. The returned handle should be stored
+/// to reference the mounted filesystem. If it's dropped, the filesystem will
+/// be unmounted.
+/// 
+/// NOTE: This is the corresponding function to mount2.
+pub fn spawn_mount2<'a, FS: Filesystem + Send + 'static + 'a, P: AsRef<Path>>(
+    filesystem: FS,
+    mountpoint: P,
+    options: &[MountOption],
+) -> io::Result<BackgroundSession> {
+    check_option_conflicts(options)?;
+    Session::new(filesystem, mountpoint.as_ref(), options).and_then(|se| se.spawn())
+}


### PR DESCRIPTION
This is nothing special, but it would be nice if there is the corresponding background equivalent to mount2 also in the upstream of fuser. I use fuser in several projects and prefer to have something like this directly in the upstream.