### PR TITLE
Add fields to fuse_init_in unconditionally

### DIFF
--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -16,6 +16,8 @@
 //! - supports ABI 7.19 since FUSE 2.9.1
 //! - supports ABI 7.26 since FUSE 3.0.0
 //!
+//! FreeBSD kernel headers: <https://github.com/freebsd/freebsd-src/blob/main/sys/fs/fuse/fuse_kernel.h>
+//!
 //! Items without a version annotation are valid with ABI 7.8 and later
 
 #![warn(missing_debug_implementations)]
@@ -937,9 +939,10 @@ pub(crate) struct fuse_init_in {
     pub(crate) minor: u32,
     pub(crate) max_readahead: u32,
     pub(crate) flags: u32,
-    #[cfg(feature = "abi-7-36")]
+    // FreeBSD does not have fields these fields.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub(crate) flags2: u32,
-    #[cfg(feature = "abi-7-36")]
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
     pub(crate) unused: [u32; 11],
 }
 


### PR DESCRIPTION
Both libfuse and macfuse define these fields unconditionally.

libfuse documentation also does not mention that these fields may depend on version
https://github.com/libfuse/libfuse/blob/fa03307c656326733182ab7e30a3cd9e05da43f4/doc/libfuse-operations.txt#L195

libfuse reads the `flags2` field unconditionally
https://github.com/libfuse/libfuse/blob/fa03307c656326733182ab7e30a3cd9e05da43f4/lib/fuse_lowlevel.c#L2711-L2712

So I believe it is OK to not truncate the struct.

Except FreeBSD, that does not declare these fields. https://github.com/freebsd/freebsd-src/blob/1e8c28712aafc9a3339e8a832767a70c08168bdc/sys/fs/fuse/fuse_kernel.h#L759