### PR TITLE
derive(TryFromPrimitive)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ bitflags = "2.9"
 libc = "0.2.51"
 log = "0.4.6"
 memchr = "2.7.2"
+num_enum = "0.7.5"
 page_size = "0.6.0"
 serde = { version = "1.0.102", features = ["std", "derive"], optional = true }
 smallvec = "1.6.1"

--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -24,7 +24,7 @@
 #![allow(missing_docs)]
 
 use bitflags::bitflags;
-use std::convert::TryFrom;
+use num_enum::TryFromPrimitive;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 pub(crate) const FUSE_KERNEL_VERSION: u32 = 7;
@@ -429,12 +429,8 @@ pub mod consts {
     pub const FUSE_MIN_READ_BUFFER: usize = 8192;
 }
 
-/// Invalid opcode error.
-#[derive(Debug)]
-pub(crate) struct InvalidOpcodeError;
-
-#[repr(C)]
-#[derive(Debug)]
+#[repr(u32)]
+#[derive(Debug, TryFromPrimitive)]
 #[allow(non_camel_case_types)]
 pub(crate) enum fuse_opcode {
     FUSE_LOOKUP = 1,
@@ -497,81 +493,8 @@ pub(crate) enum fuse_opcode {
     CUSE_INIT = 4096,
 }
 
-impl TryFrom<u32> for fuse_opcode {
-    type Error = InvalidOpcodeError;
-
-    fn try_from(n: u32) -> Result<Self, Self::Error> {
-        match n {
-            1 => Ok(fuse_opcode::FUSE_LOOKUP),
-            2 => Ok(fuse_opcode::FUSE_FORGET),
-            3 => Ok(fuse_opcode::FUSE_GETATTR),
-            4 => Ok(fuse_opcode::FUSE_SETATTR),
-            5 => Ok(fuse_opcode::FUSE_READLINK),
-            6 => Ok(fuse_opcode::FUSE_SYMLINK),
-            8 => Ok(fuse_opcode::FUSE_MKNOD),
-            9 => Ok(fuse_opcode::FUSE_MKDIR),
-            10 => Ok(fuse_opcode::FUSE_UNLINK),
-            11 => Ok(fuse_opcode::FUSE_RMDIR),
-            12 => Ok(fuse_opcode::FUSE_RENAME),
-            13 => Ok(fuse_opcode::FUSE_LINK),
-            14 => Ok(fuse_opcode::FUSE_OPEN),
-            15 => Ok(fuse_opcode::FUSE_READ),
-            16 => Ok(fuse_opcode::FUSE_WRITE),
-            17 => Ok(fuse_opcode::FUSE_STATFS),
-            18 => Ok(fuse_opcode::FUSE_RELEASE),
-            20 => Ok(fuse_opcode::FUSE_FSYNC),
-            21 => Ok(fuse_opcode::FUSE_SETXATTR),
-            22 => Ok(fuse_opcode::FUSE_GETXATTR),
-            23 => Ok(fuse_opcode::FUSE_LISTXATTR),
-            24 => Ok(fuse_opcode::FUSE_REMOVEXATTR),
-            25 => Ok(fuse_opcode::FUSE_FLUSH),
-            26 => Ok(fuse_opcode::FUSE_INIT),
-            27 => Ok(fuse_opcode::FUSE_OPENDIR),
-            28 => Ok(fuse_opcode::FUSE_READDIR),
-            29 => Ok(fuse_opcode::FUSE_RELEASEDIR),
-            30 => Ok(fuse_opcode::FUSE_FSYNCDIR),
-            31 => Ok(fuse_opcode::FUSE_GETLK),
-            32 => Ok(fuse_opcode::FUSE_SETLK),
-            33 => Ok(fuse_opcode::FUSE_SETLKW),
-            34 => Ok(fuse_opcode::FUSE_ACCESS),
-            35 => Ok(fuse_opcode::FUSE_CREATE),
-            36 => Ok(fuse_opcode::FUSE_INTERRUPT),
-            37 => Ok(fuse_opcode::FUSE_BMAP),
-            38 => Ok(fuse_opcode::FUSE_DESTROY),
-            39 => Ok(fuse_opcode::FUSE_IOCTL),
-            40 => Ok(fuse_opcode::FUSE_POLL),
-            41 => Ok(fuse_opcode::FUSE_NOTIFY_REPLY),
-            42 => Ok(fuse_opcode::FUSE_BATCH_FORGET),
-            43 => Ok(fuse_opcode::FUSE_FALLOCATE),
-            #[cfg(feature = "abi-7-21")]
-            44 => Ok(fuse_opcode::FUSE_READDIRPLUS),
-            #[cfg(feature = "abi-7-23")]
-            45 => Ok(fuse_opcode::FUSE_RENAME2),
-            #[cfg(feature = "abi-7-24")]
-            46 => Ok(fuse_opcode::FUSE_LSEEK),
-            #[cfg(feature = "abi-7-28")]
-            47 => Ok(fuse_opcode::FUSE_COPY_FILE_RANGE),
-
-            #[cfg(target_os = "macos")]
-            61 => Ok(fuse_opcode::FUSE_SETVOLNAME),
-            #[cfg(target_os = "macos")]
-            62 => Ok(fuse_opcode::FUSE_GETXTIMES),
-            #[cfg(target_os = "macos")]
-            63 => Ok(fuse_opcode::FUSE_EXCHANGE),
-
-            4096 => Ok(fuse_opcode::CUSE_INIT),
-
-            _ => Err(InvalidOpcodeError),
-        }
-    }
-}
-
-/// Invalid notify code error.
-#[derive(Debug)]
-pub(crate) struct InvalidNotifyCodeError;
-
-#[repr(C)]
-#[derive(Debug)]
+#[repr(u32)]
+#[derive(Debug, TryFromPrimitive)]
 #[allow(non_camel_case_types)]
 pub(crate) enum fuse_notify_code {
     FUSE_POLL = 1,
@@ -580,23 +503,6 @@ pub(crate) enum fuse_notify_code {
     FUSE_NOTIFY_STORE = 4,
     FUSE_NOTIFY_RETRIEVE = 5,
     FUSE_NOTIFY_DELETE = 6,
-}
-
-impl TryFrom<u32> for fuse_notify_code {
-    type Error = InvalidNotifyCodeError;
-
-    fn try_from(n: u32) -> Result<Self, Self::Error> {
-        match n {
-            1 => Ok(fuse_notify_code::FUSE_POLL),
-            2 => Ok(fuse_notify_code::FUSE_NOTIFY_INVAL_INODE),
-            3 => Ok(fuse_notify_code::FUSE_NOTIFY_INVAL_ENTRY),
-            4 => Ok(fuse_notify_code::FUSE_NOTIFY_STORE),
-            5 => Ok(fuse_notify_code::FUSE_NOTIFY_RETRIEVE),
-            6 => Ok(fuse_notify_code::FUSE_NOTIFY_DELETE),
-
-            _ => Err(InvalidNotifyCodeError),
-        }
-    }
 }
 
 #[repr(C)]

--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -3,7 +3,7 @@
 //! A request represents information about a filesystem operation the kernel driver wants us to
 //! perform.
 
-use super::fuse_abi::{InvalidOpcodeError, fuse_in_header, fuse_opcode};
+use super::fuse_abi::{fuse_in_header, fuse_opcode};
 
 use super::{Errno, Response, fuse_abi as abi};
 use nix::unistd::{Gid, Pid, Uid};
@@ -2116,8 +2116,9 @@ impl_request!(AnyRequest<'_>);
 impl<'a> AnyRequest<'a> {
     pub(crate) fn operation(&self) -> Result<Operation<'a>, RequestError> {
         // Parse/check opcode
-        let opcode = fuse_opcode::try_from(self.header.opcode)
-            .map_err(|_: InvalidOpcodeError| RequestError::UnknownOperation(self.header.opcode))?;
+        let opcode = fuse_opcode::try_from(self.header.opcode).map_err(
+            |e: num_enum::TryFromPrimitiveError<_>| RequestError::UnknownOperation(e.number),
+        )?;
         // Parse/check operation arguments
         op::parse(self.header, &opcode, self.data).ok_or(RequestError::InsufficientData)
     }


### PR DESCRIPTION
Derive instead of writing manually.

Alternative possible approach is to derive `zerocopy::TryFromBytes`, and convert `fuse_xxx_in` fields to enums, and also do `TryFromBytes` instead of `FromBytes`, but that may be too much divergence from C definition of protocol, not sure.