### PR TITLE
Do not panic in BackgroundSession::join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Change integers to newtypes in various public APIs
 * Add `FileType` conversion from std `FileType`
+* Rename `BackgroundSession::join` to `umount_and_join`
+  and change it to return `io::Result<()>` instead of panicking
 
 ## 0.16.0 - 2025-09-12
 * Add support for passthrough file descriptors


### PR DESCRIPTION
... and rename it to `stop_and_join`.

Panicking is problem for programs compiled with panic=abort.  And after shutdown the program may expect to perform additional operations like logging or state validation.