### PR TITLE
Make the mount field public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,18 @@
 [package]
-name = "fuser"
+name = "levitating-fuser"
 edition = "2018"
 version = "0.11.1"
 authors = ["Christopher Berner <christopherberner@gmail.com>"]
-description = "Filesystem in Userspace (FUSE) for Rust"
-documentation = "https://docs.rs/fuser"
-homepage = "https://github.com/cberner/fuser"
-repository = "https://github.com/cberner/fuser"
+description = "My fork of Filesystem in Userspace (FUSE) for Rust"
+repository = "https://github.com/LevitatingBusinessMan/fuser"
 readme = "README.md"
 keywords = ["fuse", "filesystem", "system", "bindings"]
 categories = ["external-ffi-bindings", "api-bindings", "filesystem", "os::unix-apis"]
 build = "build.rs"
 license = "MIT"
 
-[badges]
-travis-ci = { repository = "cberner/fuser" }
+#[badges]
+#travis-ci = { repository = "cberner/fuser" }
 
 [dependencies]
 libc = "0.2.51"

--- a/src/ll/reply.rs
+++ b/src/ll/reply.rs
@@ -23,7 +23,6 @@ pub enum Response {
     Data(ResponseBuf),
 }
 
-#[must_use]
 impl Response {
     pub(crate) fn with_iovec<F: FnOnce(&[IoSlice<'_>]) -> T, T>(
         &self,
@@ -411,6 +410,7 @@ impl DirEntList {
 
 #[derive(Debug)]
 pub struct DirEntryPlus<T: AsRef<Path>> {
+    #[allow(unused)]
     ino: INodeNo,
     generation: Generation,
     offset: DirEntOffset,

--- a/src/request.rs
+++ b/src/request.rs
@@ -27,6 +27,7 @@ pub struct Request<'a> {
     /// Channel sender for sending the reply
     ch: ChannelSender,
     /// Request raw data
+    #[allow(unused)]
     data: &'a [u8],
     /// Parsed request
     request: ll::AnyRequest<'a>,

--- a/src/session.rs
+++ b/src/session.rs
@@ -42,7 +42,7 @@ pub struct Session<FS: Filesystem> {
     /// Communication channel to the kernel driver
     ch: Channel,
     /// Handle to the mount.  Dropping this unmounts.
-    mount: Option<Mount>,
+    pub mount: Option<Mount>,
     /// Mount point
     mountpoint: PathBuf,
     /// Whether to restrict access to owner, root + owner, or unrestricted


### PR DESCRIPTION
This allows for unmounting a session running in a different thread, similar to `BackgroundSession`s behavior.

One issue with using `BackgroundSession` is that it require the filesystem to be bound by `Send`.

You can see the benefit [Here](https://github.com/LevitatingBusinessMan/reddit-fs/blob/master/src/main.rs#L447-L471).