### PR TITLE
Allow users to create Notifier objects when handling requests

### DIFF
--- a/examples/poll.rs
+++ b/examples/poll.rs
@@ -23,7 +23,7 @@ use libc::{EACCES, EBADF, EBUSY, EINVAL, ENOENT, ENOTDIR};
 
 use fuser::{
     consts::{FOPEN_DIRECT_IO, FOPEN_NONSEEKABLE, FUSE_POLL_SCHEDULE_NOTIFY},
-    FileAttr, FileType, MountOption, Request, FUSE_ROOT_ID,
+    FileAttr, FileType, MountOption, PollHandle, Request, FUSE_ROOT_ID,
 };
 
 const NUMFILES: u8 = 16;
@@ -251,7 +251,7 @@ impl fuser::Filesystem for FSelFS {
         _req: &Request,
         _ino: u64,
         fh: u64,
-        kh: u64,
+        ph: PollHandle,
         _events: u32,
         flags: u32,
         reply: fuser::ReplyPoll,
@@ -271,7 +271,7 @@ impl fuser::Filesystem for FSelFS {
 
             if flags & FUSE_POLL_SCHEDULE_NOTIFY != 0 {
                 d.notify_mask |= 1 << idx;
-                d.poll_handles[idx as usize] = kh;
+                d.poll_handles[idx as usize] = ph.into();
             }
 
             let nbytes = d.bytecnt[idx as usize];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ use crate::session::MAX_WRITE_SIZE;
 pub use ll::fuse_abi::fuse_forget_one;
 pub use mnt::mount_options::MountOption;
 #[cfg(feature = "abi-7-11")]
-pub use notify::Notifier;
+pub use notify::{Notifier, PollHandle};
 #[cfg(feature = "abi-7-11")]
 pub use reply::ReplyPoll;
 #[cfg(target_os = "macos")]
@@ -884,14 +884,14 @@ pub trait Filesystem {
         _req: &Request<'_>,
         ino: u64,
         fh: u64,
-        kh: u64,
+        ph: PollHandle,
         events: u32,
         flags: u32,
         reply: ReplyPoll,
     ) {
         debug!(
-            "[Not Implemented] poll(ino: {:#x?}, fh: {}, kh: {}, events: {}, flags: {})",
-            ino, fh, kh, events, flags
+            "[Not Implemented] poll(ino: {:#x?}, fh: {}, ph: {:?}, events: {}, flags: {})",
+            ino, fh, ph, events, flags
         );
         reply.error(ENOSYS);
     }

--- a/src/request.rs
+++ b/src/request.rs
@@ -19,6 +19,8 @@ use crate::reply::ReplyDirectoryPlus;
 use crate::reply::{Reply, ReplyDirectory, ReplySender};
 use crate::session::{Session, SessionACL};
 use crate::Filesystem;
+#[cfg(feature = "abi-7-11")]
+use crate::Notifier;
 use crate::{ll, KernelConfig};
 
 /// Request data structure
@@ -641,6 +643,13 @@ impl<'a> Request<'a> {
     /// implementation and makes sure that a request is replied exactly once
     fn reply<T: Reply>(&self) -> T {
         Reply::new(self.request.unique().into(), self.ch.clone())
+    }
+
+    /// Create a [Notifier] that can be used to send notifications back to the
+    /// kernel.
+    #[cfg(feature = "abi-7-11")]
+    pub fn notifier(&self) -> Notifier {
+        Notifier::new(self.ch.clone())
     }
 
     /// Returns the unique identifier of this request

--- a/src/request.rs
+++ b/src/request.rs
@@ -20,7 +20,7 @@ use crate::reply::{Reply, ReplyDirectory, ReplySender};
 use crate::session::{Session, SessionACL};
 use crate::Filesystem;
 #[cfg(feature = "abi-7-11")]
-use crate::Notifier;
+use crate::PollHandle;
 use crate::{ll, KernelConfig};
 
 /// Request data structure
@@ -524,11 +524,13 @@ impl<'a> Request<'a> {
             }
             #[cfg(feature = "abi-7-11")]
             ll::Operation::Poll(x) => {
+                let ph = PollHandle::new(se.ch.sender(), x.kernel_handle());
+
                 se.filesystem.poll(
                     self,
                     self.request.nodeid().into(),
                     x.file_handle().into(),
-                    x.kernel_handle(),
+                    ph,
                     x.events(),
                     x.flags(),
                     self.reply(),
@@ -643,13 +645,6 @@ impl<'a> Request<'a> {
     /// implementation and makes sure that a request is replied exactly once
     fn reply<T: Reply>(&self) -> T {
         Reply::new(self.request.unique().into(), self.ch.clone())
-    }
-
-    /// Create a [Notifier] that can be used to send notifications back to the
-    /// kernel.
-    #[cfg(feature = "abi-7-11")]
-    pub fn notifier(&self) -> Notifier {
-        Notifier::new(self.ch.clone())
     }
 
     /// Returns the unique identifier of this request

--- a/src/session.rs
+++ b/src/session.rs
@@ -44,7 +44,7 @@ pub struct Session<FS: Filesystem> {
     /// Filesystem operation implementations
     pub(crate) filesystem: FS,
     /// Communication channel to the kernel driver
-    ch: Channel,
+    pub(crate) ch: Channel,
     /// Handle to the mount.  Dropping this unmounts.
     mount: Arc<Mutex<Option<Mount>>>,
     /// Mount point


### PR DESCRIPTION
This is often useful in `poll` implementations. It also comes into play in #300, because your initialization and setup (when you can call `Session::notifier`) is often separate from creating the session.