### PR TITLE
Fix visibility of fuse_forget_one

### DIFF
--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -454,8 +454,8 @@ pub(crate) struct fuse_forget_in {
 #[repr(C)]
 #[derive(Debug, FromBytes, KnownLayout, Immutable)]
 pub struct fuse_forget_one {
-    pub(crate) nodeid: u64,
-    pub(crate) nlookup: u64,
+    pub nodeid: u64,
+    pub nlookup: u64,
 }
 
 #[repr(C)]


### PR DESCRIPTION
This struct is public API.

Was accidentally made private in https://github.com/cberner/fuser/pull/431