### PR TITLE
Small optimization tweaks

### DIFF
--- a/src/ll/reply.rs
+++ b/src/ll/reply.rs
@@ -66,9 +66,9 @@ impl<'a> Response<'a> {
 
     pub(crate) fn new_data<T: AsRef<[u8]> + Into<Vec<u8>>>(data: T) -> Self {
         Self::Data(if data.as_ref().len() <= INLINE_DATA_THRESHOLD {
-            data.as_ref().into()
+            ResponseBuf::from_slice(data.as_ref())
         } else {
-            data.into().into()
+            ResponseBuf::from_vec(data.into())
         })
     }
 
@@ -218,7 +218,7 @@ impl<'a> Response<'a> {
             out_iovs: if !data.is_empty() { 1 } else { 0 },
         };
         // TODO: Don't copy this data
-        let mut v: ResponseBuf = r.as_bytes().into();
+        let mut v: ResponseBuf = ResponseBuf::from_slice(r.as_bytes());
         for x in data {
             v.extend_from_slice(x)
         }
@@ -241,7 +241,7 @@ impl<'a> Response<'a> {
     }
 
     fn from_struct<T: AsBytes + ?Sized>(data: &T) -> Self {
-        Self::Data(data.as_bytes().into())
+        Self::Data(SmallVec::from_slice(data.as_bytes()))
     }
 }
 


### PR DESCRIPTION
Use `SmallVec::from_slice` instead of `SmallVec::from` as it can directly copy bytes.

Reference - https://docs.rs/smallvec/1.10.0/smallvec/struct.SmallVec.html#method.from_slice.