### PR TITLE
Make `MountOption` to/from `str` conversion public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1005,7 +1005,7 @@ pub fn spawn_mount<'a, FS: Filesystem + Send + 'static + 'a, P: AsRef<Path>>(
 ) -> io::Result<BackgroundSession> {
     let options: Option<Vec<_>> = options
         .iter()
-        .map(|x| Some(MountOption::from_str(x.to_str()?)))
+        .map(|x| Some(MountOption::from(x.to_str()?)))
         .collect();
     let options = options.ok_or(ErrorKind::InvalidData)?;
     Session::new(filesystem, mountpoint.as_ref(), options.as_ref()).and_then(|se| se.spawn())


### PR DESCRIPTION
The goal here is to make the to/from string conversion of the `MountOption` type publically accessible. In the process, I've also implemented standard traits rather than using custom functions where appropriate. 

I considered using `std::str::FromStr` instead of `From`, but that trait has an associated error type and the current function is infallible.

Closes #229 