### PR TITLE
Make Session::new consistent with mount2

### DIFF
--- a/examples/notify_inval_entry.rs
+++ b/examples/notify_inval_entry.rs
@@ -162,7 +162,7 @@ fn main() {
         timeout: Duration::from_secs_f32(opts.timeout),
     };
 
-    let session = fuser::Session::new(fs, opts.mount_point.as_ref(), &options).unwrap();
+    let session = fuser::Session::new(fs, opts.mount_point, &options).unwrap();
     let notifier = session.notifier();
     let _bg = session.spawn().unwrap();
 

--- a/examples/notify_inval_inode.rs
+++ b/examples/notify_inval_inode.rs
@@ -200,7 +200,7 @@ fn main() {
         lookup_cnt,
     };
 
-    let session = fuser::Session::new(fs, opts.mount_point.as_ref(), &options).unwrap();
+    let session = fuser::Session::new(fs, opts.mount_point, &options).unwrap();
     let notifier = session.notifier();
     let _bg = session.spawn().unwrap();
 

--- a/examples/poll.rs
+++ b/examples/poll.rs
@@ -337,7 +337,7 @@ fn main() {
     let fs = FSelFS { data: data.clone() };
 
     let mntpt = std::env::args().nth(1).unwrap();
-    let session = fuser::Session::new(fs, mntpt.as_ref(), &options).unwrap();
+    let session = fuser::Session::new(fs, mntpt, &options).unwrap();
     let bg = session.spawn().unwrap();
 
     producer(&data, &bg.notifier());

--- a/src/session.rs
+++ b/src/session.rs
@@ -65,11 +65,12 @@ pub struct Session<FS: Filesystem> {
 
 impl<FS: Filesystem> Session<FS> {
     /// Create a new session by mounting the given filesystem to the given mountpoint
-    pub fn new(
+    pub fn new<P: AsRef<Path>>(
         filesystem: FS,
-        mountpoint: &Path,
+        mountpoint: P,
         options: &[MountOption],
     ) -> io::Result<Session<FS>> {
+        let mountpoint = mountpoint.as_ref();
         info!("Mounting {}", mountpoint.display());
         // If AutoUnmount is requested, but not AllowRoot or AllowOther we enforce the ACL
         // ourself and implicitly set AllowOther because fusermount needs allow_root or allow_other


### PR DESCRIPTION
Hiya @cberner!

I am a huge fan of this crate. It works very well for me. This PR is a small quality of life improvement that makes the `Session::new` method consistent with `mount2`/`spawn_mount2`. That is, you can now pass in anything that is `AsRef<Path>` as the mountpoint. Since `&Path` is `AsRef<Path>`, ~~this won't break existing callsites.~~ - clearly it will break some callsites where the compiler infers which `AsRef<T>` is the appropriate type for `String`.