### PR TITLE
Fix CI for MacOS

### DIFF
--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -3,49 +3,11 @@ name: Macos CI
 on:
   pull_request:
 jobs:
-  ci-osxfuse:
-    runs-on: macos-10.15
-    env:
-      PKG_CONFIG_PATH: /usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install packages
-        run: |
-          brew update > /dev/null && brew install --cask osxfuse
-      - name: Start fuse
-        run: |
-          /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: rustfmt, clippy
-      - name: Cache cargo registry
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-      - name: Build all targets
-        run: cargo build --all --all-targets
-      - name: Build all targets, all features
-        run: cargo build --all --all-targets --all-features
-      - name: Run all tests
-        run: cargo test --all
-      - name: Run all tests, all features
-        run: cargo test --all --all-features
-      - name: Run cargo doc for all features
-        run: cargo doc --all --no-deps --all-features
-      - name: Run macos mount tests
-        run: bash osx_mount_tests.sh
-  ci-macfuse:
+   ci-macfuse:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-10.15]
+        os: [macos-10.15, macos-11, macos-12]
     env:
       PKG_CONFIG_PATH: /usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
     steps:
@@ -53,9 +15,6 @@ jobs:
       - name: Install packages
         run: |
           brew update > /dev/null && brew install --cask macfuse
-      - name: Start fuse
-        run: |
-          /Library/Filesystems/macfuse.fs/Contents/Resources/load_macfuse
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ clap = { version = "3.0", features = ["cargo"] }
 bincode = "1.3.1"
 serde = { version = "1.0.102", features = ["std", "derive"] }
 tempfile = "3"
+ntest = "0.8.1"
 
 [build-dependencies]
 pkg-config = { version = "0.3.14", optional = true }

--- a/src/mnt/mod.rs
+++ b/src/mnt/mod.rs
@@ -130,7 +130,8 @@ fn ensure_last_os_error() -> io::Error {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::{ffi::CStr, mem::ManuallyDrop};
+    use std::{ffi::CStr, mem::ManuallyDrop, time::Duration};
+    use ntest::timeout;
 
     #[test]
     fn fuse_args() {
@@ -166,6 +167,7 @@ mod test {
     }
 
     #[test]
+    #[timeout(1500)]
     fn mount_unmount() {
         // We use ManuallyDrop here to leak the directory on test failure.  We don't
         // want to try and clean up the directory if it's a mountpoint otherwise we'll

--- a/src/mnt/mod.rs
+++ b/src/mnt/mod.rs
@@ -130,8 +130,8 @@ fn ensure_last_os_error() -> io::Error {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::{ffi::CStr, mem::ManuallyDrop, time::Duration};
     use ntest::timeout;
+    use std::{ffi::CStr, mem::ManuallyDrop, time::Duration};
 
     #[test]
     fn fuse_args() {


### PR DESCRIPTION
* `osxfuse` has removed as it has been succeeded by `macfuse`

* CI runs for all MacOS versions

* `load_macfuse` is not used as is not required now

* Add timeout for `mnt::test::mount_umount` to check infinity loop