### PR TITLE
Remove unnecessary clone of xattr data

### DIFF
--- a/src/reply.rs
+++ b/src/reply.rs
@@ -624,7 +624,7 @@ impl ReplyXattr {
 
     /// Reply to a request with the data in the xattr.
     pub fn data(self, data: &[u8]) {
-        self.reply.send_ll(&ll::Response::new_data(data))
+        self.reply.send_ll(&ll::Response::new_slice(data))
     }
 
     /// Reply to a request with the given error code.


### PR DESCRIPTION
`ReplyXattr::data()` did an unnecessary clone of the data argument when creating the response object. Using `Response::new_slice` instead of `Response::new_data` should be able to avoid that, assuming I understand the code right.