### PR TITLE
AsyncFilesystem should be spawn, not block_on

### DIFF
--- a/src/experimental.rs
+++ b/src/experimental.rs
@@ -4,6 +4,7 @@ use crate::{
     FileAttr, FileType, Filesystem, ReplyAttr, ReplyData, ReplyDirectory, ReplyEntry, Request,
 };
 use std::ffi::OsStr;
+use std::sync::Arc;
 use std::time::Duration;
 
 pub type Result<T> = std::result::Result<T, libc::c_int>;
@@ -104,14 +105,14 @@ impl GetAttrResponse {
 /// Adapter to allow running an [`AsyncFilesystem`] with tokio's runtime.
 #[derive(Debug)]
 pub struct TokioAdapter<T: AsyncFilesystem> {
-    inner: T,
+    inner: Arc<T>,
     runtime: tokio::runtime::Runtime,
 }
 
 impl<T: AsyncFilesystem> TokioAdapter<T> {
     pub fn new(inner: T) -> Self {
         Self {
-            inner,
+            inner: Arc::new(inner),
             runtime: tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
@@ -120,29 +121,32 @@ impl<T: AsyncFilesystem> TokioAdapter<T> {
     }
 }
 
-impl<T: AsyncFilesystem> Filesystem for TokioAdapter<T> {
+impl<T: AsyncFilesystem + Send + Sync + 'static> Filesystem for TokioAdapter<T> {
     fn lookup(&mut self, req: &Request<'_>, parent: u64, name: &OsStr, reply: ReplyEntry) {
-        match self
-            .runtime
-            .block_on(self.inner.lookup(&req.into(), parent, name))
-        {
-            Ok(LookupResponse {
-                ttl,
-                attr,
-                generation,
-            }) => reply.entry(&ttl, &attr, generation),
-            Err(e) => reply.error(e),
-        }
+        let context: RequestContext = req.into();
+        let name = name.to_os_string();
+        let inner = self.inner.clone();
+        self.runtime.spawn(async move {
+            match inner.lookup(&context, parent, &name).await {
+                Ok(LookupResponse {
+                    ttl,
+                    attr,
+                    generation,
+                }) => reply.entry(&ttl, &attr, generation),
+                Err(e) => reply.error(e),
+            }
+        });
     }
 
     fn getattr(&mut self, req: &Request<'_>, ino: u64, fh: Option<u64>, reply: ReplyAttr) {
-        match self
-            .runtime
-            .block_on(self.inner.getattr(&req.into(), ino, fh))
-        {
-            Ok(GetAttrResponse { ttl, attr }) => reply.attr(&ttl, &attr),
-            Err(e) => reply.error(e),
-        }
+        let context: RequestContext = req.into();
+        let inner = self.inner.clone();
+        self.runtime.spawn(async move {
+            match inner.getattr(&context, ino, fh).await {
+                Ok(GetAttrResponse { ttl, attr }) => reply.attr(&ttl, &attr),
+                Err(e) => reply.error(e),
+            }
+        });
     }
 
     fn read(
@@ -156,20 +160,18 @@ impl<T: AsyncFilesystem> Filesystem for TokioAdapter<T> {
         lock_owner: Option<u64>,
         reply: ReplyData,
     ) {
-        let mut buf = vec![];
-        match self.runtime.block_on(self.inner.read(
-            &req.into(),
-            ino,
-            fh,
-            offset,
-            size,
-            flags,
-            lock_owner,
-            &mut buf,
-        )) {
-            Ok(()) => reply.data(&buf),
-            Err(e) => reply.error(e),
-        }
+        let context: RequestContext = req.into();
+        let inner = self.inner.clone();
+        self.runtime.spawn(async move {
+            let mut buf = vec![];
+            match inner
+                .read(&context, ino, fh, offset, size, flags, lock_owner, &mut buf)
+                .await
+            {
+                Ok(()) => reply.data(&buf),
+                Err(e) => reply.error(e),
+            }
+        });
     }
 
     fn readdir(
@@ -180,16 +182,17 @@ impl<T: AsyncFilesystem> Filesystem for TokioAdapter<T> {
         offset: i64,
         mut reply: ReplyDirectory,
     ) {
-        let builder = DirEntListBuilder {
-            entries: &mut reply,
-        };
-        match self
-            .runtime
-            .block_on(self.inner.readdir(&req.into(), ino, fh, offset, builder))
-        {
-            Ok(()) => reply.ok(),
-            Err(e) => reply.error(e),
-        }
+        let context: RequestContext = req.into();
+        let inner = self.inner.clone();
+        self.runtime.spawn(async move {
+            let builder = DirEntListBuilder {
+                entries: &mut reply,
+            };
+            match inner.readdir(&context, ino, fh, offset, builder).await {
+                Ok(()) => reply.ok(),
+                Err(e) => reply.error(e),
+            }
+        });
     }
 }
 


### PR DESCRIPTION
Calling `block_on` makes `async` useless, preventing concurrent handling of requests.