### PR TITLE
Newtype DevFuse

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,17 +1,17 @@
 use std::{
-    fs::File,
     io,
     os::fd::{AsFd, BorrowedFd},
     sync::Arc,
 };
 
+use crate::dev_fuse::DevFuse;
 #[cfg(feature = "abi-7-40")]
 use crate::passthrough::BackingId;
 use crate::reply::ReplySender;
 
 /// A raw communication channel to the FUSE kernel driver
 #[derive(Debug)]
-pub(crate) struct Channel(Arc<File>);
+pub(crate) struct Channel(Arc<DevFuse>);
 
 impl AsFd for Channel {
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -23,7 +23,7 @@ impl Channel {
     /// Create a new communication channel to the kernel driver by mounting the
     /// given path. The kernel driver will delegate filesystem operations of
     /// the given path to the channel.
-    pub(crate) fn new(device: Arc<File>) -> Self {
+    pub(crate) fn new(device: Arc<DevFuse>) -> Self {
         Self(device)
     }
 
@@ -43,7 +43,7 @@ impl Channel {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct ChannelSender(Arc<File>);
+pub(crate) struct ChannelSender(Arc<DevFuse>);
 
 impl ReplySender for ChannelSender {
     fn send(&self, bufs: &[io::IoSlice<'_>]) -> io::Result<()> {

--- a/src/dev_fuse.rs
+++ b/src/dev_fuse.rs
@@ -1,0 +1,32 @@
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd};
+
+/// A newtype for `File` that represents the `/dev/fuse` device.
+#[derive(Debug)]
+pub(crate) struct DevFuse(pub(crate) File);
+
+impl AsRawFd for DevFuse {
+    fn as_raw_fd(&self) -> std::os::unix::io::RawFd {
+        self.0.as_raw_fd()
+    }
+}
+
+impl AsFd for DevFuse {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.0.as_fd()
+    }
+}
+
+impl DevFuse {
+    pub(crate) const PATH: &'static str = "/dev/fuse";
+
+    #[allow(dead_code)] // Not used with every feature.
+    pub(crate) fn open() -> io::Result<Self> {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(Self::PATH)
+            .map(Self)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ use std::cmp::max;
 use std::cmp::min;
 
 mod channel;
+mod dev_fuse;
 /// Experimental APIs
 #[cfg(feature = "experimental")]
 pub mod experimental;

--- a/src/mnt/fuse2.rs
+++ b/src/mnt/fuse2.rs
@@ -9,6 +9,8 @@ use std::{
     sync::Arc,
 };
 
+use crate::dev_fuse::DevFuse;
+
 /// Ensures that an os error is never 0/Success
 fn ensure_last_os_error() -> io::Error {
     let err = io::Error::last_os_error();
@@ -26,7 +28,7 @@ impl Mount {
     pub(crate) fn new(
         mountpoint: &Path,
         options: &[MountOption],
-    ) -> io::Result<(Arc<File>, Mount)> {
+    ) -> io::Result<(Arc<DevFuse>, Mount)> {
         let mountpoint = CString::new(mountpoint.as_os_str().as_bytes()).unwrap();
         with_fuse_args(options, |args| {
             let fd = unsafe { fuse_mount_compat25(mountpoint.as_ptr(), args) };
@@ -34,7 +36,7 @@ impl Mount {
                 Err(ensure_last_os_error())
             } else {
                 let file = unsafe { File::from_raw_fd(fd) };
-                Ok((Arc::new(file), Mount { mountpoint }))
+                Ok((Arc::new(DevFuse(file)), Mount { mountpoint }))
             }
         })
     }

--- a/src/mnt/fuse3.rs
+++ b/src/mnt/fuse3.rs
@@ -15,6 +15,8 @@ use std::{
     sync::Arc,
 };
 
+use crate::dev_fuse::DevFuse;
+
 /// Ensures that an os error is never 0/Success
 fn ensure_last_os_error() -> io::Error {
     let err = io::Error::last_os_error();
@@ -30,7 +32,7 @@ pub(crate) struct Mount {
     mountpoint: CString,
 }
 impl Mount {
-    pub(crate) fn new(mnt: &Path, options: &[MountOption]) -> io::Result<(Arc<File>, Mount)> {
+    pub(crate) fn new(mnt: &Path, options: &[MountOption]) -> io::Result<(Arc<DevFuse>, Mount)> {
         let mnt = CString::new(mnt.as_os_str().as_bytes()).unwrap();
         with_fuse_args(options, |args| {
             let ops = fuse_lowlevel_ops::default();
@@ -63,7 +65,7 @@ impl Mount {
             // don't want it being closed out from under us:
             let fd = nix::fcntl::fcntl(fd, nix::fcntl::FcntlArg::F_DUPFD_CLOEXEC(0))?;
             let file = unsafe { File::from_raw_fd(fd) };
-            Ok((Arc::new(file), mount))
+            Ok((Arc::new(DevFuse(file)), mount))
         })
     }
 }

--- a/src/mnt/mod.rs
+++ b/src/mnt/mod.rs
@@ -15,10 +15,10 @@ mod fuse3_sys;
 mod fuse_pure;
 pub(crate) mod mount_options;
 
+#[cfg(any(test, fuser_mount_impl = "pure-rust"))]
+use crate::dev_fuse::DevFuse;
 #[cfg(any(test, fuser_mount_impl = "libfuse2", fuser_mount_impl = "libfuse3"))]
 use fuse2_sys::fuse_args;
-#[cfg(any(test, fuser_mount_impl = "pure-rust"))]
-use std::fs::File;
 use std::io;
 
 #[cfg(any(test, fuser_mount_impl = "libfuse2", fuser_mount_impl = "libfuse3"))]
@@ -83,7 +83,7 @@ fn libc_umount(mnt: &CStr) -> io::Result<()> {
 /// Warning: This will return true if the filesystem has been detached (lazy unmounted), but not
 /// yet destroyed by the kernel.
 #[cfg(any(test, fuser_mount_impl = "pure-rust"))]
-fn is_mounted(fuse_device: &File) -> bool {
+fn is_mounted(fuse_device: &DevFuse) -> bool {
     use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
     use std::os::unix::io::AsFd;
     use std::slice;

--- a/src/passthrough.rs
+++ b/src/passthrough.rs
@@ -1,6 +1,8 @@
-use std::fs::File;
-use std::os::fd::{AsFd, AsRawFd};
+use std::os::fd::AsFd;
+use std::os::unix::io::AsRawFd;
 use std::sync::{Arc, Weak};
+
+use crate::dev_fuse::DevFuse;
 
 #[repr(C)]
 struct fuse_backing_map {
@@ -45,13 +47,13 @@ nix::ioctl_write_ptr!(
 /// make that call (if the channel hasn't already been closed).
 #[derive(Debug)]
 pub struct BackingId {
-    pub(crate) channel: Weak<File>,
+    pub(crate) channel: Weak<DevFuse>,
     /// The `backing_id` field passed to and from the kernel
     pub(crate) backing_id: u32,
 }
 
 impl BackingId {
-    pub(crate) fn create(channel: &Arc<File>, fd: impl AsFd) -> std::io::Result<Self> {
+    pub(crate) fn create(channel: &Arc<DevFuse>, fd: impl AsFd) -> std::io::Result<Self> {
         let map = fuse_backing_map {
             fd: fd.as_fd().as_raw_fd() as u32,
             flags: 0,

--- a/src/session.rs
+++ b/src/session.rs
@@ -8,6 +8,7 @@
 use libc::{EAGAIN, EINTR, ENODEV, ENOENT};
 use log::{info, warn};
 use nix::unistd::geteuid;
+use std::fs::File;
 use std::io;
 use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
 use std::path::{Path, PathBuf};
@@ -16,6 +17,7 @@ use std::thread::{self, JoinHandle};
 
 use crate::Filesystem;
 use crate::MountOption;
+use crate::dev_fuse::DevFuse;
 use crate::ll::{Version, fuse_abi as abi};
 use crate::request::Request;
 use crate::{channel::Channel, mnt::Mount};
@@ -120,7 +122,7 @@ impl<FS: Filesystem> Session<FS> {
     /// Wrap an existing /dev/fuse file descriptor. This doesn't mount the
     /// filesystem anywhere; that must be done separately.
     pub fn from_fd(filesystem: FS, fd: OwnedFd, acl: SessionACL) -> Self {
-        let ch = Channel::new(Arc::new(fd.into()));
+        let ch = Channel::new(Arc::new(DevFuse(File::from(fd))));
         Session {
             filesystem,
             ch,


### PR DESCRIPTION
There's `File` used in various places, and while reading the library, it is not always obvious that the file is actually opened `/dev/fuse` (and not for example, a unix socket for `fusermount`).

If this PR is not considered an improvement, feel free to close it.