### PR TITLE
libc::getuid -> nix

### DIFF
--- a/examples/ioctl.rs
+++ b/examples/ioctl.rs
@@ -25,8 +25,8 @@ struct FiocFS {
 
 impl FiocFS {
     fn new() -> Self {
-        let uid = unsafe { libc::getuid() };
-        let gid = unsafe { libc::getgid() };
+        let uid = nix::unistd::getuid().into();
+        let gid = nix::unistd::getgid().into();
 
         let root_attr = FileAttr {
             ino: 1,

--- a/examples/passthrough.rs
+++ b/examples/passthrough.rs
@@ -89,8 +89,8 @@ struct PassthroughFs {
 
 impl PassthroughFs {
     fn new() -> Self {
-        let uid = unsafe { libc::getuid() };
-        let gid = unsafe { libc::getgid() };
+        let uid = nix::unistd::getuid().into();
+        let gid = nix::unistd::getgid().into();
 
         let root_attr = FileAttr {
             ino: 1,


### PR DESCRIPTION
This is example, it does not matter much, but clearner since the project uses nix.