### PR TITLE
Update README with new name for Nix package (osxfuse -> macfuse-stubs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ brew install macfuse
 #### To install using Nix
 
 ``` sh
-nix-env -iA nixos.osxfuse
+nix-env -iA nixos.macfuse-stubs
 ```
 
 And `pkg-config` (required for building):


### PR DESCRIPTION
The following commit shows `macfuse-stubs` package replacing `osxfuse` in nixpkgs: NixOS/nixpkgs@fa6c8b656b72dfa97d7a5aa9892569fd6eb64dfc