### PR TITLE
Allow wrapping an existing /dev/fuse file descriptor

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,4 +1,12 @@
-use std::{fs::File, io, os::unix::prelude::AsRawFd, sync::Arc};
+use std::{
+    fs::File,
+    io,
+    os::{
+        fd::{AsFd, BorrowedFd},
+        unix::prelude::AsRawFd,
+    },
+    sync::Arc,
+};
 
 use libc::{c_int, c_void, size_t};
 
@@ -7,6 +15,12 @@ use crate::reply::ReplySender;
 /// A raw communication channel to the FUSE kernel driver
 #[derive(Debug)]
 pub struct Channel(Arc<File>);
+
+impl AsFd for Channel {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.0.as_fd()
+    }
+}
 
 impl Channel {
     /// Create a new communication channel to the kernel driver by mounting the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub use reply::{
     ReplyStatfs, ReplyWrite,
 };
 pub use request::Request;
-pub use session::{BackgroundSession, Session, SessionUnmounter};
+pub use session::{BackgroundSession, Session, SessionACL, SessionUnmounter};
 #[cfg(feature = "abi-7-28")]
 use std::cmp::max;
 #[cfg(feature = "abi-7-13")]

--- a/src/session.rs
+++ b/src/session.rs
@@ -9,6 +9,7 @@ use libc::{EAGAIN, EINTR, ENODEV, ENOENT};
 use log::{info, warn};
 use nix::unistd::geteuid;
 use std::fmt;
+use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
@@ -31,10 +32,15 @@ pub const MAX_WRITE_SIZE: usize = 16 * 1024 * 1024;
 /// up to MAX_WRITE_SIZE bytes in a write request, we use that value plus some extra space.
 const BUFFER_SIZE: usize = MAX_WRITE_SIZE + 4096;
 
