### PR TITLE
skip umount if session has been destroyed

### DIFF
--- a/src/mnt/fuse2.rs
+++ b/src/mnt/fuse2.rs
@@ -6,7 +6,10 @@ use std::{
     io,
     os::unix::prelude::{FromRawFd, OsStrExt},
     path::Path,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
 };
 
 /// Ensures that an os error is never 0/Success
@@ -21,9 +24,14 @@ fn ensure_last_os_error() -> io::Error {
 #[derive(Debug)]
 pub struct Mount {
     mountpoint: CString,
+    destroyed: Arc<AtomicBool>,
 }
 impl Mount {
-    pub fn new(mountpoint: &Path, options: &[MountOption]) -> io::Result<(Arc<File>, Mount)> {
+    pub fn new(
+        mountpoint: &Path,
+        options: &[MountOption],
+        destroyed: Arc<AtomicBool>,
+    ) -> io::Result<(Arc<File>, Mount)> {
         let mountpoint = CString::new(mountpoint.as_os_str().as_bytes()).unwrap();
         with_fuse_args(options, |args| {
             let fd = unsafe { fuse_mount_compat25(mountpoint.as_ptr(), args) };
@@ -31,7 +39,13 @@ impl Mount {
                 Err(ensure_last_os_error())
             } else {
                 let file = unsafe { File::from_raw_fd(fd) };
-                Ok((Arc::new(file), Mount { mountpoint }))
+                Ok((
+                    Arc::new(file),
+                    Mount {
+                        mountpoint,
+                        destroyed,
+                    },
+                ))
             }
         })
     }
@@ -40,30 +54,32 @@ impl Drop for Mount {
     fn drop(&mut self) {
         use std::io::ErrorKind::PermissionDenied;
 
-        // fuse_unmount_compat22 unfortunately doesn't return a status. Additionally,
-        // it attempts to call realpath, which in turn calls into the filesystem. So
-        // if the filesystem returns an error, the unmount does not take place, with
-        // no indication of the error available to the caller. So we call unmount
-        // directly, which is what osxfuse does anyway, since we already converted
-        // to the real path when we first mounted.
-        if let Err(err) = super::libc_umount(&self.mountpoint) {
-            // Linux always returns EPERM for non-root users.  We have to let the
-            // library go through the setuid-root "fusermount -u" to unmount.
-            if err.kind() == PermissionDenied {
-                #[cfg(not(any(
-                    target_os = "macos",
-                    target_os = "freebsd",
-                    target_os = "dragonfly",
-                    target_os = "openbsd",
-                    target_os = "bitrig",
-                    target_os = "netbsd"
-                )))]
-                unsafe {
-                    fuse_unmount_compat22(self.mountpoint.as_ptr());
-                    return;
+        if !self.destroyed.load(Ordering::Relaxed) {
+            // fuse_unmount_compat22 unfortunately doesn't return a status. Additionally,
+            // it attempts to call realpath, which in turn calls into the filesystem. So
+            // if the filesystem returns an error, the unmount does not take place, with
+            // no indication of the error available to the caller. So we call unmount
+            // directly, which is what osxfuse does anyway, since we already converted
+            // to the real path when we first mounted.
+            if let Err(err) = super::libc_umount(&self.mountpoint) {
+                // Linux always returns EPERM for non-root users.  We have to let the
+                // library go through the setuid-root "fusermount -u" to unmount.
+                if err.kind() == PermissionDenied {
+                    #[cfg(not(any(
+                        target_os = "macos",
+                        target_os = "freebsd",
+                        target_os = "dragonfly",
+                        target_os = "openbsd",
+                        target_os = "bitrig",
+                        target_os = "netbsd"
+                    )))]
+                    unsafe {
+                        fuse_unmount_compat22(self.mountpoint.as_ptr());
+                        return;
+                    }
                 }
+                warn!("umount failed with {:?}", err);
             }
-            warn!("umount failed with {:?}", err);
         }
     }
 }

