### PR TITLE
Use checked arithmetic for addition to Unix epoch.

### DIFF
--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -413,9 +413,8 @@ mod op {
             #[cfg(target_os = "macos")]
             match self.arg.valid & FATTR_CRTIME {
                 0 => None,
-                _ => Some(
-                    SystemTime::UNIX_EPOCH + Duration::new(self.arg.crtime, self.arg.crtimensec),
-                ),
+                _ => SystemTime::UNIX_EPOCH
+                    .checked_add(Duration::new(self.arg.crtime, self.arg.crtimensec)),
             }
             #[cfg(not(target_os = "macos"))]
             None
@@ -424,9 +423,8 @@ mod op {
             #[cfg(target_os = "macos")]
             match self.arg.valid & FATTR_CHGTIME {
                 0 => None,
-                _ => Some(
-                    SystemTime::UNIX_EPOCH + Duration::new(self.arg.chgtime, self.arg.chgtimensec),
-                ),
+                _ => SystemTime::UNIX_EPOCH
+                    .checked_add(Duration::new(self.arg.chgtime, self.arg.chgtimensec)),
             }
             #[cfg(not(target_os = "macos"))]
             None
@@ -435,10 +433,8 @@ mod op {
             #[cfg(target_os = "macos")]
             match self.arg.valid & FATTR_BKUPTIME {
                 0 => None,
-                _ => Some(
-                    SystemTime::UNIX_EPOCH
-                        + Duration::new(self.arg.bkuptime, self.arg.bkuptimensec),
-                ),
+                _ => SystemTime::UNIX_EPOCH
+                    .checked_add(Duration::new(self.arg.bkuptime, self.arg.bkuptimensec)),
             }
             #[cfg(not(target_os = "macos"))]
             None


### PR DESCRIPTION
The current code can panic with filesystems that do not store times. Using checked arithmetic allows such filesystems to operate without panic.