### PR TITLE
chore(examples): fix HelloFS getattr signature

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -3,10 +3,11 @@ use fuser::{
     FileAttr, FileType, Filesystem, MountOption, ReplyAttr, ReplyData, ReplyDirectory, ReplyEntry,
     Request,
 };
-use libc::ENOENT;
 use std::ffi::OsStr;
 use std::time::{Duration, UNIX_EPOCH};
 
+// Defintion from libc::ENOENT
+const ENOENT: i32 = 2;
 const TTL: Duration = Duration::from_secs(1); // 1 second
 
 const HELLO_DIR_ATTR: FileAttr = FileAttr {
@@ -58,7 +59,7 @@ impl Filesystem for HelloFS {
         }
     }
 
-    fn getattr(&mut self, _req: &Request, ino: u64, _fh: Option<u64>, reply: ReplyAttr) {
+    fn getattr(&mut self, _req: &Request, ino: u64, reply: ReplyAttr) {
         match ino {
             1 => reply.attr(&TTL, &HELLO_DIR_ATTR),
             2 => reply.attr(&TTL, &HELLO_TXT_ATTR),
@@ -136,7 +137,6 @@ fn main() {
                 .help("Allow root user to access filesystem"),
         )
         .get_matches();
-    env_logger::init();
     let mountpoint = matches.get_one::<String>("MOUNT_POINT").unwrap();
     let mut options = vec![MountOption::RO, MountOption::FSName("hello".to_string())];
     if matches.get_flag("auto_unmount") {


### PR DESCRIPTION
This commit adjusts the signature of HelloFS 'getattr' function, so that it is aligned with the Filesystem trait, thus making the example build.

In addition, the following minor miscellaneous changes were made to examples/hello.rs:
* dependency on libc crate was removed, to simplify the example and its usage
* unnecessary `env_logger::init()` call was removed