### PR TITLE
Don't doubly unmount the file system when using libfuse

### DIFF
--- a/src/mnt/fuse3.rs
+++ b/src/mnt/fuse3.rs
@@ -1,6 +1,5 @@
 use super::fuse3_sys::{
     fuse_session_destroy, fuse_session_fd, fuse_session_mount, fuse_session_new,
-    fuse_session_unmount,
 };
 use super::{with_fuse_args, MountOption};
 use std::{
@@ -54,7 +53,6 @@ impl Mount {
 impl Drop for Mount {
     fn drop(&mut self) {
         unsafe {
-            fuse_session_unmount(self.fuse_session);
             fuse_session_destroy(self.fuse_session);
         }
     }

--- a/src/mnt/fuse3_sys.rs
+++ b/src/mnt/fuse3_sys.rs
@@ -25,7 +25,5 @@ extern "C" {
     // This function's argument is really a *fuse_session
     pub fn fuse_session_fd(se: *mut c_void) -> c_int;
     // This function's argument is really a *fuse_session
-    pub fn fuse_session_unmount(se: *mut c_void);
-    // This function's argument is really a *fuse_session
     pub fn fuse_session_destroy(se: *mut c_void);
 }


### PR DESCRIPTION
fuse_session_destroy already includes an unmount, so it's redundant do call both that and fuse_session_unmount.  It's dangerous even, because it could race with a different process using the same mountpoint, and unmount that process's file system.

This change will be more important after the next libfuse release, which will fix a similar double-unmount problem: 1287[^1].

Both this commit and [^1] are necessary to eliminate "unmounting /tmp/mnt failed: Invalid argument" warnings that appeared beginning with libfuse 3.17.0.

[^1]: https://github.com/libfuse/libfuse/pull/1287