### PR TITLE
Avoid copy of data when sending Response. 

### DIFF
--- a/src/ll/mod.rs
+++ b/src/ll/mod.rs
@@ -37,7 +37,7 @@ macro_rules! errno {
 }
 
 /// Represents an error code to be returned to the caller
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct Errno(pub NonZeroI32);
 impl Errno {
     /// Operation not permitted

--- a/src/ll/reply.rs
+++ b/src/ll/reply.rs
@@ -26,7 +26,7 @@ pub(crate) trait ResponseTrait {
     fn get<'a>(&'a self) -> ResponseData<'a>;
 }
 
-pub(crate) fn send_with_iovec<R: ResponseTrait, F: FnOnce(&[IoSlice<'_>]) -> T, T>(
+pub(crate) fn send_with_iovec<R: ResponseTrait + ?Sized, F: FnOnce(&[IoSlice<'_>]) -> T, T>(
     response: &R,
     unique: RequestId,
     f: F,

--- a/src/ll/reply.rs
+++ b/src/ll/reply.rs
@@ -70,6 +70,12 @@ impl ResponseTrait for Response {
     }
 }
 
+impl ResponseTrait for [u8] {
+    fn get<'a>(&'a self) -> ResponseData<'a> {
+        ResponseData::Data(self)
+    }
+}
+
 #[must_use]
 impl Response {
     // Constructors

--- a/src/ll/reply.rs
+++ b/src/ll/reply.rs
@@ -88,14 +88,6 @@ impl Response {
         Self::Error(error.into())
     }
 
-    pub(crate) fn new_data<T: AsRef<[u8]> + Into<Vec<u8>>>(data: T) -> Self {
-        Self::Data(if data.as_ref().len() <= INLINE_DATA_THRESHOLD {
-            data.as_ref().into()
-        } else {
-            data.into().into()
-        })
-    }
-
     pub(crate) fn new_entry(
         ino: INodeNo,
         generation: Generation,
@@ -521,9 +513,9 @@ mod test {
 
     #[test]
     fn reply_data() {
-        let r = Response::new_data([0xde, 0xad, 0xbe, 0xef].as_ref());
+        let r = [0xde, 0xad, 0xbe, 0xef];
         assert_eq!(
-            send_with_iovec(&r, RequestId(0xdeadbeef), ioslice_to_vec),
+            send_with_iovec(&r[..], RequestId(0xdeadbeef), ioslice_to_vec),
             vec![
                 0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xef, 0xbe, 0xad, 0xde, 0x00, 0x00,
                 0x00, 0x00, 0xde, 0xad, 0xbe, 0xef,
@@ -831,9 +823,9 @@ mod test {
             0x14, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xEF, 0xBE, 0xAD, 0xDE, 0x00, 0x00,
             0x00, 0x00, 0x11, 0x22, 0x33, 0x44,
         ];
-        let r = Response::new_data([0x11, 0x22, 0x33, 0x44].as_ref());
+        let r = [0x11, 0x22, 0x33, 0x44];
         assert_eq!(
-            send_with_iovec(&r, RequestId(0xdeadbeef), ioslice_to_vec),
+            send_with_iovec(&r[..], RequestId(0xdeadbeef), ioslice_to_vec),
             expected
         );
     }

--- a/src/ll/reply.rs
+++ b/src/ll/reply.rs
@@ -76,16 +76,18 @@ impl ResponseTrait for [u8] {
     }
 }
 
+impl ResponseTrait for Errno {
+    fn get<'a>(&'a self) -> ResponseData<'a> {
+        ResponseData::Error((*self).into())
+    }
+}
+
 
 #[must_use]
 impl Response {
     // Constructors
     pub(crate) fn new_empty() -> Self {
         Self::Error(0)
-    }
-
-    pub(crate) fn new_error(error: Errno) -> Self {
-        Self::Error(error.into())
     }
 
     pub(crate) fn new_entry(
@@ -501,7 +503,7 @@ mod test {
 
     #[test]
     fn reply_error() {
-        let r = Response::new_error(Errno(NonZeroI32::new(66).unwrap()));
+        let r = Errno(NonZeroI32::new(66).unwrap());
         assert_eq!(
             send_with_iovec(&r, RequestId(0xdeadbeef), ioslice_to_vec),
             vec![

--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -989,7 +989,7 @@ mod op {
                 #[cfg(feature = "abi-7-28")]
                 reserved: [0; 8],
             };
-            Response::new_data(init.as_bytes())
+            Response::Data(init.as_bytes().into())
         }
     }
 

--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -226,11 +226,6 @@ pub trait Request: Sized {
 
     /// Returns the PID of the process that triggered this request.
     fn pid(&self) -> u32;
-
-    /// Create an error response for this Request
-    fn reply_err(&self, errno: Errno) -> Response {
-        Response::new_error(errno)
-    }
 }
 
 macro_rules! impl_request {

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -22,6 +22,7 @@ use std::ffi::OsStr;
 use std::fmt;
 use std::io::IoSlice;
 use std::time::Duration;
+use zerocopy::AsBytes;
 
 #[cfg(target_os = "macos")]
 use std::time::SystemTime;
@@ -176,13 +177,13 @@ impl Reply for ReplyEntry {
 impl ReplyEntry {
     /// Reply to a request with the given entry
     pub fn entry(self, ttl: &Duration, attr: &FileAttr, generation: u64) {
-        self.reply.send_ll(&ll::Response::new_entry(
+        self.reply.send_ll(ll::Response::new_entry(
             ll::INodeNo(attr.ino),
             ll::Generation(generation),
             &attr.into(),
             *ttl,
             *ttl,
-        ));
+        ).as_bytes());
     }
 
     /// Reply to a request with the given error code
@@ -211,7 +212,7 @@ impl ReplyAttr {
     /// Reply to a request with the given attribute
     pub fn attr(self, ttl: &Duration, attr: &FileAttr) {
         self.reply
-            .send_ll(&ll::Response::new_attr(ttl, &attr.into()));
+            .send_ll(ll::Response::new_attr(ttl, &attr.into()).as_bytes());
     }
 
     /// Reply to a request with the given error code
@@ -272,7 +273,7 @@ impl ReplyOpen {
     /// Reply to a request with the given open result
     pub fn opened(self, fh: u64, flags: u32) {
         self.reply
-            .send_ll(&ll::Response::new_open(ll::FileHandle(fh), flags))
+            .send_ll(ll::Response::new_open(ll::FileHandle(fh), flags).as_bytes())
     }
 
     /// Reply to a request with the given error code
@@ -300,7 +301,7 @@ impl Reply for ReplyWrite {
 impl ReplyWrite {
     /// Reply to a request with the given open result
     pub fn written(self, size: u32) {
-        self.reply.send_ll(&ll::Response::new_write(size))
+        self.reply.send_ll(ll::Response::new_write(size).as_bytes())
     }
 
     /// Reply to a request with the given error code
@@ -339,9 +340,9 @@ impl ReplyStatfs {
         namelen: u32,
         frsize: u32,
     ) {
-        self.reply.send_ll(&ll::Response::new_statfs(
+        self.reply.send_ll(ll::Response::new_statfs(
             blocks, bfree, bavail, files, ffree, bsize, namelen, frsize,
-        ))
+        ).as_bytes())
     }
 
     /// Reply to a request with the given error code
@@ -369,13 +370,13 @@ impl Reply for ReplyCreate {
 impl ReplyCreate {
     /// Reply to a request with the given entry
     pub fn created(self, ttl: &Duration, attr: &FileAttr, generation: u64, fh: u64, flags: u32) {
-        self.reply.send_ll(&ll::Response::new_create(
+        self.reply.send_ll(ll::Response::new_create(
             ttl,
             &attr.into(),
             ll::Generation(generation),
             ll::FileHandle(fh),
             flags,
-        ))
+        ).as_bytes())
     }
 
     /// Reply to a request with the given error code
@@ -403,11 +404,11 @@ impl Reply for ReplyLock {
 impl ReplyLock {
     /// Reply to a request with the given open result
     pub fn locked(self, start: u64, end: u64, typ: i32, pid: u32) {
-        self.reply.send_ll(&ll::Response::new_lock(&ll::Lock {
+        self.reply.send_ll(ll::Response::new_lock(&ll::Lock {
             range: (start, end),
             typ,
             pid,
-        }))
+        }).as_bytes())
     }
 
     /// Reply to a request with the given error code
@@ -435,7 +436,7 @@ impl Reply for ReplyBmap {
 impl ReplyBmap {
     /// Reply to a request with the given open result
     pub fn bmap(self, block: u64) {
-        self.reply.send_ll(&ll::Response::new_bmap(block))
+        self.reply.send_ll(ll::Response::new_bmap(block).as_bytes())
     }
 
     /// Reply to a request with the given error code
@@ -588,7 +589,7 @@ impl Reply for ReplyXattr {
 impl ReplyXattr {
     /// Reply to a request with the size of the xattr.
     pub fn size(self, size: u32) {
-        self.reply.send_ll(&ll::Response::new_xattr_size(size))
+        self.reply.send_ll(ll::Response::new_xattr_size(size).as_bytes())
     }
 
     /// Reply to a request with the data in the xattr.
@@ -621,7 +622,7 @@ impl Reply for ReplyLseek {
 impl ReplyLseek {
     /// Reply to a request with seeked offset
     pub fn offset(self, offset: i64) {
-        self.reply.send_ll(&ll::Response::new_lseek(offset))
+        self.reply.send_ll(ll::Response::new_lseek(offset).as_bytes())
     }
 
     /// Reply to a request with the given error code

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -86,7 +86,7 @@ impl ReplyRaw {
     /// Reply to a request with the given error code
     pub fn error(self, err: c_int) {
         assert_ne!(err, 0);
-        self.send_ll(&ll::Response::new_error(ll::Errno::from_i32(err)));
+        self.send_ll(&ll::Errno::from_i32(err));
     }
 }
 
@@ -97,7 +97,7 @@ impl Drop for ReplyRaw {
                 "Reply not sent for operation {}, replying with I/O error",
                 self.unique.0
             );
-            self.send_ll_mut(&ll::Response::new_error(ll::Errno::EIO));
+            self.send_ll_mut(&ll::Errno::EIO);
         }
     }
 }

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -12,7 +12,7 @@ use crate::ll::{
     Generation,
 };
 use crate::ll::{
-    reply::{DirEntList, DirEntOffset, DirEntry},
+    reply::{DirEntList, DirEntOffset, DirEntry, send_with_iovec},
     INodeNo,
 };
 use libc::c_int;
@@ -73,7 +73,7 @@ impl ReplyRaw {
     fn send_ll_mut(&mut self, response: &ll::Response) {
         assert!(self.sender.is_some());
         let sender = self.sender.take().unwrap();
-        let res = response.with_iovec(self.unique, |iov| sender.send(iov));
+        let res = send_with_iovec(response, self.unique, |iov| sender.send(iov));
         if let Err(err) = res {
             error!("Failed to send FUSE reply: {}", err);
         }

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -508,7 +508,7 @@ impl ReplyDirectory {
 
     /// Reply to a request with the filled directory buffer
     pub fn ok(self) {
-        self.reply.send_ll::<ll::Response>(&self.data.into());
+        self.reply.send_ll(&self.data);
     }
 
     /// Reply to a request with the given error code
@@ -561,7 +561,7 @@ impl ReplyDirectoryPlus {
 
     /// Reply to a request with the filled directory buffer
     pub fn ok(self) {
-        self.reply.send_ll::<ll::Response>(&self.buf.into());
+        self.reply.send_ll(&self.buf);
     }
 
     /// Reply to a request with the given error code

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -149,7 +149,7 @@ impl Reply for ReplyData {
 impl ReplyData {
     /// Reply to a request with the given data
     pub fn data(self, data: &[u8]) {
-        self.reply.send_ll(&ll::Response::new_data(data));
+        self.reply.send_ll(data);
     }
 
     /// Reply to a request with the given error code
@@ -594,7 +594,7 @@ impl ReplyXattr {
 
     /// Reply to a request with the data in the xattr.
     pub fn data(self, data: &[u8]) {
-        self.reply.send_ll(&ll::Response::new_data(data))
+        self.reply.send_ll(data)
     }
 
     /// Reply to a request with the given error code.
@@ -699,7 +699,7 @@ mod test {
             ],
         };
         let reply: ReplyRaw = Reply::new(0xdeadbeef, sender);
-        reply.send_ll(&ll::Response::new_data(data.as_bytes()));
+        reply.send_ll(data.as_bytes());
     }
 
     #[test]

--- a/src/request.rs
+++ b/src/request.rs
@@ -53,12 +53,12 @@ impl<'a> Request<'a> {
         debug!("{}", self.request);
         let unique = self.request.unique();
 
-        let res = match self.dispatch_req(se) {
+        let response = match self.dispatch_req(se) {
             Ok(Some(resp)) => resp,
             Ok(None) => return,
             Err(errno) => self.request.reply_err(errno),
-        }
-        .with_iovec(unique, |iov| self.ch.send(iov));
+        };
+        let res = ll::reply::send_with_iovec(&response, unique, |iov| self.ch.send(iov));
 
         if let Err(err) = res {
             warn!("Request {:?}: Failed to send reply: {}", unique, err)


### PR DESCRIPTION
The `Response` structure is owning the data. So it force us to copy (own) the data even if we don't want (nor need) to.
This is especially usefull to avoid copy of the data in ReplyData which can be pretty "big".

This PR introduce a ResponseTrait with a single method returning e `ResponseData` which borrow the data.
It also make `[u8]` and `Response` implement `ResponseTrait`.
So we can now directly pass `&[u8]` (if we don't want to own the data) or still use `Response` if we need to (to pass response from a method to another).

Methods `Response::new_<foo>` have been keep to avoid to much change in the code (and direct creation of `abi::fuse_<foo>_out`). But they may me better moved as free function or `new` method in the struct themselves (or simply removed ?)