### PR TITLE
WIP: Add Multithreading Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ abi-7-28 = ["abi-7-27"]
 abi-7-29 = ["abi-7-28"]
 abi-7-30 = ["abi-7-29"]
 abi-7-31 = ["abi-7-30"]
+multithreading = []
 
 [[example]]
 name = "poll"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ page_size = "0.6.0"
 serde = { version = "1.0.102", features = ["std", "derive"], optional = true }
 smallvec = "1.6.1"
 zerocopy = { version = "0.7", features = ["derive"] }
-nix = { version = "0.28.0", features = ["fs", "user"] }
+nix = { version = "0.28.0", features = ["fs", "user", "ioctl",] }
 
 [dev-dependencies]
 env_logger = "0.11.3"

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -47,6 +47,7 @@ const HELLO_TXT_ATTR: FileAttr = FileAttr {
     blksize: 512,
 };
 
+#[derive(Clone)]
 struct HelloFS;
 
 impl Filesystem for HelloFS {
@@ -145,5 +146,8 @@ fn main() {
     if matches.get_flag("allow-root") {
         options.push(MountOption::AllowRoot);
     }
-    fuser::mount2(HelloFS, mountpoint, &options).unwrap();
+    let s = fuser::spawn_mount2(HelloFS, mountpoint, &options).unwrap();
+
+    println!("ready");
+    s.guard.join();
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -146,8 +146,6 @@ fn main() {
     if matches.get_flag("allow-root") {
         options.push(MountOption::AllowRoot);
     }
-    let s = fuser::spawn_mount2(HelloFS, mountpoint, &options, 2).unwrap();
-
-    println!("ready");
+    let s = fuser::spawn_mount2_threaded(HelloFS, mountpoint, &options, 2).unwrap();
     s.guard.join();
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -146,7 +146,7 @@ fn main() {
     if matches.get_flag("allow-root") {
         options.push(MountOption::AllowRoot);
     }
-    let s = fuser::spawn_mount2(HelloFS, mountpoint, &options).unwrap();
+    let s = fuser::spawn_mount2(HelloFS, mountpoint, &options, 2).unwrap();
 
     println!("ready");
     s.guard.join();

--- a/examples/null.rs
+++ b/examples/null.rs
@@ -1,6 +1,7 @@
 use fuser::{Filesystem, MountOption};
 use std::env;
 
+#[derive(Clone)]
 struct NullFS;
 
 impl Filesystem for NullFS {}

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -32,6 +32,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::{env, fs, io};
+use std::sync::Arc;
 
 const BLOCK_SIZE: u64 = 512;
 const MAX_NAME_LENGTH: u32 = 255;
@@ -243,9 +244,10 @@ impl From<InodeAttributes> for fuser::FileAttr {
 
 // Stores inode metadata data in "$data_dir/inodes" and file contents in "$data_dir/contents"
 // Directory data is stored in the file's contents, as a serialized DirectoryDescriptor
+#[derive(Clone)]
 struct SimpleFS {
     data_dir: String,
-    next_file_handle: AtomicU64,
+    next_file_handle: Arc<AtomicU64>,
     direct_io: bool,
     suid_support: bool,
 }
@@ -260,7 +262,7 @@ impl SimpleFS {
         {
             SimpleFS {
                 data_dir,
-                next_file_handle: AtomicU64::new(1),
+                next_file_handle: Arc::new(AtomicU64::new(1)),
                 direct_io,
                 suid_support,
             }
@@ -269,7 +271,7 @@ impl SimpleFS {
         {
             SimpleFS {
                 data_dir,
-                next_file_handle: AtomicU64::new(1),
+                next_file_handle: Arc::new(AtomicU64::new(1)),
                 direct_io,
                 suid_support: false,
             }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -3,13 +3,12 @@ use std::os::fd::FromRawFd;
 use libc::{c_int, c_void, size_t};
 use crate::reply::ReplySender;
 
-/// The implementation of fuse fd clone.
+/// The implementation of fuse fd clone. Taken from (Datenlord)[https://github.com/datenlord/datenlord/blob/master/src/async_fuse/fuse/session.rs#L73 under the MIT License.
 /// This module is just for avoiding the `missing_docs` of `ioctl_read` macro.
 #[allow(missing_docs)] // Raised by `ioctl_read!`
 mod _fuse_fd_clone {
     use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 
-    // use clippy_utilities::Cast;
     use nix::fcntl::{self, FcntlArg, FdFlag, OFlag};
     use nix::ioctl_read;
     use nix::sys::stat::Mode;
@@ -53,6 +52,7 @@ impl Channel {
     }
 
     pub(crate) fn new_worker(session_fd: &c_int) -> (Self, c_int) {
+        // TODO SAFETY: `session_fd` is ensured to be valid
         let fd = unsafe { _fuse_fd_clone::fuse_fd_clone(*session_fd) };
 
         let fd = match fd {
@@ -62,6 +62,7 @@ impl Channel {
             }
         };
 
+        // SAFETY: `fd` is ensured to be valid at the start of function
         let device = unsafe { File::from_raw_fd(fd) };
 
         (Self(Arc::new(device)), fd)

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -51,8 +51,14 @@ impl Channel {
         Self(device)
     }
 
-    pub(crate) fn new_worker(session_fd: &c_int) -> (Self, c_int) {
-        // TODO SAFETY: `session_fd` is ensured to be valid
+    /// Create a new communication channel to the kernel driver by calling ['_fuse_fd_clone::fuse_fd_clone']
+    /// with the Session FD. This will create a new communication channel to 
+    /// the kernel driver attached to the parent session.
+    #[cfg(all(feature = "multithreading", feature = "libfuse3"))]
+    pub(crate) fn worker(mount: &Mount) -> (Self, c_int) {
+        let session_fd = mount.session_fd(); 
+
+        // SAFETY: `session_fd` is ensured to be valid
         let fd = unsafe { _fuse_fd_clone::fuse_fd_clone(*session_fd) };
 
         let fd = match fd {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,8 +1,44 @@
 use std::{fs::File, io, os::unix::prelude::AsRawFd, sync::Arc};
-
+use std::os::fd::FromRawFd;
 use libc::{c_int, c_void, size_t};
-
 use crate::reply::ReplySender;
+
+/// The implementation of fuse fd clone.
+/// This module is just for avoiding the `missing_docs` of `ioctl_read` macro.
+#[allow(missing_docs)] // Raised by `ioctl_read!`
+mod _fuse_fd_clone {
+    use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
+
+    // use clippy_utilities::Cast;
+    use nix::fcntl::{self, FcntlArg, FdFlag, OFlag};
+    use nix::ioctl_read;
+    use nix::sys::stat::Mode;
+    ioctl_read!(fuse_fd_clone_impl, 229, 0, u32);
+
+    /// Clones a FUSE session fd into a FUSE worker fd.
+    ///
+    /// # Safety
+    /// Behavior is undefined if any of the following conditions are violated:
+    ///
+    /// - `session_fd` must be a valid file descriptor to an open FUSE device.
+    #[allow(clippy::unnecessary_safety_comment)]
+    pub unsafe fn fuse_fd_clone(session_fd: RawFd) -> nix::Result<RawFd> {
+        let devname = "/dev/fuse";
+        let cloned_fd = fcntl::open(devname, OFlag::O_RDWR | OFlag::O_CLOEXEC, Mode::empty())?;
+        // use `OwnedFd` here is just to release the fd when error occurs
+        // SAFETY: the `cloned_fd` is just opened
+        let cloned_fd = OwnedFd::from_raw_fd(cloned_fd);
+
+        fcntl::fcntl(cloned_fd.as_raw_fd(), FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC))?;
+
+        let mut result_fd: u32 = session_fd.try_into().unwrap();
+        // SAFETY: `cloned_fd` is ensured to be valid, and `&mut result_fd` is a valid
+        // pointer to a value on stack
+        fuse_fd_clone_impl(cloned_fd.as_raw_fd(), &mut result_fd)?;
+        Ok(cloned_fd.into_raw_fd()) // use `into_raw_fd` to transfer the
+        // ownership of the fd
+    }
+}
 
 /// A raw communication channel to the FUSE kernel driver
 #[derive(Debug)]
@@ -14,6 +50,21 @@ impl Channel {
     /// the given path to the channel.
     pub(crate) fn new(device: Arc<File>) -> Self {
         Self(device)
+    }
+
+    pub(crate) fn new_worker(session_fd: &c_int) -> (Self, c_int) {
+        let fd = unsafe { _fuse_fd_clone::fuse_fd_clone(*session_fd) };
+
+        let fd = match fd {
+            Ok(fd) => fd,
+            Err(err) => {
+                panic!("fuse: failed to clone device fd: {:?}", err);
+            }
+        };
+
+        let device = unsafe { File::from_raw_fd(fd) };
+
+        (Self(Arc::new(device)), fd)
     }
 
     /// Receives data up to the capacity of the given buffer (can block).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,7 +291,7 @@ impl KernelConfig {
 /// implementations are provided here to get a mountable filesystem that does
 /// nothing.
 #[allow(clippy::too_many_arguments)]
-pub trait Filesystem {
+pub trait Filesystem: Clone {
     /// Initialize filesystem.
     /// Called before any other filesystem method.
     /// The kernel module connection can be configured using the KernelConfig object

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1055,7 +1055,9 @@ pub fn spawn_mount2<'a, FS: Filesystem + Send + 'static + 'a, P: AsRef<Path>>(
     Session::new(filesystem, mountpoint.as_ref(), options).and_then(|se| se.spawn(1))
 }
 
-/// Mount the given filesystem to the given mountpoint; spawning n number of worker threads.
+/// Mount the given filesystem to the given mountpoint; spawning n number of worker threads. 
+/// There is an assumption that the [`Filesystem`] given is thread-safe, and has proper internal 
+/// synchronization to prevent deadlocks. 
 #[cfg(feature = "multithreading")]
 pub fn spawn_mount2_threaded<'a, FS: Filesystem + Send + 'static + 'a, P: AsRef<Path>>(
     filesystem: FS,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1058,7 +1058,7 @@ pub fn spawn_mount2<'a, FS: Filesystem + Send + 'static + 'a, P: AsRef<Path>>(
 /// Mount the given filesystem to the given mountpoint; spawning n number of worker threads. 
 /// There is an assumption that the [`Filesystem`] given is thread-safe, and has proper internal 
 /// synchronization to prevent deadlocks. 
-#[cfg(feature = "multithreading")]
+#[cfg(all(feature = "multithreading", feature = "libfuse3"))]
 pub fn spawn_mount2_threaded<'a, FS: Filesystem + Send + 'static + 'a, P: AsRef<Path>>(
     filesystem: FS,
     mountpoint: P,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1036,7 +1036,7 @@ pub fn spawn_mount<'a, FS: Filesystem + Send + 'static + 'a, P: AsRef<Path>>(
         .map(|x| Some(MountOption::from_str(x.to_str()?)))
         .collect();
     let options = options.ok_or(ErrorKind::InvalidData)?;
-    Session::new(filesystem, mountpoint.as_ref(), options.as_ref()).and_then(|se| se.spawn())
+    Session::new(filesystem, mountpoint.as_ref(), options.as_ref()).and_then(|se| se.spawn(1))
 }
 
 /// Mount the given filesystem to the given mountpoint. This function spawns
@@ -1049,8 +1049,20 @@ pub fn spawn_mount<'a, FS: Filesystem + Send + 'static + 'a, P: AsRef<Path>>(
 pub fn spawn_mount2<'a, FS: Filesystem + Send + 'static + 'a, P: AsRef<Path>>(
     filesystem: FS,
     mountpoint: P,
-    options: &[MountOption],
+    options: &[MountOption]
 ) -> io::Result<BackgroundSession> {
     check_option_conflicts(options)?;
-    Session::new(filesystem, mountpoint.as_ref(), options).and_then(|se| se.spawn())
+    Session::new(filesystem, mountpoint.as_ref(), options).and_then(|se| se.spawn(1))
+}
+
+/// Mount the given filesystem to the given mountpoint; spawning n number of worker threads.
+#[cfg(feature = "multithreading")]
+pub fn spawn_mount2_threaded<'a, FS: Filesystem + Send + 'static + 'a, P: AsRef<Path>>(
+    filesystem: FS,
+    mountpoint: P,
+    options: &[MountOption],
+    threads: u8
+) -> io::Result<BackgroundSession> {
+    check_option_conflicts(options)?;
+    Session::new(filesystem, mountpoint.as_ref(), options).and_then(|se| se.spawn(threads))
 }

--- a/src/ll/mod.rs
+++ b/src/ll/mod.rs
@@ -11,7 +11,7 @@ use std::{convert::TryInto, num::NonZeroI32, time::SystemTime};
 
 pub use reply::Response;
 pub use request::{
-    AnyRequest, FileHandle, INodeNo, Lock, Operation, Request, RequestError, RequestId, Version,
+    AnyRequest, FileHandle, INodeNo, Lock, Operation, Request, RequestId, Version,
 };
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/src/mnt/fuse3.rs
+++ b/src/mnt/fuse3.rs
@@ -12,6 +12,7 @@ use std::{
     ptr,
     sync::Arc,
 };
+use libc::c_int;
 
 /// Ensures that an os error is never 0/Success
 fn ensure_last_os_error() -> io::Error {
@@ -49,6 +50,10 @@ impl Mount {
             let file = unsafe { File::from_raw_fd(fd) };
             Ok((Arc::new(file), mount))
         })
+    }
+
+    pub fn session_fd(&self) -> c_int {
+        unsafe { fuse_session_fd(self.fuse_session) }
     }
 }
 impl Drop for Mount {

--- a/src/mnt/fuse3.rs
+++ b/src/mnt/fuse3.rs
@@ -52,6 +52,7 @@ impl Mount {
         })
     }
 
+    #[cfg(feature = "multithreading")]
     pub fn session_fd(&self) -> c_int {
         unsafe { fuse_session_fd(self.fuse_session) }
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -8,6 +8,7 @@ use tempfile::TempDir;
 #[cfg(target_os = "linux")]
 fn unmount_no_send() {
     // Rc to make this !Send
+    #[derive(Clone)]
     struct NoSendFS(Rc<()>);
 
     impl Filesystem for NoSendFS {}


### PR DESCRIPTION
Add Multithreading Support to fuser.

This implementation modifies `BackgroundSession` to accept a thread quantity. If this number is two or more, then n - 1 background workers will be created. There will always be a primary worker created, hence n - 1. 

`Session::worker` is called to clone the Session, which in turn calls `Channel::worker`. This method accepts the Mount object, and using `.session_fd` to return the Session FD, `fuse_fd_clone` is invoked to clone the file descriptor and run the needed ioctl call to setup the session. 

I can't take all the credit, as the main piece of code in channel.rs is from the Datenlord project where they are doing a native async_fuse library.

The code in question is from here: https://github.com/datenlord/datenlord/blob/d90fd43732373451207e56e9b9cd7eef9e7b53e1/src/async_fuse/fuse/session.rs#L73

Additional References:
* https://john-millikin.com/the-fuse-protocol#multi-threading
* https://fuse-devel.narkive.com/CodQceXu/how-could-fuse-support-parallel-opreation

TODO

- [ ] Clean up feature gate
- [ ] Add more function documentation 
- [ ] Add changelog entry
- [ ] Bump version 