--- a/src/mnt/mod.rs
+++ b/src/mnt/mod.rs
@@ -162,7 +162,7 @@ mod test {
         // want to try and clean up the directory if it's a mountpoint otherwise we'll
         // deadlock.
         let tmp = ManuallyDrop::new(tempfile::tempdir().unwrap());
-        let (file, mount) = Mount::new(tmp.path(), &[]).unwrap();
+        let (file, mount) = Mount::new(tmp.path(), &[], Default::default()).unwrap();
         let mnt = cmd_mount();
         eprintln!("Our mountpoint: {:?}\nfuse mounts:\n{}", tmp.path(), mnt,);
         assert!(mnt.contains(&*tmp.path().to_string_lossy()));

--- a/src/request.rs
+++ b/src/request.rs
@@ -11,6 +11,7 @@ use std::convert::TryFrom;
 #[cfg(feature = "abi-7-28")]
 use std::convert::TryInto;
 use std::path::Path;
+use std::sync::atomic::Ordering;
 
 use crate::channel::ChannelSender;
 use crate::ll::Request as _;
@@ -179,11 +180,11 @@ impl<'a> Request<'a> {
             // Filesystem destroyed
             ll::Operation::Destroy(x) => {
                 se.filesystem.destroy();
-                se.destroyed = true;
+                se.destroyed.store(true, Ordering::Relaxed);
                 return Ok(Some(x.reply()));
             }
             // Any operation is invalid after destroy
-            _ if se.destroyed => {
+            _ if se.destroyed() => {
                 warn!("Ignoring FUSE operation after destroy: {}", self.request);
                 return Err(Errno::EIO);
             }

--- a/src/session.rs
+++ b/src/session.rs
@@ -10,6 +10,7 @@ use log::{info, warn};
 use nix::unistd::geteuid;
 use std::fmt;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::{io, ops::DerefMut};
@@ -61,7 +62,7 @@ pub struct Session<FS: Filesystem> {
     /// True if the filesystem is initialized (init operation done)
     pub(crate) initialized: bool,
     /// True if the filesystem was destroyed (destroy operation done)
-    pub(crate) destroyed: bool,
+    pub(crate) destroyed: Arc<AtomicBool>,
 }
 
 impl<FS: Filesystem> Session<FS> {
@@ -73,6 +74,7 @@ impl<FS: Filesystem> Session<FS> {
     ) -> io::Result<Session<FS>> {
         let mountpoint = mountpoint.as_ref();
         info!("Mounting {}", mountpoint.display());
+        let destroyed = Arc::new(AtomicBool::new(false));
         // If AutoUnmount is requested, but not AllowRoot or AllowOther we enforce the ACL
         // ourself and implicitly set AllowOther because fusermount needs allow_root or allow_other
         // to handle the auto_unmount option
@@ -83,9 +85,9 @@ impl<FS: Filesystem> Session<FS> {
             warn!("Given auto_unmount without allow_root or allow_other; adding allow_other, with userspace permission handling");
             let mut modified_options = options.to_vec();
             modified_options.push(MountOption::AllowOther);
-            Mount::new(mountpoint, &modified_options)?
+            Mount::new(mountpoint, &modified_options, destroyed.clone())?
         } else {
-            Mount::new(mountpoint, options)?
+            Mount::new(mountpoint, options, destroyed.clone())?
         };
 
         let ch = Channel::new(file);
@@ -107,7 +109,7 @@ impl<FS: Filesystem> Session<FS> {
             proto_major: 0,
             proto_minor: 0,
             initialized: false,
-            destroyed: false,
+            destroyed,
         })
     }
 
@@ -172,6 +174,10 @@ impl<FS: Filesystem> Session<FS> {
     pub fn notifier(&self) -> Notifier {
         Notifier::new(self.ch.sender())
     }
+
+    pub(crate) fn destroyed(&self) -> bool {
+        self.destroyed.load(Ordering::Relaxed)
+    }
 }
 
 #[derive(Debug)]
@@ -206,9 +212,9 @@ impl<FS: 'static + Filesystem + Send> Session<FS> {
 
 impl<FS: Filesystem> Drop for Session<FS> {
     fn drop(&mut self) {
-        if !self.destroyed {
+        if !self.destroyed() {
             self.filesystem.destroy();
-            self.destroyed = true;
+            self.destroyed.store(true, Ordering::Relaxed);
         }
         info!("Unmounted {}", self.mountpoint().display());
     }


### PR DESCRIPTION
when the mountpoint is unmounted in other ways (like `$ umount <mountpoint>`), fuser will got this message

```
WARN fuser::mnt::fuse2(fuse2.rs:66) - umount failed with Os { code: 22, kind: InvalidInput, message: "Invalid argument" }

```

the reason is that the Mount::drop call umount directly regardless the mountpoint is unmounted.

------
this pr introduced a shared var to ignore umount when Session is destroyed. 