### PR TITLE
Fix warnings on stable Rust

### DIFF
--- a/src/ll/mod.rs
+++ b/src/ll/mod.rs
@@ -10,9 +10,7 @@ mod request;
 use std::{convert::TryInto, num::NonZeroI32, time::SystemTime};
 
 pub use reply::Response;
-pub use request::{
-    AnyRequest, FileHandle, INodeNo, Lock, Operation, Request, RequestError, RequestId, Version,
-};
+pub use request::{AnyRequest, FileHandle, INodeNo, Lock, Operation, Request, RequestId, Version};
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 /// Possible input arguments for atime & mtime, which can either be set to a specified time,

--- a/src/ll/notify.rs
+++ b/src/ll/notify.rs
@@ -17,6 +17,7 @@ pub(crate) enum Notification<'a> {
     Bare(NotificationBuf),
 
     /// For notifications that include a buffer of arbitrary data
+    #[allow(dead_code)]
     WithData(NotificationBuf, &'a [u8]),
 
     /// For notifications that include a NUL-terminated name
@@ -122,6 +123,7 @@ impl<'a> Notification<'a> {
         Self::WithName(buf.as_bytes().into(), name)
     }
 
+    #[allow(dead_code)]
     fn from_struct_with_data<T: IntoBytes + Immutable + ?Sized>(buf: &T, data: &'a [u8]) -> Self {
         Self::WithData(buf.as_bytes().into(), data)
     }

--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -874,6 +874,7 @@ mod op {
         GetSize(GetXAttrSize),
         /// User is requesting the data stored in the XAttr.  If the data will fit
         /// in this number of bytes it should be returned, otherwise return [Err(Errno::ERANGE)].
+        #[allow(dead_code)]
         Size(NonZeroU32),
     }
     impl<'a> GetXAttr<'a> {
@@ -1517,6 +1518,7 @@ mod op {
     }
 
     /// Copy the specified range from the source inode to the destination inode
+    #[cfg(feature = "abi-7-28")]
     #[derive(Debug, Clone, Copy)]
     pub struct CopyFileRangeFile {
         pub inode: INodeNo,
@@ -1885,6 +1887,7 @@ pub enum Operation<'a> {
     Forget(Forget<'a>),
     GetAttr(GetAttr<'a>),
     SetAttr(SetAttr<'a>),
+    #[allow(dead_code)]
     ReadLink(ReadLink<'a>),
     SymLink(SymLink<'a>),
     MkNod(MkNod<'a>),
@@ -1896,6 +1899,7 @@ pub enum Operation<'a> {
     Open(Open<'a>),
     Read(Read<'a>),
     Write(Write<'a>),
+    #[allow(dead_code)]
     StatFs(StatFs<'a>),
     Release(Release<'a>),
     FSync(FSync<'a>),
@@ -1922,6 +1926,7 @@ pub enum Operation<'a> {
     #[cfg(feature = "abi-7-11")]
     Poll(Poll<'a>),
     #[cfg(feature = "abi-7-15")]
+    #[allow(dead_code)]
     NotifyReply(NotifyReply<'a>),
     #[cfg(feature = "abi-7-16")]
     BatchForget(BatchForget<'a>),
@@ -1944,6 +1949,7 @@ pub enum Operation<'a> {
     Exchange(Exchange<'a>),
 
     #[cfg(feature = "abi-7-12")]
+    #[allow(dead_code)]
     CuseInit(CuseInit<'a>),
 }
 


### PR DESCRIPTION
Hey! We currently maintain a fork of `fuser` for own use, and we use stable Rust toolchain (v1.82 as of today). As Rust got better on detecting unused code since v1.74 (the [version used in `fuser`](https://github.com/cberner/fuser/blob/master/rust-toolchain)), we get some warning during compilation.

<details>
  <summary>cargo +stable check</summary>
  
```
warning: unused import: `RequestError`
  --> src/ll/mod.rs:14:64
   |
14 |     AnyRequest, FileHandle, INodeNo, Lock, Operation, Request, RequestError, RequestId, Version,
   |                                                                ^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: field `0` is never read
    --> src/ll/request.rs:1888:14
     |
1888 |     ReadLink(ReadLink<'a>),
     |     -------- ^^^^^^^^^^^^
     |     |
     |     field in this variant
     |
     = note: `Operation` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
     = note: `#[warn(dead_code)]` on by default
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
     |
1888 |     ReadLink(()),
     |              ~~

warning: field `0` is never read
    --> src/ll/request.rs:1899:12
     |
1899 |     StatFs(StatFs<'a>),
     |     ------ ^^^^^^^^^^
     |     |
     |     field in this variant
     |
     = note: `Operation` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
     |
1899 |     StatFs(()),
     |            ~~

warning: field `0` is never read
   --> src/ll/request.rs:877:14
    |
877 |         Size(NonZeroU32),
    |         ---- ^^^^^^^^^^
    |         |
    |         field in this variant
    |
    = note: `GetXAttrSizeEnum` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
    |
877 |         Size(()),
    |              ~~

warning: struct `CopyFileRangeFile` is never constructed
    --> src/ll/request.rs:1521:16
     |
1521 |     pub struct CopyFileRangeFile {
     |                ^^^^^^^^^^^^^^^^^
     |
     = note: `CopyFileRangeFile` has derived impls for the traits `Clone` and `Debug`, but these are intentionally ignored during dead code analysis

warning: `fuser` (lib) generated 5 warnings (run `cargo fix --lib -p fuser` to apply 1 suggestion)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s
```
</details>

This PR fixes these warnings. I also verified each feature flag using [cargo hack](https://github.com/taiki-e/cargo-hack) to ensure each of them still compiles without any warnings.

 
<details>
  <summary>cargo +stable hack check --each-feature --no-dev-deps</summary>
  
```
info: --no-dev-deps modifies real `Cargo.toml` while cargo-hack is running and restores it when finished
info: running `cargo check --all-features` on fuser (1/29)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.05s

info: running `cargo check --no-default-features` on fuser (2/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.34s

info: running `cargo check --no-default-features --features abi-7-10` on fuser (3/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.38s

info: running `cargo check --no-default-features --features abi-7-11` on fuser (4/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.37s

info: running `cargo check --no-default-features --features abi-7-12` on fuser (5/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.41s

info: running `cargo check --no-default-features --features abi-7-13` on fuser (6/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.38s

info: running `cargo check --no-default-features --features abi-7-14` on fuser (7/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.44s

info: running `cargo check --no-default-features --features abi-7-15` on fuser (8/29)
    Blocking waiting for file lock on build directory
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.95s

info: running `cargo check --no-default-features --features abi-7-16` on fuser (9/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.41s

info: running `cargo check --no-default-features --features abi-7-17` on fuser (10/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.38s

info: running `cargo check --no-default-features --features abi-7-18` on fuser (11/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.39s

info: running `cargo check --no-default-features --features abi-7-19` on fuser (12/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.38s

info: running `cargo check --no-default-features --features abi-7-20` on fuser (13/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.39s

info: running `cargo check --no-default-features --features abi-7-21` on fuser (14/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.39s

info: running `cargo check --no-default-features --features abi-7-22` on fuser (15/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.39s

info: running `cargo check --no-default-features --features abi-7-23` on fuser (16/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.39s

info: running `cargo check --no-default-features --features abi-7-24` on fuser (17/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.39s

info: running `cargo check --no-default-features --features abi-7-25` on fuser (18/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.39s

info: running `cargo check --no-default-features --features abi-7-26` on fuser (19/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.39s

info: running `cargo check --no-default-features --features abi-7-27` on fuser (20/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.39s

info: running `cargo check --no-default-features --features abi-7-28` on fuser (21/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.39s

info: running `cargo check --no-default-features --features abi-7-29` on fuser (22/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.40s

info: running `cargo check --no-default-features --features abi-7-30` on fuser (23/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.41s

info: running `cargo check --no-default-features --features abi-7-31` on fuser (24/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.39s

info: running `cargo check --no-default-features --features abi-7-9` on fuser (25/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.32s

info: running `cargo check --no-default-features --features default` on fuser (26/29)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s

info: running `cargo check --no-default-features --features libfuse` on fuser (27/29)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s

info: running `cargo check --no-default-features --features macfuse-4-compat` on fuser (28/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.32s

info: running `cargo check --no-default-features --features serializable` on fuser (29/29)
   Compiling fuser v0.15.0 (/workplace/burakvar/fuser)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.35s
```
</details>
