### PR TITLE
Edited 'simple.rs' as mknod incomplete implementation error didn't comply with linux standard

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -757,7 +757,7 @@ impl Filesystem for SimpleFS {
         {
             // TODO
             warn!("mknod() implementation is incomplete. Only supports regular files, symlinks, and directories. Got {:o}", mode);
-            reply.error(libc::ENOSYS);
+            reply.error(libc::EPERM);
             return;
         }
 


### PR DESCRIPTION
In the man 2 for mknod:

EPERM [...]  also returned if the filesystem containing pathname does not support the
              type of node requested.