### PR TITLE
Fix test and example build warnings on stable Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ required-features = ["abi-7-12"]
 
 [[example]]
 name = "notify_inval_inode"
-required-features = ["abi-7-12"]
+required-features = ["abi-7-15"]
 
 [[example]]
 name = "ioctl"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1098,6 +1098,10 @@ impl Filesystem for SimpleFS {
         flags: u32,
         reply: ReplyEmpty,
     ) {
+        debug!(
+            "rename() called with: source {parent:?} {name:?}, \
+            destination {new_parent:?} {new_name:?}, flags {flags:#b}",
+        );
         let mut inode_attrs = match self.lookup_name(parent, name) {
             Ok(attrs) => attrs,
             Err(error_code) => {
@@ -1922,8 +1926,7 @@ fn as_file_kind(mut mode: u32) -> FileKind {
 }
 
 fn get_groups(pid: u32) -> Vec<u32> {
-    #[cfg(not(target_os = "macos"))]
-    {
+    if cfg!(not(target_os = "macos")) {
         let path = format!("/proc/{pid}/task/{pid}/status");
         let file = File::open(path).unwrap();
         for line in BufReader::new(file).lines() {

--- a/src/request.rs
+++ b/src/request.rs
@@ -615,9 +615,9 @@ impl<'a> Request<'a> {
                 se.filesystem.setvolname(self, x.name(), self.reply());
             }
             #[cfg(target_os = "macos")]
-            ll::Operation::GetXTimes(_) => {
+            ll::Operation::GetXTimes(x) => {
                 se.filesystem
-                    .getxtimes(self, self.request.nodeid().into(), self.reply());
+                    .getxtimes(self, x.nodeid().into(), self.reply());
             }
             #[cfg(target_os = "macos")]
             ll::Operation::Exchange(x) => {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,3 +1,6 @@
+// No integration tests for non-Linux targets, so turn off the module for now.
+#![cfg(target_os = "linux")]
+
 use fuser::{Filesystem, Session};
 use std::rc::Rc;
 use std::thread;
@@ -7,8 +10,10 @@ use tempfile::TempDir;
 #[test]
 #[cfg(target_os = "linux")]
 fn unmount_no_send() {
-    // Rc to make this !Send
-    struct NoSendFS(Rc<()>);
+    struct NoSendFS(
+        // Rc to make this !Send
+        #[allow(dead_code)] Rc<()>,
+    );
 
     impl Filesystem for NoSendFS {}
 


### PR DESCRIPTION
This change addresses remaining build warnings on Rust toolchain v1.82. This is a follow-up change from #314, but tackles warnings in examples and tests.

To test, I ran the following using [cargo-hack](https://github.com/taiki-e/cargo-hack) to check all examples and tests compile without warnings:

```
cargo +stable hack test --no-run --each-feature
```

<details>
<pre>
 cargo +stable hack test --no-run --each-feature
info: running `cargo test --no-run --all-features` on fuser (1/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.89s
  Executable unittests src/lib.rs (target/debug/deps/fuser-19a359d13b46cf93)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-026e89ffd72c4a5e)

info: running `cargo test --no-run --no-default-features` on fuser (2/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2.36s
  Executable unittests src/lib.rs (target/debug/deps/fuser-3dece279defdbcff)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-dfccd4809f6abe77)

info: running `cargo test --no-run --no-default-features --features abi-7-10` on fuser (3/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2.36s
  Executable unittests src/lib.rs (target/debug/deps/fuser-7947f2b23c31867b)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-40fa1addb0797e3f)

info: running `cargo test --no-run --no-default-features --features abi-7-11` on fuser (4/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2.69s
  Executable unittests src/lib.rs (target/debug/deps/fuser-c28692db34cd265c)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-02f1620dca0f11bc)

info: running `cargo test --no-run --no-default-features --features abi-7-12` on fuser (5/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 3.62s
  Executable unittests src/lib.rs (target/debug/deps/fuser-6d785e8175cb6036)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-0f972000ebab9c47)

info: running `cargo test --no-run --no-default-features --features abi-7-13` on fuser (6/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 5.27s
  Executable unittests src/lib.rs (target/debug/deps/fuser-0b50e51e22b0e58b)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-3134b0f1d7c387e0)

info: running `cargo test --no-run --no-default-features --features abi-7-14` on fuser (7/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 5.32s
  Executable unittests src/lib.rs (target/debug/deps/fuser-e8813b32a52bea3b)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-3ca93b89a4c80cc3)

info: running `cargo test --no-run --no-default-features --features abi-7-15` on fuser (8/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 5.55s
  Executable unittests src/lib.rs (target/debug/deps/fuser-23e7822cdd44e8ce)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-06a92f81cbe8381c)

info: running `cargo test --no-run --no-default-features --features abi-7-16` on fuser (9/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 5.88s
  Executable unittests src/lib.rs (target/debug/deps/fuser-9dc0865ce9244aa0)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-5b107b72923de1f8)

info: running `cargo test --no-run --no-default-features --features abi-7-17` on fuser (10/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 5.94s
  Executable unittests src/lib.rs (target/debug/deps/fuser-c812d0319955be99)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-1942218f67510bec)

info: running `cargo test --no-run --no-default-features --features abi-7-18` on fuser (11/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 5.87s
  Executable unittests src/lib.rs (target/debug/deps/fuser-2f5161b88fffc89b)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-718ec1aeca5c84bd)

info: running `cargo test --no-run --no-default-features --features abi-7-19` on fuser (12/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 5.57s
  Executable unittests src/lib.rs (target/debug/deps/fuser-407cda202823333f)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-921d43eb8d1da8ad)

info: running `cargo test --no-run --no-default-features --features abi-7-20` on fuser (13/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 6.10s
  Executable unittests src/lib.rs (target/debug/deps/fuser-723d0103d62dcbf4)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-b50118d5d473f43a)

info: running `cargo test --no-run --no-default-features --features abi-7-21` on fuser (14/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 5.75s
  Executable unittests src/lib.rs (target/debug/deps/fuser-86d2c47e3749dfb6)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-a048ce04248f716a)

info: running `cargo test --no-run --no-default-features --features abi-7-22` on fuser (15/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 5.69s
  Executable unittests src/lib.rs (target/debug/deps/fuser-8cb29cbd67c4fce8)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-bf690458ab8c45bb)

info: running `cargo test --no-run --no-default-features --features abi-7-23` on fuser (16/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 5.90s
  Executable unittests src/lib.rs (target/debug/deps/fuser-1d740218a4771e2d)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-607f7fa4f34baaf9)

info: running `cargo test --no-run --no-default-features --features abi-7-24` on fuser (17/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 5.74s
  Executable unittests src/lib.rs (target/debug/deps/fuser-9aacb8f542a34eb8)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-58126e870edd657b)

info: running `cargo test --no-run --no-default-features --features abi-7-25` on fuser (18/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 5.71s
  Executable unittests src/lib.rs (target/debug/deps/fuser-1f497047b00de003)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-5ca201f211f4c261)

info: running `cargo test --no-run --no-default-features --features abi-7-26` on fuser (19/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 6.02s
  Executable unittests src/lib.rs (target/debug/deps/fuser-671f7dc4eaf42d14)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-8e47343970b132f1)

info: running `cargo test --no-run --no-default-features --features abi-7-27` on fuser (20/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 5.94s
  Executable unittests src/lib.rs (target/debug/deps/fuser-d246bdb2a3ac481e)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-dd3f0357f7b323f2)

info: running `cargo test --no-run --no-default-features --features abi-7-28` on fuser (21/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 5.96s
  Executable unittests src/lib.rs (target/debug/deps/fuser-43982a01c6f5ff38)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-488398e8cb00ee18)

info: running `cargo test --no-run --no-default-features --features abi-7-29` on fuser (22/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 5.92s
  Executable unittests src/lib.rs (target/debug/deps/fuser-02c681f29037fcf0)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-c7af7f9549d9edec)

info: running `cargo test --no-run --no-default-features --features abi-7-30` on fuser (23/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 5.83s
  Executable unittests src/lib.rs (target/debug/deps/fuser-7ef1c9bb55dfd728)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-81a6ac1ae8198bb7)

info: running `cargo test --no-run --no-default-features --features abi-7-31` on fuser (24/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 6.04s
  Executable unittests src/lib.rs (target/debug/deps/fuser-66221c2a7c2b4b95)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-7a08c7ca9b9f5549)

info: running `cargo test --no-run --no-default-features --features abi-7-9` on fuser (25/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 4.30s
  Executable unittests src/lib.rs (target/debug/deps/fuser-363c86e49135dd69)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-9efa26a9ac3801b7)

info: running `cargo test --no-run --no-default-features --features default` on fuser (26/29)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.05s
  Executable unittests src/lib.rs (target/debug/deps/fuser-5a46633bcb5cdafb)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-fc6733877cbad737)

info: running `cargo test --no-run --no-default-features --features libfuse` on fuser (27/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 4.02s
  Executable unittests src/lib.rs (target/debug/deps/fuser-153a16339afde52b)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-4d17f365d69d30dc)

info: running `cargo test --no-run --no-default-features --features macfuse-4-compat` on fuser (28/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 4.24s
  Executable unittests src/lib.rs (target/debug/deps/fuser-672c5b71d91fb804)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-7c650737291f713f)

info: running `cargo test --no-run --no-default-features --features serializable` on fuser (29/29)
   Compiling fuser v0.15.0 (/local/home/djonesoa/devel/fuser)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 4.36s
  Executable unittests src/lib.rs (target/debug/deps/fuser-fb3cee2950586cf7)
  Executable tests/integration_tests.rs (target/debug/deps/integration_tests-22d17e8f9ef58304)
</pre>
</details>

This also identified that the features for one example were not sufficient, and this has now been fixed.