### PR TITLE
Limit CI job duration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   compile:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     strategy:
       matrix:
         libfuse: [libfuse-dev, libfuse3-dev]
@@ -55,6 +56,7 @@ jobs:
 
   ci:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     env:
       RUSTFLAGS: --deny warnings
     steps:
@@ -95,6 +97,7 @@ jobs:
 
   test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 120
     strategy:
       matrix:
         test_group: [mount_tests, pjdfs_tests, xfstests]


### PR DESCRIPTION
If job hanged, see it earlier.

Default is 6 hours.