### PR TITLE
Format, fix, document, Etc 03/15

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -277,10 +277,10 @@ impl SimpleFS {
     }
 
     fn creation_mode(&self, mode: u32) -> u16 {
-        if !self.suid_support {
-            (mode & !(libc::S_ISUID | libc::S_ISGID) as u32) as u16
-        } else {
+        if self.suid_support {
             mode as u16
+        } else {
+            (mode & !(libc::S_ISUID | libc::S_ISGID) as u32) as u16
         }
     }
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -432,9 +432,8 @@ impl SimpleFS {
         let entries = self.get_directory_content(parent)?;
         if let Some((inode, _)) = entries.get(name.as_bytes()) {
             return self.get_inode(*inode);
-        } else {
-            return Err(libc::ENOENT);
         }
+        return Err(libc::ENOENT);
     }
 
     fn insert_link(
@@ -1964,9 +1963,8 @@ fn as_file_kind(mut mode: u32) -> FileKind {
         return FileKind::Symlink;
     } else if mode == libc::S_IFDIR as u32 {
         return FileKind::Directory;
-    } else {
-        unimplemented!("{mode}");
     }
+    unimplemented!("{mode}");
 }
 
 fn get_groups(pid: u32) -> Vec<u32> {

--- a/src/ll/argument.rs
+++ b/src/ll/argument.rs
@@ -86,7 +86,6 @@ impl<'a> ArgumentIterator<'a> {
 
 #[cfg(test)]
 pub mod tests {
-    use std::ops::Deref;
 
     use super::super::test::AlignedData;
     use super::*;
@@ -105,7 +104,7 @@ pub mod tests {
 
     #[test]
     fn all_data() {
-        let mut it = ArgumentIterator::new(TEST_DATA.deref());
+        let mut it = ArgumentIterator::new(&*TEST_DATA);
         it.fetch_str().unwrap();
         let arg = it.fetch_all();
         assert_eq!(arg, [0x62, 0x61, 0x72, 0x00, 0x62, 0x61]);
@@ -113,7 +112,7 @@ pub mod tests {
 
     #[test]
     fn generic_argument() {
-        let mut it = ArgumentIterator::new(TEST_DATA.deref());
+        let mut it = ArgumentIterator::new(&*TEST_DATA);
         let arg: &TestArgument = it.fetch().unwrap();
         assert_eq!(arg.p1, 0x66);
         assert_eq!(arg.p2, 0x6f);
@@ -127,7 +126,7 @@ pub mod tests {
 
     #[test]
     fn string_argument() {
-        let mut it = ArgumentIterator::new(TEST_DATA.deref());
+        let mut it = ArgumentIterator::new(&*TEST_DATA);
         let arg = it.fetch_str().unwrap();
         assert_eq!(arg, "foo");
         let arg = it.fetch_str().unwrap();
@@ -137,7 +136,7 @@ pub mod tests {
 
     #[test]
     fn mixed_arguments() {
-        let mut it = ArgumentIterator::new(TEST_DATA.deref());
+        let mut it = ArgumentIterator::new(&*TEST_DATA);
         let arg: &TestArgument = it.fetch().unwrap();
         assert_eq!(arg.p1, 0x66);
         assert_eq!(arg.p2, 0x6f);
@@ -150,7 +149,7 @@ pub mod tests {
 
     #[test]
     fn out_of_data() {
-        let mut it = ArgumentIterator::new(TEST_DATA.deref());
+        let mut it = ArgumentIterator::new(&*TEST_DATA);
         it.fetch::<u64>().unwrap();
         let arg: Option<&TestArgument> = it.fetch();
         assert!(arg.is_none());

--- a/src/ll/reply.rs
+++ b/src/ll/reply.rs
@@ -228,7 +228,8 @@ impl<'a> Response<'a> {
             // these fields are only needed for unrestricted ioctls
             flags: 0,
             in_iovs: 1,
-            out_iovs: if !data.is_empty() { 1 } else { 0 },
+            // boolean to integer
+            out_iovs: u32::from(!data.is_empty()),
         };
         // TODO: Don't copy this data
         let mut v: ResponseBuf = ResponseBuf::from_slice(r.as_bytes());

--- a/src/mnt/mod.rs
+++ b/src/mnt/mod.rs
@@ -101,12 +101,11 @@ fn is_mounted(fuse_device: &File) -> bool {
                 let err = io::Error::last_os_error();
                 if err.kind() == io::ErrorKind::Interrupted {
                     continue;
-                } else {
-                    // This should never happen. The fd is guaranteed good as `File` owns it.
-                    // According to man poll ENOMEM is the only error code unhandled, so we panic
-                    // consistent with rust's usual ENOMEM behaviour.
-                    panic!("Poll failed with error {err}")
                 }
+                // This should never happen. The fd is guaranteed good as `File` owns it.
+                // According to man poll ENOMEM is the only error code unhandled, so we panic
+                // consistent with rust's usual ENOMEM behaviour.
+                panic!("Poll failed with error {err}")
             }
             _ => unreachable!(),
         };

--- a/src/mnt/mount_options.rs
+++ b/src/mnt/mount_options.rs
@@ -91,13 +91,13 @@ pub fn check_option_conflicts(options: &[MountOption]) -> Result<(), io::Error> 
     options_set.extend(options.iter().cloned());
     let conflicting: HashSet<MountOption> = options.iter().flat_map(conflicts_with).collect();
     let intersection: Vec<MountOption> = conflicting.intersection(&options_set).cloned().collect();
-    if !intersection.is_empty() {
+    if intersection.is_empty() {
+        Ok(())
+    } else {
         Err(io::Error::new(
             ErrorKind::InvalidInput,
             format!("Conflicting mount options found: {intersection:?}"),
         ))
-    } else {
-        Ok(())
     }
 }
 

--- a/src/mnt/mount_options.rs
+++ b/src/mnt/mount_options.rs
@@ -194,7 +194,7 @@ mod test {
     #[test]
     fn option_round_trip() {
         use super::MountOption::*;
-        for x in [
+        for x in &[
             FSName("Blah".to_owned()),
             Subtype("Bloo".to_owned()),
             CUSTOM("bongos".to_owned()),
@@ -214,10 +214,8 @@ mod test {
             DirSync,
             Sync,
             Async,
-        ]
-        .iter()
-        {
-            assert_eq!(*x, MountOption::from_str(option_to_string(x).as_ref()))
+        ] {
+            assert_eq!(*x, MountOption::from_str(option_to_string(x).as_ref()));
         }
     }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -482,18 +482,17 @@ impl<'a> Request<'a> {
             ll::Operation::IoCtl(x) => {
                 if x.unrestricted() {
                     return Err(Errno::ENOSYS);
-                } else {
-                    se.filesystem.ioctl(
-                        self,
-                        self.request.nodeid().into(),
-                        x.file_handle().into(),
-                        x.flags(),
-                        x.command(),
-                        x.in_data(),
-                        x.out_size(),
-                        self.reply(),
-                    );
                 }
+                se.filesystem.ioctl(
+                    self,
+                    self.request.nodeid().into(),
+                    x.file_handle().into(),
+                    x.flags(),
+                    x.command(),
+                    x.in_data(),
+                    x.out_size(),
+                    self.reply(),
+                );
             }
             ll::Operation::Poll(x) => {
                 let ph = PollHandle::new(se.ch.sender(), x.kernel_handle());


### PR DESCRIPTION
Clippy says its better to rewrite the logic in a more conventional way.
Clippy says its better to use `&` for borrows, when possible.

Previous PR in sequence was #392 

