### PR TITLE
Unimpl From<nix::errno::Errno> for Errno

### DIFF
--- a/src/ll/mod.rs
+++ b/src/ll/mod.rs
@@ -243,12 +243,6 @@ impl From<std::io::Error> for Errno {
         }
     }
 }
-impl From<nix::errno::Errno> for Errno {
-    fn from(x: nix::errno::Errno) -> Self {
-        let err: std::io::Error = x.into();
-        err.into()
-    }
-}
 impl From<std::io::ErrorKind> for Errno {
     fn from(x: std::io::ErrorKind) -> Self {
         let err: std::io::Error = x.into();


### PR DESCRIPTION
There are two reasons for this change.

- Error may need to be made public, but dependency on nix should probably be private (to avoid issues like compilation breaks when nix version is bumped)
- Logically these are different errors: API/protocol errors vs fuser local IO errors