### PR TITLE
Add CI to run tests on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,23 @@ jobs:
 
       - name: Run tests
         run: INTERACTIVE="" make ${{ matrix.test_group }}
+
+  test-mac:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Note that this is a partial install of macFUSE, for a complete installation that would require to install the kernel extension
+      # But that currently not possible without restarting the machine
+      - name: Install macFUSE
+        run: brew install --cask macfuse
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Run tests
+        # The macFuse kernel extension is not installed so we need to skip the unmount_no_send test
+        run: cargo test --features=libfuse -- --skip unmount_no_send
+        env:
+          RUST_LOG: DEBUG
+        timeout-minutes: 5
+

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1098,6 +1098,9 @@ impl Filesystem for SimpleFS {
         flags: u32,
         reply: ReplyEmpty,
     ) {
+        #[cfg(target_os = "macos")]
+        let _ = flags;
+
         let mut inode_attrs = match self.lookup_name(parent, name) {
             Ok(attrs) => attrs,
             Err(error_code) => {
@@ -1922,6 +1925,9 @@ fn as_file_kind(mut mode: u32) -> FileKind {
 }
 
 fn get_groups(pid: u32) -> Vec<u32> {
+    #[cfg(target_os = "macos")]
+    let _ = pid;
+
     #[cfg(not(target_os = "macos"))]
     {
         let path = format!("/proc/{pid}/task/{pid}/status");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -5,8 +5,9 @@ use std::time::Duration;
 use tempfile::TempDir;
 
 #[test]
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn unmount_no_send() {
+    env_logger::init();
     // Rc to make this !Send
     struct NoSendFS(Rc<()>);
 


### PR DESCRIPTION
- Enable test `unmount_no_send` for macOS but skip it on CI

  This is due to the macFUSE's kernel extension that is not installed causing the test to not finish.

- Disable test `mount_unmount`, it seems macOS need an handshake of some sort for the mountpoint to be acknowledged.

- Fix unused variable when targeting macos.