### PR TITLE
fuse3: Set FD_CLOEXEC on duplicated fuse session fd

### DIFF
--- a/src/mnt/fuse3.rs
+++ b/src/mnt/fuse3.rs
@@ -45,7 +45,7 @@ impl Mount {
             }
             // We dup the fd here as the existing fd is owned by the fuse_session, and we
             // don't want it being closed out from under us:
-            let fd = nix::unistd::dup(fd)?;
+            let fd = nix::fcntl::fcntl(fd, nix::fcntl::FcntlArg::F_DUPFD_CLOEXEC(0))?;
             let file = unsafe { File::from_raw_fd(fd) };
             Ok((Arc::new(file), mount))
         })


### PR DESCRIPTION
The duplicated file descriptor returned by `dup` will not have `FD_CLOEXEC` flag set:

> The two file descriptors do not share file descriptor flags (the close-on-exec flag).  The close-on-exec flag (FD_CLOEXEC; see fcntl(2)) for the duplicate descriptor is off.

(The file descriptor returned by libfuse3 has `FD_CLOEXEC` set as of https://github.com/libfuse/libfuse/commit/4a6fb6768aada05e456b2e8cbbcf5660637564ce)

It's good practice to set the close-on-exec flag on file descriptors to avoid "leaking" fds when calling `exec*()`.