### PR TITLE
Use `ensure_last_os_error()` with libfuse2

### DIFF
--- a/src/mnt/fuse2.rs
+++ b/src/mnt/fuse2.rs
@@ -1,4 +1,4 @@
-use super::{fuse2_sys::*, with_fuse_args, MountOption};
+use super::{ensure_last_os_error, fuse2_sys::*, with_fuse_args, MountOption};
 use log::warn;
 use std::{
     ffi::CString,
@@ -19,7 +19,7 @@ impl Mount {
         with_fuse_args(options, |args| {
             let fd = unsafe { fuse_mount_compat25(mountpoint.as_ptr(), args) };
             if fd < 0 {
-                Err(io::Error::last_os_error())
+                Err(ensure_last_os_error())
             } else {
                 let file = unsafe { File::from_raw_fd(fd) };
                 Ok((Arc::new(file), Mount { mountpoint }))

--- a/src/mnt/mod.rs
+++ b/src/mnt/mod.rs
@@ -118,7 +118,6 @@ fn is_mounted(fuse_device: &File) -> bool {
 }
 
 /// Ensures that an os error is never 0/Success
-#[cfg(feature = "libfuse3")]
 fn ensure_last_os_error() -> io::Error {
     let err = io::Error::last_os_error();
     match err.raw_os_error() {


### PR DESCRIPTION
Under some conditions, `fuse_mount_compat25` may return -1 to indicate
an error but does not set errno. `io::Error::last_os_error()` will then
be equivalent to `Err(Success)` which is somewhat surprising.

In particular, if the mount options `auto_unmount,allow_{root,other}`
are set but the user does not have `user_allow_other` set in their
`fuse.conf`, the `fusermount` binary will print an error message to
stderr but not set errno.

`fusermount3` has the same behaviour, but this issue was mitigated for
the libfuse3 binding in cberner/fuser#178 by mapping `Err(Success)` to
the slightly more useful `Error(Other, "Unspecified Error")`. This
commit applies the same fix to the libfuse2 binding.