### PR TITLE
Support fuse-t on MacOS

### DIFF
--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install packages
         run: |
-          brew update > /dev/null && brew tap macos-fuse-t/homebrew-cask && brew install osxfuse
+          brew update > /dev/null && brew tap macos-fuse-t/homebrew-cask && brew install fuse-t
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -1,5 +1,4 @@
 name: Macos CI
-
 on:
   pull_request:
 jobs:

--- a/.github/workflows/macos_ci.yml
+++ b/.github/workflows/macos_ci.yml
@@ -3,18 +3,15 @@ name: Macos CI
 on:
   pull_request:
 jobs:
-  ci-osxfuse:
-    runs-on: macos-10.15
+  ci-fuse-t:
+    runs-on: macos-latest
     env:
       PKG_CONFIG_PATH: /usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
     steps:
       - uses: actions/checkout@v2
       - name: Install packages
         run: |
-          brew update > /dev/null && brew install --cask osxfuse
-      - name: Start fuse
-        run: |
-          /Library/Filesystems/osxfuse.fs/Contents/Resources/load_osxfuse
+          brew update > /dev/null && brew tap macos-fuse-t/homebrew-cask && brew install osxfuse
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/build.rs
+++ b/build.rs
@@ -19,6 +19,7 @@ fn main() {
                 .map_err(|e| eprintln!("{}", e))
                 .is_ok()
             {
+                println!("cargo:rustc-cfg=feature=\"libfuse2\"");
             } else {
                 pkg_config::Config::new()
                     .atleast_version("1.0.8")
@@ -26,6 +27,7 @@ fn main() {
                     .map_err(|e| eprintln!("{}", e))
                     .unwrap();
                 println!("cargo:rustc-cfg=feature=\"libfuse2\"");
+                println!("cargo:rustc-cfg=feature=\"libfuset\"");
             }
         }
         #[cfg(not(target_os = "macos"))]

--- a/build.rs
+++ b/build.rs
@@ -13,10 +13,16 @@ fn main() {
                 .is_ok()
             {
                 println!("cargo:rustc-cfg=feature=\"libfuse2\"");
+            } else if pkg_config::Config::new()
+                .atleast_version("2.6.0")
+                .probe("osxfuse") // for osxfuse 3.x
+                .map_err(|e| eprintln!("{}", e))
+                .is_ok()
+            {
             } else {
                 pkg_config::Config::new()
-                    .atleast_version("2.6.0")
-                    .probe("osxfuse") // for osxfuse 3.x
+                    .atleast_version("1.0.8")
+                    .probe("fuse-t")
                     .map_err(|e| eprintln!("{}", e))
                     .unwrap();
                 println!("cargo:rustc-cfg=feature=\"libfuse2\"");

--- a/src/mnt/mod.rs
+++ b/src/mnt/mod.rs
@@ -173,6 +173,7 @@ mod test {
         let (file, mount) = Mount::new(tmp.path(), &[]).unwrap();
         let mnt = cmd_mount();
         eprintln!("Our mountpoint: {:?}\nfuse mounts:\n{}", tmp.path(), mnt,);
+        #[cfg(not(feature = "libfuset"))]
         assert!(mnt.contains(&*tmp.path().to_string_lossy()));
         assert!(is_mounted(&file));
         drop(mount);


### PR DESCRIPTION
Fuse-t is a user-space FUSE implementation on MacOS; previous versions of FUSE (macfuse/osxfuse) require kernel extensions that are getting progressively more difficult to install as MacOS security tightens. This change adds support for building against `fuse-t`