-#[derive(Debug, Eq, PartialEq)]
-pub(crate) enum SessionACL {
+#[derive(Default, Debug, Eq, PartialEq)]
+/// How requests should be filtered based on the calling UID.
+pub enum SessionACL {
+    /// Allow requests from any user. Corresponds to the `allow_other` mount option.
     All,
+    /// Allow requests from root. Corresponds to the `allow_root` mount option.
     RootAndOwner,
+    /// Allow requests from the owning UID. This is FUSE's default mode of operation.
+    #[default]
     Owner,
 }
 
@@ -46,9 +52,7 @@ pub struct Session<FS: Filesystem> {
     /// Communication channel to the kernel driver
     pub(crate) ch: Channel,
     /// Handle to the mount.  Dropping this unmounts.
-    mount: Arc<Mutex<Option<Mount>>>,
-    /// Mount point
-    mountpoint: PathBuf,
+    mount: Arc<Mutex<Option<(PathBuf, Mount)>>>,
     /// Whether to restrict access to owner, root + owner, or unrestricted
     /// Used to implement allow_root and auto_unmount
     pub(crate) allowed: SessionACL,
@@ -62,6 +66,12 @@ pub struct Session<FS: Filesystem> {
     pub(crate) initialized: bool,
     /// True if the filesystem was destroyed (destroy operation done)
     pub(crate) destroyed: bool,
+}
+
+impl<FS: Filesystem> AsFd for Session<FS> {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.ch.as_fd()
+    }
 }
 
 impl<FS: Filesystem> Session<FS> {
@@ -100,8 +110,7 @@ impl<FS: Filesystem> Session<FS> {
         Ok(Session {
             filesystem,
             ch,
-            mount: Arc::new(Mutex::new(Some(mount))),
-            mountpoint: mountpoint.to_owned(),
+            mount: Arc::new(Mutex::new(Some((mountpoint.to_owned(), mount)))),
             allowed,
             session_owner: geteuid().as_raw(),
             proto_major: 0,
@@ -111,9 +120,21 @@ impl<FS: Filesystem> Session<FS> {
         })
     }
 
-    /// Return path of the mounted filesystem
-    pub fn mountpoint(&self) -> &Path {
-        &self.mountpoint
+    /// Wrap an existing /dev/fuse file descriptor. This doesn't mount the
+    /// filesystem anywhere; that must be done separately.
+    pub fn from_fd(filesystem: FS, fd: OwnedFd, acl: SessionACL) -> Self {
+        let ch = Channel::new(Arc::new(fd.into()));
+        Session {
+            filesystem,
+            ch,
+            mount: Arc::new(Mutex::new(None)),
+            allowed: acl,
+            session_owner: geteuid().as_raw(),
+            proto_major: 0,
+            proto_minor: 0,
+            initialized: false,
+            destroyed: false,
+        }
     }
 
     /// Run the session loop that receives kernel requests and dispatches them to method
@@ -177,7 +198,7 @@ impl<FS: Filesystem> Session<FS> {
 #[derive(Debug)]
 /// A thread-safe object that can be used to unmount a Filesystem
 pub struct SessionUnmounter {
-    mount: Arc<Mutex<Option<Mount>>>,
+    mount: Arc<Mutex<Option<(PathBuf, Mount)>>>,
 }
 
 impl SessionUnmounter {
@@ -210,21 +231,22 @@ impl<FS: Filesystem> Drop for Session<FS> {
             self.filesystem.destroy();
             self.destroyed = true;
         }
-        info!("Unmounted {}", self.mountpoint().display());
+
+        if let Some((mountpoint, _mount)) = std::mem::take(&mut *self.mount.lock().unwrap()) {
+            info!("unmounting session at {}", mountpoint.display());
+        }
     }
 }
 
 /// The background session data structure
 pub struct BackgroundSession {
-    /// Path of the mounted filesystem
-    pub mountpoint: PathBuf,
     /// Thread guard of the background session
     pub guard: JoinHandle<io::Result<()>>,
     /// Object for creating Notifiers for client use
     #[cfg(feature = "abi-7-11")]
     sender: ChannelSender,
     /// Ensures the filesystem is unmounted when the session ends
-    _mount: Mount,
+    _mount: Option<Mount>,
 }
 
 impl BackgroundSession {
@@ -232,18 +254,15 @@ impl BackgroundSession {
     /// session loop in a background thread. If the returned handle is dropped,
     /// the filesystem is unmounted and the given session ends.
     pub fn new<FS: Filesystem + Send + 'static>(se: Session<FS>) -> io::Result<BackgroundSession> {
-        let mountpoint = se.mountpoint().to_path_buf();
         #[cfg(feature = "abi-7-11")]
         let sender = se.ch.sender();
         // Take the fuse_session, so that we can unmount it
-        let mount = std::mem::take(&mut *se.mount.lock().unwrap());
-        let mount = mount.ok_or_else(|| io::Error::from_raw_os_error(libc::ENODEV))?;
+        let mount = std::mem::take(&mut *se.mount.lock().unwrap()).map(|(_, mount)| mount);
         let guard = thread::spawn(move || {
             let mut se = se;
             se.run()
         });
         Ok(BackgroundSession {
-            mountpoint,
             guard,
             #[cfg(feature = "abi-7-11")]
             sender,
@@ -253,7 +272,6 @@ impl BackgroundSession {
     /// Unmount the filesystem and join the background thread.
     pub fn join(self) {
         let Self {
-            mountpoint: _,
             guard,
             #[cfg(feature = "abi-7-11")]
                 sender: _,
@@ -274,10 +292,6 @@ impl BackgroundSession {
 // thread_scoped::JoinGuard
 impl fmt::Debug for BackgroundSession {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(
-            f,
-            "BackgroundSession {{ mountpoint: {:?}, guard: JoinGuard<()> }}",
-            self.mountpoint
-        )
+        write!(f, "BackgroundSession {{ guard: JoinGuard<()> }}",)
     }
 }


### PR DESCRIPTION
This is important for container runtimes, which need to do a special namespace mount dance.

Fixes #300. This is a less invasive version of #301, but I like that one better.