### PR TITLE
Avoid copying reply buffer in `ReplyData`

### DIFF
--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -228,7 +228,7 @@ pub trait Request: Sized {
     fn pid(&self) -> u32;
 
     /// Create an error response for this Request
-    fn reply_err(&self, errno: Errno) -> Response {
+    fn reply_err(&self, errno: Errno) -> Response<'_> {
         Response::new_error(errno)
     }
 }
@@ -965,7 +965,7 @@ mod op {
             super::Version(self.arg.major, self.arg.minor)
         }
 
-        pub fn reply(&self, config: &crate::KernelConfig) -> Response {
+        pub fn reply(&self, config: &crate::KernelConfig) -> Response<'a> {
             let init = fuse_init_out {
                 major: FUSE_KERNEL_VERSION,
                 minor: FUSE_KERNEL_MINOR_VERSION,
@@ -1278,7 +1278,7 @@ mod op {
     }
     impl_request!(Destroy<'a>);
     impl<'a> Destroy<'a> {
-        pub fn reply(&self) -> Response {
+        pub fn reply(&self) -> Response<'a> {
             Response::new_empty()
         }
     }

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -70,7 +70,7 @@ impl Reply for ReplyRaw {
 impl ReplyRaw {
     /// Reply to a request with the given error code and data. Must be called
     /// only once (the `ok` and `error` methods ensure this by consuming `self`)
-    fn send_ll_mut(&mut self, response: &ll::Response) {
+    fn send_ll_mut(&mut self, response: &ll::Response<'_>) {
         assert!(self.sender.is_some());
         let sender = self.sender.take().unwrap();
         let res = response.with_iovec(self.unique, |iov| sender.send(iov));
@@ -78,7 +78,7 @@ impl ReplyRaw {
             error!("Failed to send FUSE reply: {}", err);
         }
     }
-    fn send_ll(mut self, response: &ll::Response) {
+    fn send_ll(mut self, response: &ll::Response<'_>) {
         self.send_ll_mut(response)
     }
 
@@ -148,7 +148,7 @@ impl Reply for ReplyData {
 impl ReplyData {
     /// Reply to a request with the given data
     pub fn data(self, data: &[u8]) {
-        self.reply.send_ll(&ll::Response::new_data(data));
+        self.reply.send_ll(&ll::Response::new_slice(data));
     }
 
     /// Reply to a request with the given error code

--- a/src/request.rs
+++ b/src/request.rs
@@ -68,7 +68,7 @@ impl<'a> Request<'a> {
     fn dispatch_req<FS: Filesystem>(
         &self,
         se: &mut Session<FS>,
-    ) -> Result<Option<Response>, Errno> {
+    ) -> Result<Option<Response<'_>>, Errno> {
         let op = self.request.operation().map_err(|_| Errno::ENOSYS)?;
         // Implement allow_root & access check for auto_unmount
         if (se.allowed == SessionACL::RootAndOwner


### PR DESCRIPTION
The reply already doesn't take ownership of the buffer, and it just ends up being written synchronously to the FUSE device, so there's no need to make a copy of it. Instead, the `Response` can just hold onto the slice and use it directly when building the IoVec for writing the response.

This is an alternative to https://github.com/cberner/fuser/pull/232 that is hopefully a little simpler while solving the same problem.

Fixes #232