### PR TITLE
Fix some compiler warnings

### DIFF
--- a/src/ll/reply.rs
+++ b/src/ll/reply.rs
@@ -24,7 +24,6 @@ pub enum Response<'a> {
     Slice(&'a [u8]),
 }
 
-#[must_use]
 impl<'a> Response<'a> {
     pub(crate) fn with_iovec<F: FnOnce(&[IoSlice<'_>]) -> T, T>(
         &self,
@@ -418,6 +417,7 @@ impl DirEntList {
 
 #[derive(Debug)]
 pub struct DirEntryPlus<T: AsRef<Path>> {
+    #[allow(unused)] // We use `attr.ino` instead
     ino: INodeNo,
     generation: Generation,
     offset: DirEntOffset,

--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -1340,6 +1340,7 @@ mod op {
     #[derive(Debug)]
     pub struct NotifyReply<'a> {
         header: &'a fuse_in_header,
+        #[allow(unused)]
         arg: &'a [u8],
     }
     #[cfg(feature = "abi-7-15")]
@@ -1350,6 +1351,7 @@ mod op {
     #[derive(Debug)]
     pub struct BatchForget<'a> {
         header: &'a fuse_in_header,
+        #[allow(unused)]
         arg: &'a fuse_batch_forget_in,
         nodes: &'a [fuse_forget_one],
     }
@@ -1587,6 +1589,7 @@ mod op {
     #[derive(Debug)]
     pub struct CuseInit<'a> {
         header: &'a fuse_in_header,
+        #[allow(unused)]
         arg: &'a fuse_init_in,
     }
     #[cfg(feature = "abi-7-12")]

--- a/src/request.rs
+++ b/src/request.rs
@@ -27,6 +27,7 @@ pub struct Request<'a> {
     /// Channel sender for sending the reply
     ch: ChannelSender,
     /// Request raw data
+    #[allow(unused)]
     data: &'a [u8],
     /// Parsed request
     request: ll::AnyRequest<'a>,

--- a/src/session.rs
+++ b/src/session.rs
@@ -218,9 +218,7 @@ impl BackgroundSession {
     /// Create a new background session for the given session by running its
     /// session loop in a background thread. If the returned handle is dropped,
     /// the filesystem is unmounted and the given session ends.
-    pub fn new<FS: Filesystem + Send + 'static>(
-        mut se: Session<FS>,
-    ) -> io::Result<BackgroundSession> {
+    pub fn new<FS: Filesystem + Send + 'static>(se: Session<FS>) -> io::Result<BackgroundSession> {
         let mountpoint = se.mountpoint().to_path_buf();
         // Take the fuse_session, so that we can unmount it
         let mount = std::mem::take(&mut *se.mount.lock().unwrap());


### PR DESCRIPTION
* `#[must_use]` doesn't do anything on impls, only methods
* We hold onto a couple of arguments that aren't used for convenience