### PR TITLE
Fix `macFuse` `fuse_rename_in` missing fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ pkg-config = { version = "0.3.14", optional = true }
 default = ["libfuse"]
 libfuse = ["pkg-config"]
 serializable = ["serde"]
+macfuse-4-compat = []
 abi-7-9 = []
 abi-7-10 = ["abi-7-9"]
 abi-7-11 = ["abi-7-10"]

--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,7 @@ fn main() {
                 .is_ok()
             {
                 println!("cargo:rustc-cfg=feature=\"libfuse2\"");
+                println!("cargo:rustc-cfg=feature=\"macfuse-4-compat\"");
             } else {
                 pkg_config::Config::new()
                     .atleast_version("2.6.0")

--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -586,9 +586,9 @@ pub struct fuse_mkdir_in {
 pub struct fuse_rename_in {
     pub newdir: u64,
     #[cfg(target_os = "macos")]
-    pub _flags: u32,
+    pub flags: u32,
     #[cfg(target_os = "macos")]
-    pub _padding: u32,
+    pub padding: u32,
 }
 
 #[repr(C)]

--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -585,9 +585,9 @@ pub struct fuse_mkdir_in {
 #[derive(Debug, FromBytes, FromZeroes)]
 pub struct fuse_rename_in {
     pub newdir: u64,
-    #[cfg(target_os = "macos")]
+    #[cfg(feature = "macfuse-4-compat")]
     pub flags: u32,
-    #[cfg(target_os = "macos")]
+    #[cfg(feature = "macfuse-4-compat")]
     pub padding: u32,
 }
 

--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -585,6 +585,10 @@ pub struct fuse_mkdir_in {
 #[derive(Debug, FromBytes, FromZeroes)]
 pub struct fuse_rename_in {
     pub newdir: u64,
+    #[cfg(target_os = "macos")]
+    pub _flags: u32,
+    #[cfg(target_os = "macos")]
+    pub _padding: u32,
 }
 
 #[repr(C)]


### PR DESCRIPTION
`MacFuse@4.8` define the struct `fuse_rename_in` like so:

```c
struct fuse_rename_in {
	__u64	newdir;
#ifdef __APPLE__
	__u32	flags;
	__u32	padding;
#endif
};
```

> [`fuse_rename_in`](https://github.com/osxfuse/fuse/blob/6f7322893456f6ff9db145f096b9bfc2ba95d627/include/fuse_kernel.h#L446-L452)

But on `fuser` side, we only have the field `newdir`:

```rust
pub struct fuse_rename_in {
    pub newdir: u64,
}
```

> [`fuse_rename_in`](https://github.com/cberner/fuser/blob/v0.14.0/src/ll/fuse_abi.rs#L584-L588)

This result in `name` and `newname` (of `Rename`) being at best empty Path or invalid valid depending on the value of the field `flags` & `padding`.