### PR TITLE
Simplify some ABI-specific field handling

### DIFF
--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -588,18 +588,12 @@ pub(crate) struct fuse_setattr_in {
     // NOTE: this field is defined as u64 in fuse_kernel.h in libfuse. However, it is treated as signed
     // to match stat.st_mtime
     pub(crate) mtime: i64,
-    #[cfg(not(feature = "abi-7-23"))]
-    pub(crate) unused2: u64,
-    #[cfg(feature = "abi-7-23")]
     // NOTE: this field is defined as u64 in fuse_kernel.h in libfuse. However, it is treated as signed
     // to match stat.st_ctime
-    pub(crate) ctime: i64,
+    pub(crate) ctime: i64, // Used since ABI 7.23.
     pub(crate) atimensec: u32,
     pub(crate) mtimensec: u32,
-    #[cfg(not(feature = "abi-7-23"))]
-    pub(crate) unused3: u32,
-    #[cfg(feature = "abi-7-23")]
-    pub(crate) ctimensec: u32,
+    pub(crate) ctimensec: u32, // Used since ABI 7.23.
     pub(crate) mode: u32,
     pub(crate) unused4: u32,
     pub(crate) uid: u32,
@@ -660,10 +654,7 @@ pub(crate) struct fuse_create_out(pub(crate) fuse_entry_out, pub(crate) fuse_ope
 pub(crate) struct fuse_open_out {
     pub(crate) fh: u64,
     pub(crate) open_flags: u32,
-    #[cfg(not(feature = "abi-7-40"))]
-    pub(crate) padding: u32,
-    #[cfg(feature = "abi-7-40")]
-    pub(crate) backing_id: u32,
+    pub(crate) backing_id: u32, // Used since ABI 7.40.
 }
 
 #[repr(C)]
@@ -914,10 +905,7 @@ pub(crate) struct fuse_poll_in {
     pub(crate) fh: u64,
     pub(crate) kh: u64,
     pub(crate) flags: u32,
-    #[cfg(not(feature = "abi-7-21"))]
-    pub(crate) padding: u32,
-    #[cfg(feature = "abi-7-21")]
-    pub(crate) events: u32,
+    pub(crate) events: u32, // Used since ABI 7.21.
 }
 
 #[repr(C)]

--- a/src/ll/reply.rs
+++ b/src/ll/reply.rs
@@ -119,15 +119,9 @@ impl<'a> Response<'a> {
     }
 
     pub(crate) fn new_open(fh: FileHandle, flags: FopenFlags, backing_id: u32) -> Self {
-        #[cfg(not(feature = "abi-7-40"))]
-        let _ = backing_id;
-
         let r = abi::fuse_open_out {
             fh: fh.into(),
             open_flags: flags.bits(),
-            #[cfg(not(feature = "abi-7-40"))]
-            padding: 0,
-            #[cfg(feature = "abi-7-40")]
             backing_id,
         };
         Self::from_struct(&r)
@@ -194,9 +188,6 @@ impl<'a> Response<'a> {
         flags: FopenFlags,
         backing_id: u32,
     ) -> Self {
-        #[cfg(not(feature = "abi-7-40"))]
-        let _ = backing_id;
-
         let r = abi::fuse_create_out(
             abi::fuse_entry_out {
                 nodeid: attr.attr.ino,
@@ -210,9 +201,6 @@ impl<'a> Response<'a> {
             abi::fuse_open_out {
                 fh: fh.into(),
                 open_flags: flags.bits(),
-                #[cfg(not(feature = "abi-7-40"))]
-                padding: 0,
-                #[cfg(feature = "abi-7-40")]
                 backing_id,
             },
         );


### PR DESCRIPTION
C library works without ifdefs so should we for code simplicity.  This is a small step to that direction.