### PR TITLE
Stop using deprecated clap struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,9 +57,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.6"
+version = "3.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1957aa4a5fb388f0a0a73ce7556c5b42025b874e5cdc2c670775e346e97adec0"
+checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
 dependencies = [
  "atty",
  "bitflags",
@@ -337,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "unicode-xid"

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,4 +1,4 @@
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, Command, Arg};
 use fuser::{
     FileAttr, FileType, Filesystem, MountOption, ReplyAttr, ReplyData, ReplyDirectory, ReplyEntry,
     Request,
@@ -114,7 +114,7 @@ impl Filesystem for HelloFS {
 }
 
 fn main() {
-    let matches = App::new("hello")
+    let matches = Command::new("hello")
         .version(crate_version!())
         .author("Christopher Berner")
         .arg(

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,4 +1,4 @@
-use clap::{crate_version, Command, Arg};
+use clap::{crate_version, Arg, Command};
 use fuser::{
     FileAttr, FileType, Filesystem, MountOption, ReplyAttr, ReplyData, ReplyDirectory, ReplyEntry,
     Request,

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::needless_return)]
 
-use clap::{crate_version, App, Arg};
+use clap::{crate_version, Command, Arg};
 use fuser::consts::FOPEN_DIRECT_IO;
 #[cfg(feature = "abi-7-26")]
 use fuser::consts::FUSE_HANDLE_KILLPRIV;
@@ -1944,7 +1944,7 @@ fn fuse_allow_other_enabled() -> io::Result<bool> {
 }
 
 fn main() {
-    let matches = App::new("Fuser")
+    let matches = Command::new("Fuser")
         .version(crate_version!())
         .author("Christopher Berner")
         .arg(

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::needless_return)]
 
-use clap::{crate_version, Command, Arg};
+use clap::{crate_version, Arg, Command};
 use fuser::consts::FOPEN_DIRECT_IO;
 #[cfg(feature = "abi-7-26")]
 use fuser::consts::FUSE_HANDLE_KILLPRIV;


### PR DESCRIPTION
The compiler was complaining about a deprecated struct and recommended using Command instead of App.  This does that and makes no substantive changes.