### PR TITLE
Replace features libfuse2,libfuse3 with a dedicated build cfg value

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,18 +1,25 @@
 fn main() {
+    // Register rustc cfg for switching between mount implementations.
+    // When fuser MSRV is updated to v1.77 or above, we should switch from 'cargo:' to 'cargo::' syntax.
+    println!("cargo:rustc-check-cfg=cfg(fuser_mount_impl, values(\"pure-rust\", \"libfuse2\", \"libfuse3\"))");
+
     #[cfg(all(not(feature = "libfuse"), not(target_os = "linux")))]
     unimplemented!("Building without libfuse is only supported on Linux");
 
+    #[cfg(not(feature = "libfuse"))]
+    {
+        println!("cargo:rustc-cfg=fuser_mount_impl=\"pure-rust\"");
+    }
     #[cfg(feature = "libfuse")]
     {
-        #[cfg(target_os = "macos")]
-        {
+        if cfg!(target_os = "macos") {
             if pkg_config::Config::new()
                 .atleast_version("2.6.0")
                 .probe("fuse") // for macFUSE 4.x
                 .map_err(|e| eprintln!("{}", e))
                 .is_ok()
             {
-                println!("cargo:rustc-cfg=feature=\"libfuse2\"");
+                println!("cargo:rustc-cfg=fuser_mount_impl=\"libfuse2\"");
                 println!("cargo:rustc-cfg=feature=\"macfuse-4-compat\"");
             } else {
                 pkg_config::Config::new()
@@ -20,11 +27,9 @@ fn main() {
                     .probe("osxfuse") // for osxfuse 3.x
                     .map_err(|e| eprintln!("{}", e))
                     .unwrap();
-                println!("cargo:rustc-cfg=feature=\"libfuse2\"");
+                println!("cargo:rustc-cfg=fuser_mount_impl=\"libfuse2\"");
             }
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
+        } else {
             // First try to link with libfuse3
             if pkg_config::Config::new()
                 .atleast_version("3.0.0")
@@ -32,7 +37,7 @@ fn main() {
                 .map_err(|e| eprintln!("{e}"))
                 .is_ok()
             {
-                println!("cargo:rustc-cfg=feature=\"libfuse3\"");
+                println!("cargo:rustc-cfg=fuser_mount_impl=\"libfuse3\"");
             } else {
                 // Fallback to libfuse
                 pkg_config::Config::new()
@@ -40,7 +45,7 @@ fn main() {
                     .probe("fuse")
                     .map_err(|e| eprintln!("{e}"))
                     .unwrap();
-                println!("cargo:rustc-cfg=feature=\"libfuse2\"");
+                println!("cargo:rustc-cfg=fuser_mount_impl=\"libfuse2\"");
             }
         }
     }

--- a/src/mnt/fuse2_sys.rs
+++ b/src/mnt/fuse2_sys.rs
@@ -16,7 +16,7 @@ pub struct fuse_args {
     pub allocated: c_int,
 }
 
-#[cfg(feature = "libfuse2")]
+#[cfg(fuser_mount_impl = "libfuse2")]
 extern "C" {
     // *_compat25 functions were introduced in FUSE 2.6 when function signatures changed.
     // Therefore, the minimum version requirement for *_compat25 functions is libfuse-2.6.0.

--- a/src/mnt/mod.rs
+++ b/src/mnt/mod.rs
@@ -2,24 +2,24 @@
 //!
 //! Raw communication channel to the FUSE kernel driver.
 
-#[cfg(feature = "libfuse2")]
+#[cfg(fuser_mount_impl = "libfuse2")]
 mod fuse2;
 #[cfg(any(feature = "libfuse", test))]
 mod fuse2_sys;
-#[cfg(feature = "libfuse3")]
+#[cfg(fuser_mount_impl = "libfuse3")]
 mod fuse3;
-#[cfg(feature = "libfuse3")]
+#[cfg(fuser_mount_impl = "libfuse3")]
 mod fuse3_sys;
 
-#[cfg(not(feature = "libfuse"))]
+#[cfg(fuser_mount_impl = "pure-rust")]
 mod fuse_pure;
 pub mod mount_options;
 
-#[cfg(any(feature = "libfuse", test))]
+#[cfg(any(test, feature = "libfuse"))]
 use fuse2_sys::fuse_args;
 #[cfg(any(test, not(feature = "libfuse")))]
 use std::fs::File;
-#[cfg(any(test, not(feature = "libfuse"), not(feature = "libfuse3")))]
+#[cfg(any(test, fuser_mount_impl = "pure-rust", fuser_mount_impl = "libfuse2"))]
 use std::io;
 
 #[cfg(any(feature = "libfuse", test))]
@@ -47,16 +47,16 @@ fn with_fuse_args<T, F: FnOnce(&fuse_args) -> T>(options: &[MountOption], f: F) 
     })
 }
 
-#[cfg(feature = "libfuse2")]
+#[cfg(fuser_mount_impl = "libfuse2")]
 pub use fuse2::Mount;
-#[cfg(feature = "libfuse3")]
+#[cfg(fuser_mount_impl = "libfuse3")]
 pub use fuse3::Mount;
-#[cfg(not(feature = "libfuse"))]
+#[cfg(fuser_mount_impl = "pure-rust")]
 pub use fuse_pure::Mount;
-#[cfg(not(feature = "libfuse3"))]
+#[cfg(not(fuser_mount_impl = "libfuse3"))]
 use std::ffi::CStr;
 
-#[cfg(not(feature = "libfuse3"))]
+#[cfg(not(fuser_mount_impl = "libfuse3"))]
 #[inline]
 fn libc_umount(mnt: &CStr) -> io::Result<()> {
     #[cfg(any(
@@ -87,7 +87,7 @@ fn libc_umount(mnt: &CStr) -> io::Result<()> {
 
 /// Warning: This will return true if the filesystem has been detached (lazy unmounted), but not
 /// yet destroyed by the kernel.
-#[cfg(any(test, not(feature = "libfuse")))]
+#[cfg(any(test, fuser_mount_impl = "pure-rust"))]
 fn is_mounted(fuse_device: &File) -> bool {
     use libc::{poll, pollfd};
     use std::os::unix::prelude::AsRawFd;


### PR DESCRIPTION
From Rust v1.80, cfg values will be checked to ensure they match all known possible values. https://blog.rust-lang.org/2024/05/06/check-cfg.html

fuser makes use of the features libfuse2 and libfuse3 when conditionally compiling code for each implementation of libfuse. This leads to a lot of warnings when building fuser with newer versions of Rust (v1.80+).

This change moves this conditional logic to be a new dedicated cfg field (not features) which are declared so that Rust is aware of the possible values.

An alternative to this would be to just declare libfuse2 and libfuse3 as features however this doesn't seem right, as these aren't meant to be customer-facing features.

This change was originally proposed in #311.

Fixes #311 