### PR TITLE
Remove target OS 'bitrig' which is unsupported by Rust

### DIFF
--- a/src/mnt/fuse2.rs
+++ b/src/mnt/fuse2.rs
@@ -55,7 +55,6 @@ impl Drop for Mount {
                     target_os = "freebsd",
                     target_os = "dragonfly",
                     target_os = "openbsd",
-                    target_os = "bitrig",
                     target_os = "netbsd"
                 )))]
                 unsafe {

--- a/src/mnt/fuse2_sys.rs
+++ b/src/mnt/fuse2_sys.rs
@@ -27,7 +27,6 @@ extern "C" {
         target_os = "freebsd",
         target_os = "dragonfly",
         target_os = "openbsd",
-        target_os = "bitrig",
         target_os = "netbsd"
     )))]
     pub fn fuse_unmount_compat22(mountpoint: *const c_char);

--- a/src/mnt/fuse_pure.rs
+++ b/src/mnt/fuse_pure.rs
@@ -178,7 +178,6 @@ fn receive_fusermount_message(socket: &UnixStream) -> Result<File, Error> {
         target_os = "freebsd",
         target_os = "dragonfly",
         target_os = "openbsd",
-        target_os = "bitrig",
         target_os = "netbsd"
     ))]
     {

--- a/src/mnt/mod.rs
+++ b/src/mnt/mod.rs
@@ -64,7 +64,6 @@ fn libc_umount(mnt: &CStr) -> io::Result<()> {
         target_os = "freebsd",
         target_os = "dragonfly",
         target_os = "openbsd",
-        target_os = "bitrig",
         target_os = "netbsd"
     ))]
     let r = unsafe { libc::unmount(mnt.as_ptr(), 0) };
@@ -74,7 +73,6 @@ fn libc_umount(mnt: &CStr) -> io::Result<()> {
         target_os = "freebsd",
         target_os = "dragonfly",
         target_os = "openbsd",
-        target_os = "bitrig",
         target_os = "netbsd"
     )))]
     let r = unsafe { libc::umount(mnt.as_ptr()) };


### PR DESCRIPTION
Bitrig is no longer developed and most changes were contributed back to its upstream OpenBSD. Bitrig support was removed from Rust in 2019 (https://github.com/rust-lang/rust/pull/60775). This change removes the conditions from Fuser, for which the minimum supported Rust version (MSRV) is Rust 1.74.