### PR TITLE
doc: fix outdated documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -995,8 +995,7 @@ pub trait Filesystem {
 /// Mount the given filesystem to the given mountpoint. This function will
 /// not return until the filesystem is unmounted.
 ///
-/// Note that you need to lead each option with a separate `"-o"` string. See
-/// `examples/hello.rs`.
+/// Note that you need to lead each option with a separate `"-o"` string.
 #[deprecated(note = "use mount2() instead")]
 pub fn mount<FS: Filesystem, P: AsRef<Path>>(
     filesystem: FS,


### PR DESCRIPTION
Although the function is already deprecated, the doc for the `mount` function uses `examples/hello.rs` as an example on how to use `-o` for the options, but `examples/hello.rs` now uses `mount2` function instead, which doesn't use the `-o` flags. This commit updates the documentation.