### PR TITLE
Extract handshake

### DIFF
--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -180,6 +180,7 @@ impl Lock {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
 pub(crate) struct Version(pub(crate) u32, pub(crate) u32);
+
 impl Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}.{}", self.0, self.1)
@@ -1050,6 +1051,27 @@ mod op {
                 init
             };
             Response::new_data(init)
+        }
+
+        /// Reply with only our version, used when kernel major version > our major version.
+        /// The kernel will then send a second INIT request with a compatible version.
+        pub(crate) fn reply_version_only(&self) -> Response<'a> {
+            let init = fuse_init_out {
+                major: FUSE_KERNEL_VERSION,
+                minor: FUSE_KERNEL_MINOR_VERSION,
+                max_readahead: 0,
+                flags: 0,
+                max_background: 0,
+                congestion_threshold: 0,
+                max_write: 0,
+                time_gran: 0,
+                max_pages: 0,
+                unused2: 0,
+                flags2: 0,
+                max_stack_depth: 0,
+                reserved: [0; 6],
+            };
+            Response::new_data(init.as_bytes())
         }
     }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -5,7 +5,6 @@
 //!
 //! TODO: This module is meant to go away soon in favor of `ll::Request`.
 
-use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::path::Path;
 
@@ -14,8 +13,6 @@ use log::error;
 use log::warn;
 
 use crate::Filesystem;
-use crate::InitFlags;
-use crate::KernelConfig;
 use crate::PollHandle;
 use crate::RenameFlags;
 use crate::Request;
@@ -24,7 +21,6 @@ use crate::ll;
 use crate::ll::Errno;
 use crate::ll::Request as _;
 use crate::ll::Response;
-use crate::ll::fuse_abi as abi;
 use crate::reply::Reply;
 use crate::reply::ReplyDirectory;
 use crate::reply::ReplyDirectoryPlus;
@@ -103,67 +99,9 @@ impl<'a> RequestWithSender<'a> {
             }
         }
         match op {
-            // Filesystem initialization
-            ll::Operation::Init(x) => {
-                // We don't support ABI versions before 7.6
-                let v = x.version();
-                if v < ll::Version(7, 6) {
-                    error!("Unsupported FUSE ABI version {v}");
-                    return Err(Errno::EPROTO);
-                }
-
-                let mut config = KernelConfig::new(x.capabilities(), x.max_readahead());
-                // Call filesystem init method and give it a chance to return an error
-                se.filesystem
-                    .init(self.request_header(), &mut config)
-                    .map_err(Errno::from_i32)?;
-
-                // Remember the ABI version supported by kernel and mark the session initialized.
-                se.proto_version = Some(v);
-
-                for bit in 0..64 {
-                    let bitflags = InitFlags::from_bits_retain(1 << bit);
-                    if bitflags == InitFlags::FUSE_INIT_EXT {
-                        continue;
-                    }
-                    let bitflag_is_known = InitFlags::all().contains(bitflags);
-                    let kernel_supports = x.capabilities().contains(bitflags);
-                    let we_requested = config.requested.contains(bitflags);
-                    // On macOS, there's a clash between linux and macOS constants,
-                    // so we pick macOS ones (last).
-                    let name = if let Some((name, _)) = bitflags.iter_names().last() {
-                        Cow::Borrowed(name)
-                    } else {
-                        Cow::Owned(format!("(1 << {bit})"))
-                    };
-                    if we_requested && kernel_supports {
-                        debug!("capability {name} enabled")
-                    } else if we_requested {
-                        debug!("capability {name} not supported by kernel")
-                    } else if kernel_supports {
-                        debug!("capability {name} not requested by client")
-                    } else if bitflag_is_known {
-                        debug!("capability {name} not supported nor requested")
-                    }
-                }
-
-                // Reply with our desired version and settings. If the kernel supports a
-                // larger major version, it'll re-send a matching init message. If it
-                // supports only lower major versions, we replied with an error above.
-                debug!(
-                    "INIT response: ABI {}.{}, flags {:#x}, max readahead {}, max write {}",
-                    abi::FUSE_KERNEL_VERSION,
-                    abi::FUSE_KERNEL_MINOR_VERSION,
-                    x.capabilities() & config.requested,
-                    config.max_readahead,
-                    config.max_write
-                );
-
-                return Ok(Some(x.reply(&config)));
-            }
-            // Any operation is invalid before initialization
-            _ if se.proto_version.is_none() => {
-                warn!("Ignoring FUSE operation before init: {}", self.request);
+            // Filesystem initialization - should not happen after handshake completed
+            ll::Operation::Init(_) => {
+                error!("Unexpected FUSE_INIT after handshake completed");
                 return Err(Errno::EIO);
             }
             // Filesystem destroyed


### PR DESCRIPTION
To support `FUSE_DEV_IOC_CLONE`, we need to have this operation
- handshake
- clone the descriptor
- process descriptors from several threads

This change extracts handshake code as preparation to implement this feature.

I'm not 100% sure, but I think `FUSE_OVER_IO_URING` also requires this refactoring: handshake happens over `/dev/fuse` and then rings are created to process messages.