### PR TITLE
Move some checks from Makefile to GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           cargo doc --all --no-deps --features=${{ matrix.features }}
           make test_passthrough
 
-  ci:
+  lint:
     runs-on: ubuntu-22.04
     env:
       RUSTFLAGS: --deny warnings
@@ -89,8 +89,19 @@ jobs:
         if: steps.rust-cache.outputs.cache-hit != 'true'
         run: cargo +1.81 install --force --version 0.16.2 cargo-deny --locked
 
-      - name: Run tests
-        run: INTERACTIVE="" make pre
+      - name: rustfmt check
+        run: cargo fmt --all -- --check
+
+      - name: Licenses
+        run: cargo deny check sources
+
+      - name: Clippy
+        run: |
+            cargo clippy --all-targets -- -Dwarnings
+            cargo clippy --all-targets --no-default-features -- -Dwarnings
+            cargo clippy --all-targets --features=abi-7-30 -- -Dwarnings
+            cargo clippy --all-targets --features=abi-7-36 -- -Dwarnings
+            cargo clippy --all-targets --features=abi-7-40 -- -Dwarnings
 
   test:
     runs-on: ubuntu-22.04

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,8 @@ VERSION = $(shell git describe --tags --always --dirty)
 INTERACTIVE ?= i
 
 
-build: pre
+build:
 	cargo build --examples --features=experimental
-
-pre:
-	cargo fmt --all -- --check
-	cargo deny check licenses
-	cargo clippy --all-targets
-	cargo clippy --all-targets --no-default-features
-	cargo clippy --all-targets --features=abi-7-30
-	cargo clippy --all-targets --features=abi-7-36
-	cargo clippy --all-targets --features=abi-7-40
 
 xfstests:
 	docker build -t fuser:xfstests -f xfstests.Dockerfile .
@@ -55,10 +46,10 @@ test_passthrough:
 	cargo build --example passthrough --features=abi-7-40
 	sudo tests/test_passthrough.sh target/debug/examples/passthrough
 
-test: pre mount_tests pjdfs_tests xfstests
+test: mount_tests pjdfs_tests xfstests
 	cargo test
 
-test_macos: pre
+test_macos:
 	cargo doc --all --no-deps --features=abi-7-21
 	cargo test --all --all-targets --features=libfuse -- --skip=mnt::test::mount_unmount
 	./osx_mount_tests.sh


### PR DESCRIPTION
- no need to run the same checks, e.g. rustfmt, in every job
- more clear what is failing with cleaner annotation of the jobs/steps

Unless someone actually runs `make test` for development.