### PR TITLE
Hide some usages of unsafe behind Nix crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ page_size = "0.6.0"
 serde = { version = "1.0.102", features = ["std", "derive"], optional = true }
 smallvec = "1.6.1"
 zerocopy = { version = "0.7", features = ["derive"] }
+nix = { version = "0.27.1", features = ["user", "fs"] }
 
 [dev-dependencies]
 env_logger = "0.10"

--- a/src/mnt/fuse3.rs
+++ b/src/mnt/fuse3.rs
@@ -45,10 +45,7 @@ impl Mount {
             }
             // We dup the fd here as the existing fd is owned by the fuse_session, and we
             // don't want it being closed out from under us:
-            let fd = unsafe { libc::dup(fd) };
-            if fd < 0 {
-                return Err(io::Error::last_os_error());
-            }
+            let fd = nix::unistd::dup(fd)?;
             let file = unsafe { File::from_raw_fd(fd) };
             Ok((Arc::new(file), mount))
         })

--- a/src/mnt/fuse_pure.rs
+++ b/src/mnt/fuse_pure.rs
@@ -343,8 +343,8 @@ fn fuse_mount_sys(mountpoint: &OsStr, options: &[MountOption]) -> Result<Option<
         "fd={},rootmode={:o},user_id={},group_id={}",
         file.as_raw_fd(),
         mountpoint_mode,
-        unsafe { libc::getuid() },
-        unsafe { libc::getgid() }
+        nix::unistd::getuid(),
+        nix::unistd::getgid()
     );
 
     for option in options

--- a/src/session.rs
+++ b/src/session.rs
@@ -7,6 +7,7 @@
 
 use libc::{EAGAIN, EINTR, ENODEV, ENOENT};
 use log::{info, warn};
+use nix::unistd::geteuid;
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -102,7 +103,7 @@ impl<FS: Filesystem> Session<FS> {
             mount: Arc::new(Mutex::new(Some(mount))),
             mountpoint: mountpoint.to_owned(),
             allowed,
-            session_owner: unsafe { libc::geteuid() },
+            session_owner: geteuid().as_raw(),
             proto_major: 0,
             proto_minor: 0,
             initialized: false,


### PR DESCRIPTION
Hi again @cberner!

This change intends to reduce the mental burden of reading `unsafe` blocks, by hiding `unsafe` function calls in the `nix` crate, and takes advantage of `nix`'s wrapping of fallible `libc` function calls in a `Result`. This doesn't make `fuser` safer _per se_, but it does make it a bit easier to read the code, because there is less `unsafe` to scrutinize.