### PR TITLE
Bump `env_logger` to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ zerocopy = { version = "0.8", features = ["derive"] }
 nix = { version = "0.29.0", features = ["fs", "user"] }
 
 [dev-dependencies]
-env_logger = "0.11.3"
+env_logger = "0.11.7"
 clap = { version = "4.4", features = ["cargo", "derive"] }
 bincode = "1.3.1"
 serde = { version = "1.0.102", features = ["std", "derive"] }


### PR DESCRIPTION
`humantime`, a dependency of `env_logger`, is unmaintained. Latest version of `env_logger` switches maintained `jiff` crate to provide the same functionality.

See https://rustsec.org/advisories/RUSTSEC-2025-0014