### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,15 @@ jobs:
         features: [ '', 'abi-7-19' ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install packages
         run: |
           sudo apt update
           sudo apt install -y ${{ matrix.libfuse }} build-essential
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           target: x86_64-unknown-linux-musl
-          default: true
 
       - name: Run tests
         run: |
@@ -35,35 +34,32 @@ jobs:
           cargo doc --all --no-deps --features=${{ matrix.features }}
   ci:
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        test_group: [pre, mount_tests, pjdfs_tests, xfstests]
-
     steps:
-      - uses: actions/checkout@v2
-      - name: Cache
-        id: rust-cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml', '.github/workflows/*.yml', 'rust-toolchain') }}
+      - uses: actions/checkout@v4
       - name: Install packages
         run: |
           sudo apt update
           sudo apt install -y libfuse-dev libfuse3-dev build-essential
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt, clippy
-          default: true
 
-      - name: Install cargo-deny
-        run: cargo install --force --version 0.14.3 cargo-deny --locked
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny@0.14
+
+      - name: Run tests
+        run: INTERACTIVE="" make pre
+
+  test:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        test_group: [mount_tests, pjdfs_tests, xfstests]
+
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Run tests
         run: INTERACTIVE="" make ${{ matrix.test_group }}

--- a/Makefile
+++ b/Makefile
@@ -22,22 +22,22 @@ xfstests:
 pjdfs_tests: pjdfs_tests_fuse2 pjdfs_tests_fuse3 pjdfs_tests_pure
 
 pjdfs_tests_fuse2:
-	docker build --build-arg BUILD_FEATURES='--features=abi-7-19' -t fuser:pjdfs -f pjdfs.Dockerfile .
+	docker build --build-arg BUILD_FEATURES='--features=abi-7-19' -t fuser:pjdfs-2 -f pjdfs.Dockerfile .
 	# Additional permissions are needed to be able to mount FUSE
 	docker run --rm -$(INTERACTIVE)t --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined \
-	 -v "$(shell pwd)/logs:/code/logs" fuser:pjdfs bash -c "cd /code/fuser && ./pjdfs.sh"
+	 -v "$(shell pwd)/logs:/code/logs" fuser:pjdfs-2 bash -c "cd /code/fuser && ./pjdfs.sh"
 
 pjdfs_tests_fuse3:
-	docker build --build-arg BUILD_FEATURES='--features=abi-7-31' -t fuser:pjdfs -f pjdfs.Dockerfile .
+	docker build --build-arg BUILD_FEATURES='--features=abi-7-31' -t fuser:pjdfs-3 -f pjdfs.Dockerfile .
 	# Additional permissions are needed to be able to mount FUSE
 	docker run --rm -$(INTERACTIVE)t --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined \
-	 -v "$(shell pwd)/logs:/code/logs" fuser:pjdfs bash -c "cd /code/fuser && ./pjdfs.sh"
+	 -v "$(shell pwd)/logs:/code/logs" fuser:pjdfs-3 bash -c "cd /code/fuser && ./pjdfs.sh"
 
 pjdfs_tests_pure:
-	docker build --build-arg BUILD_FEATURES='--no-default-features --features=abi-7-19' -t fuser:pjdfs -f pjdfs.Dockerfile .
+	docker build --build-arg BUILD_FEATURES='--no-default-features --features=abi-7-19' -t fuser:pjdfs-pure -f pjdfs.Dockerfile .
 	# Additional permissions are needed to be able to mount FUSE
 	docker run --rm -$(INTERACTIVE)t --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined \
-	 -v "$(shell pwd)/logs:/code/logs" fuser:pjdfs bash -c "cd /code/fuser && ./pjdfs.sh"
+	 -v "$(shell pwd)/logs:/code/logs" fuser:pjdfs-pure bash -c "cd /code/fuser && ./pjdfs.sh"
 
 mount_tests:
 	docker build -t fuser:mount_tests -f mount_tests.Dockerfile .


### PR DESCRIPTION
- Update `actions/checkout` to v4

- Replace `actions-rs/toolchain` with `actions-rust-lang/setup-rust-toolchain`

  The previous actions `actions-rs/toolchain` is no longer maintained and was archived. The new action `actions-rust-lang/setup-rust-toolchain` is the recommended way to setup the rust toolchain.

  It also provide a caching mechanism for the rust toolchain which is not available in the previous action and required the use of `actions/cache`.

- Separate `ci pre` from tests

  The `fuser`'s tests only use docker and don't need to rust setup that was only done for the `pre` group.

- Use action `taiki-e/install-action` to install `cargo-deny`

  This action install a pre-compiled version for cargo-deny which is faster than compiling it from source.

- Rename docker tag to prevent tag conflict