### PR TITLE
Add fields to fuse_init_in unconditionally (attempt 2)

### DIFF
--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -16,6 +16,8 @@
 //! - supports ABI 7.19 since FUSE 2.9.1
 //! - supports ABI 7.26 since FUSE 3.0.0
 //!
+//! FreeBSD kernel headers: <https://github.com/freebsd/freebsd-src/blob/main/sys/fs/fuse/fuse_kernel.h>
+//!
 //! Items without a version annotation are valid with ABI 7.8 and later
 
 #![warn(missing_debug_implementations)]
@@ -809,15 +811,13 @@ pub(crate) struct fuse_access_in {
 }
 
 #[repr(C)]
-#[derive(Debug, FromBytes, KnownLayout, Immutable)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable, IntoBytes)]
 pub(crate) struct fuse_init_in {
     pub(crate) major: u32,
     pub(crate) minor: u32,
     pub(crate) max_readahead: u32,
     pub(crate) flags: u32,
-    #[cfg(feature = "abi-7-36")]
     pub(crate) flags2: u32,
-    #[cfg(feature = "abi-7-36")]
     pub(crate) unused: [u32; 11],
 }
 


### PR DESCRIPTION
Two commits
- revert #464
- new approach: allocate full `fuse_init_in`, zerofill, and then copy whatever data we have over