### PR TITLE
Add file handle for get_attr requests.

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -58,7 +58,7 @@ impl Filesystem for HelloFS {
         }
     }
 
-    fn getattr(&mut self, _req: &Request, ino: u64, reply: ReplyAttr) {
+    fn getattr(&mut self, _req: &Request, ino: u64, _fd: Option<u64>, reply: ReplyAttr) {
         match ino {
             1 => reply.attr(&TTL, &HELLO_DIR_ATTR),
             2 => reply.attr(&TTL, &HELLO_TXT_ATTR),

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -58,7 +58,7 @@ impl Filesystem for HelloFS {
         }
     }
 
-    fn getattr(&mut self, _req: &Request, ino: u64, _fd: Option<u64>, reply: ReplyAttr) {
+    fn getattr(&mut self, _req: &Request, ino: u64, _fh: Option<u64>, reply: ReplyAttr) {
         match ino {
             1 => reply.attr(&TTL, &HELLO_DIR_ATTR),
             2 => reply.attr(&TTL, &HELLO_TXT_ATTR),

--- a/examples/notify_inval_entry.rs
+++ b/examples/notify_inval_entry.rs
@@ -87,7 +87,7 @@ impl<'a> Filesystem for ClockFS<'a> {
         }
     }
 
-    fn getattr(&mut self, _req: &Request, ino: u64, _fd: Option<u64>, reply: ReplyAttr) {
+    fn getattr(&mut self, _req: &Request, ino: u64, _fh: Option<u64>, reply: ReplyAttr) {
         match ClockFS::stat(ino) {
             Some(a) => reply.attr(&self.timeout, &a),
             None => reply.error(ENOENT),

--- a/examples/notify_inval_entry.rs
+++ b/examples/notify_inval_entry.rs
@@ -87,7 +87,7 @@ impl<'a> Filesystem for ClockFS<'a> {
         }
     }
 
-    fn getattr(&mut self, _req: &Request, ino: u64, reply: ReplyAttr) {
+    fn getattr(&mut self, _req: &Request, ino: u64, _fd: Option<u64>, reply: ReplyAttr) {
         match ClockFS::stat(ino) {
             Some(a) => reply.attr(&self.timeout, &a),
             None => reply.error(ENOENT),

--- a/examples/notify_inval_inode.rs
+++ b/examples/notify_inval_inode.rs
@@ -86,7 +86,7 @@ impl<'a> Filesystem for ClockFS<'a> {
         }
     }
 
-    fn getattr(&mut self, _req: &Request, ino: u64, _fd: Option<u64>, reply: ReplyAttr) {
+    fn getattr(&mut self, _req: &Request, ino: u64, _fh: Option<u64>, reply: ReplyAttr) {
         match self.stat(ino) {
             Some(a) => reply.attr(&Duration::MAX, &a),
             None => reply.error(ENOENT),

--- a/examples/notify_inval_inode.rs
+++ b/examples/notify_inval_inode.rs
@@ -86,7 +86,7 @@ impl<'a> Filesystem for ClockFS<'a> {
         }
     }
 
-    fn getattr(&mut self, _req: &Request, ino: u64, reply: ReplyAttr) {
+    fn getattr(&mut self, _req: &Request, ino: u64, _fd: Option<u64>, reply: ReplyAttr) {
         match self.stat(ino) {
             Some(a) => reply.attr(&Duration::MAX, &a),
             None => reply.error(ENOENT),

--- a/examples/poll.rs
+++ b/examples/poll.rs
@@ -101,7 +101,7 @@ impl fuser::Filesystem for FSelFS {
         reply.entry(&Duration::ZERO, &self.get_data().filestat(idx), 0);
     }
 
-    fn getattr(&mut self, _req: &Request, ino: u64, reply: fuser::ReplyAttr) {
+    fn getattr(&mut self, _req: &Request, ino: u64, _fd: Option<u64>, reply: fuser::ReplyAttr) {
         if ino == FUSE_ROOT_ID {
             let a = FileAttr {
                 ino: FUSE_ROOT_ID,

--- a/examples/poll.rs
+++ b/examples/poll.rs
@@ -101,7 +101,7 @@ impl fuser::Filesystem for FSelFS {
         reply.entry(&Duration::ZERO, &self.get_data().filestat(idx), 0);
     }
 
-    fn getattr(&mut self, _req: &Request, ino: u64, _fd: Option<u64>, reply: fuser::ReplyAttr) {
+    fn getattr(&mut self, _req: &Request, ino: u64, _fh: Option<u64>, reply: fuser::ReplyAttr) {
         if ino == FUSE_ROOT_ID {
             let a = FileAttr {
                 ino: FUSE_ROOT_ID,

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -537,7 +537,7 @@ impl Filesystem for SimpleFS {
 
     fn forget(&mut self, _req: &Request, _ino: u64, _nlookup: u64) {}
 
-    fn getattr(&mut self, _req: &Request, inode: u64, _fd: Option<u64>, reply: ReplyAttr) {
+    fn getattr(&mut self, _req: &Request, inode: u64, _fh: Option<u64>, reply: ReplyAttr) {
         match self.get_inode(inode) {
             Ok(attrs) => reply.attr(&Duration::new(0, 0), &attrs.into()),
             Err(error_code) => reply.error(error_code),

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -537,7 +537,7 @@ impl Filesystem for SimpleFS {
 
     fn forget(&mut self, _req: &Request, _ino: u64, _nlookup: u64) {}
 
-    fn getattr(&mut self, _req: &Request, inode: u64, reply: ReplyAttr) {
+    fn getattr(&mut self, _req: &Request, inode: u64, _fd: Option<u64>, reply: ReplyAttr) {
         match self.get_inode(inode) {
             Ok(attrs) => reply.attr(&Duration::new(0, 0), &attrs.into()),
             Err(error_code) => reply.error(error_code),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,8 +331,11 @@ pub trait Filesystem {
     }
 
     /// Get file attributes.
-    fn getattr(&mut self, _req: &Request<'_>, ino: u64, reply: ReplyAttr) {
-        warn!("[Not Implemented] getattr(ino: {:#x?})", ino);
+    fn getattr(&mut self, _req: &Request<'_>, ino: u64, fh: Option<u64>, reply: ReplyAttr) {
+        warn!(
+            "[Not Implemented] getattr(ino: {:#x?}, fh: {:#x?})",
+            ino, fh
+        );
         reply.error(ENOSYS);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,10 +331,10 @@ pub trait Filesystem {
     }
 
     /// Get file attributes.
-    fn getattr(&mut self, _req: &Request<'_>, ino: u64, fh: Option<u64>, reply: ReplyAttr) {
+    fn getattr(&mut self, _req: &Request<'_>, ino: u64, fd: Option<u64>, reply: ReplyAttr) {
         warn!(
-            "[Not Implemented] getattr(ino: {:#x?}, fh: {:#x?})",
-            ino, fh
+            "[Not Implemented] getattr(ino: {:#x?}, fd: {:#x?})",
+            ino, fd
         );
         reply.error(ENOSYS);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,10 +331,10 @@ pub trait Filesystem {
     }
 
     /// Get file attributes.
-    fn getattr(&mut self, _req: &Request<'_>, ino: u64, fd: Option<u64>, reply: ReplyAttr) {
+    fn getattr(&mut self, _req: &Request<'_>, ino: u64, fh: Option<u64>, reply: ReplyAttr) {
         warn!(
-            "[Not Implemented] getattr(ino: {:#x?}, fd: {:#x?})",
-            ino, fd
+            "[Not Implemented] getattr(ino: {:#x?}, fh: {:#x?})",
+            ino, fh
         );
         reply.error(ENOSYS);
     }

--- a/src/request.rs
+++ b/src/request.rs
@@ -205,9 +205,19 @@ impl<'a> Request<'a> {
                 se.filesystem
                     .forget(self, self.request.nodeid().into(), x.nlookup()); // no reply
             }
-            ll::Operation::GetAttr(_) => {
+            ll::Operation::GetAttr(_attr) => {
+                #[cfg(feature = "abi-7-9")]
+                se.filesystem.getattr(
+                    self,
+                    self.request.nodeid().into(),
+                    _attr.file_handle().map(|fh| fh.into()),
+                    self.reply(),
+                );
+
+                // Pre-abi-7-9 does not support providing a file handle.
+                #[cfg(not(feature = "abi-7-9"))]
                 se.filesystem
-                    .getattr(self, self.request.nodeid().into(), self.reply());
+                    .getattr(self, self.request.nodeid().into(), None, self.reply());
             }
             ll::Operation::SetAttr(x) => {
                 se.filesystem.setattr(


### PR DESCRIPTION
This PR adds the file handle parameter to the `getattr` request.
This feature is necessary when implementing filesystem APIs that generate file contents on request, like `/proc`.
The correct length of the file must be returned by `getattr` for that specific instance of the generated file, otherwise most programs will not read the file correctly. A file handle is needed to know which instance we are getting attributes for.

The parameter is available in ABI 7-9 and above, and has been feature gated as such. When the feature is not enabled, the `getattr` method on Filesystems will always be passed None for the file descriptor.