### PR TITLE
Filesystem &mut self -> &self

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -64,7 +64,7 @@ const HELLO_TXT_ATTR: FileAttr = FileAttr {
 struct HelloFS;
 
 impl Filesystem for HelloFS {
-    fn lookup(&mut self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
+    fn lookup(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
         if u64::from(parent) == 1 && name.to_str() == Some("hello.txt") {
             reply.entry(&TTL, &HELLO_TXT_ATTR, fuser::Generation(0));
         } else {
@@ -72,7 +72,7 @@ impl Filesystem for HelloFS {
         }
     }
 
-    fn getattr(&mut self, _req: &Request, ino: INodeNo, _fh: Option<FileHandle>, reply: ReplyAttr) {
+    fn getattr(&self, _req: &Request, ino: INodeNo, _fh: Option<FileHandle>, reply: ReplyAttr) {
         match u64::from(ino) {
             1 => reply.attr(&TTL, &HELLO_DIR_ATTR),
             2 => reply.attr(&TTL, &HELLO_TXT_ATTR),
@@ -81,7 +81,7 @@ impl Filesystem for HelloFS {
     }
 
     fn read(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         _fh: FileHandle,
@@ -99,7 +99,7 @@ impl Filesystem for HelloFS {
     }
 
     fn readdir(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         _fh: FileHandle,

--- a/examples/notify_inval_entry.rs
+++ b/examples/notify_inval_entry.rs
@@ -72,7 +72,7 @@ impl ClockFS<'_> {
 }
 
 impl Filesystem for ClockFS<'_> {
-    fn lookup(&mut self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
+    fn lookup(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
         if parent != INodeNo::ROOT || name != AsRef::<OsStr>::as_ref(&self.get_filename()) {
             reply.error(Errno::ENOENT);
             return;
@@ -86,7 +86,7 @@ impl Filesystem for ClockFS<'_> {
         );
     }
 
-    fn forget(&mut self, _req: &Request, ino: INodeNo, _nlookup: u64) {
+    fn forget(&self, _req: &Request, ino: INodeNo, _nlookup: u64) {
         if ino.0 == ClockFS::FILE_INO {
             let prev = self.lookup_cnt.fetch_sub(_nlookup, SeqCst);
             assert!(prev >= _nlookup);
@@ -95,7 +95,7 @@ impl Filesystem for ClockFS<'_> {
         }
     }
 
-    fn getattr(&mut self, _req: &Request, ino: INodeNo, _fh: Option<FileHandle>, reply: ReplyAttr) {
+    fn getattr(&self, _req: &Request, ino: INodeNo, _fh: Option<FileHandle>, reply: ReplyAttr) {
         match ClockFS::stat(ino) {
             Some(a) => reply.attr(&self.timeout, &a),
             None => reply.error(Errno::ENOENT),
@@ -103,7 +103,7 @@ impl Filesystem for ClockFS<'_> {
     }
 
     fn readdir(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         _fh: FileHandle,

--- a/examples/notify_inval_inode.rs
+++ b/examples/notify_inval_inode.rs
@@ -78,7 +78,7 @@ impl ClockFS<'_> {
 }
 
 impl Filesystem for ClockFS<'_> {
-    fn lookup(&mut self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
+    fn lookup(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
         if parent != INodeNo::ROOT || name != AsRef::<OsStr>::as_ref(&Self::FILE_NAME) {
             reply.error(Errno::ENOENT);
             return;
@@ -92,7 +92,7 @@ impl Filesystem for ClockFS<'_> {
         );
     }
 
-    fn forget(&mut self, _req: &Request, ino: INodeNo, _nlookup: u64) {
+    fn forget(&self, _req: &Request, ino: INodeNo, _nlookup: u64) {
         if ino == INodeNo(ClockFS::FILE_INO) {
             let prev = self.lookup_cnt.fetch_sub(_nlookup, SeqCst);
             assert!(prev >= _nlookup);
@@ -101,7 +101,7 @@ impl Filesystem for ClockFS<'_> {
         }
     }
 
-    fn getattr(&mut self, _req: &Request, ino: INodeNo, _fh: Option<FileHandle>, reply: ReplyAttr) {
+    fn getattr(&self, _req: &Request, ino: INodeNo, _fh: Option<FileHandle>, reply: ReplyAttr) {
         match self.stat(ino) {
             Some(a) => reply.attr(&Duration::MAX, &a),
             None => reply.error(Errno::ENOENT),
@@ -109,7 +109,7 @@ impl Filesystem for ClockFS<'_> {
     }
 
     fn readdir(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         _fh: FileHandle,
@@ -135,7 +135,7 @@ impl Filesystem for ClockFS<'_> {
         }
     }
 
-    fn open(&mut self, _req: &Request, ino: INodeNo, flags: OpenFlags, reply: ReplyOpen) {
+    fn open(&self, _req: &Request, ino: INodeNo, flags: OpenFlags, reply: ReplyOpen) {
         if ino == INodeNo::ROOT {
             reply.error(Errno::EISDIR);
         } else if flags.acc_mode() != OpenAccMode::O_RDONLY {
@@ -150,7 +150,7 @@ impl Filesystem for ClockFS<'_> {
     }
 
     fn read(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         _fh: FileHandle,

--- a/examples/poll.rs
+++ b/examples/poll.rs
@@ -94,7 +94,7 @@ impl FSelFS {
 }
 
 impl fuser::Filesystem for FSelFS {
-    fn lookup(&mut self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
+    fn lookup(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
         if parent != INodeNo::ROOT || name.len() != 1 {
             reply.error(Errno::ENOENT);
             return;
@@ -118,7 +118,7 @@ impl fuser::Filesystem for FSelFS {
         );
     }
 
-    fn getattr(&mut self, _req: &Request, ino: INodeNo, _fh: Option<FileHandle>, reply: ReplyAttr) {
+    fn getattr(&self, _req: &Request, ino: INodeNo, _fh: Option<FileHandle>, reply: ReplyAttr) {
         if ino == INodeNo::ROOT {
             let a = FileAttr {
                 ino: INodeNo::ROOT,
@@ -149,7 +149,7 @@ impl fuser::Filesystem for FSelFS {
     }
 
     fn readdir(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         _fh: FileHandle,
@@ -186,7 +186,7 @@ impl fuser::Filesystem for FSelFS {
         reply.ok();
     }
 
-    fn open(&mut self, _req: &Request, ino: INodeNo, flags: OpenFlags, reply: ReplyOpen) {
+    fn open(&self, _req: &Request, ino: INodeNo, flags: OpenFlags, reply: ReplyOpen) {
         let idx = FSelData::ino_to_idx(ino);
         if idx >= NUMFILES {
             reply.error(Errno::ENOENT);
@@ -216,7 +216,7 @@ impl fuser::Filesystem for FSelFS {
     }
 
     fn release(
-        &mut self,
+        &self,
         _req: &Request,
         _ino: INodeNo,
         _fh: FileHandle,
@@ -235,7 +235,7 @@ impl fuser::Filesystem for FSelFS {
     }
 
     fn read(
-        &mut self,
+        &self,
         _req: &Request,
         _ino: INodeNo,
         fh: FileHandle,
@@ -268,7 +268,7 @@ impl fuser::Filesystem for FSelFS {
     }
 
     fn poll(
-        &mut self,
+        &self,
         _req: &Request,
         _ino: INodeNo,
         fh: FileHandle,

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -554,7 +554,7 @@ impl Filesystem for SimpleFS {
         Ok(())
     }
 
-    fn lookup(&mut self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
+    fn lookup(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
         if name.len() > MAX_NAME_LENGTH as usize {
             reply.error(Errno::ENAMETOOLONG);
             return;
@@ -578,9 +578,9 @@ impl Filesystem for SimpleFS {
         }
     }
 
-    fn forget(&mut self, _req: &Request, _ino: INodeNo, _nlookup: u64) {}
+    fn forget(&self, _req: &Request, _ino: INodeNo, _nlookup: u64) {}
 
-    fn getattr(&mut self, _req: &Request, ino: INodeNo, _fh: Option<FileHandle>, reply: ReplyAttr) {
+    fn getattr(&self, _req: &Request, ino: INodeNo, _fh: Option<FileHandle>, reply: ReplyAttr) {
         match self.get_inode(ino) {
             Ok(attrs) => reply.attr(&Duration::new(0, 0), &attrs.into()),
             Err(error_code) => reply.error(error_code),
@@ -588,7 +588,7 @@ impl Filesystem for SimpleFS {
     }
 
     fn setattr(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         mode: Option<u32>,
@@ -780,7 +780,7 @@ impl Filesystem for SimpleFS {
         return;
     }
 
-    fn readlink(&mut self, _req: &Request, ino: INodeNo, reply: ReplyData) {
+    fn readlink(&self, _req: &Request, ino: INodeNo, reply: ReplyData) {
         debug!("readlink() called on {ino:?}");
         let path = self.content_path(ino);
         match File::open(path) {
@@ -797,7 +797,7 @@ impl Filesystem for SimpleFS {
     }
 
     fn mknod(
-        &mut self,
+        &self,
         _req: &Request,
         parent: INodeNo,
         name: &OsStr,
@@ -899,7 +899,7 @@ impl Filesystem for SimpleFS {
     }
 
     fn mkdir(
-        &mut self,
+        &self,
         _req: &Request,
         parent: INodeNo,
         name: &OsStr,
@@ -972,7 +972,7 @@ impl Filesystem for SimpleFS {
         reply.entry(&Duration::new(0, 0), &attrs.into(), fuser::Generation(0));
     }
 
-    fn unlink(&mut self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEmpty) {
+    fn unlink(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEmpty) {
         debug!("unlink() called with {parent:?} {name:?}");
         let mut attrs = match self.lookup_name(parent, name) {
             Ok(attrs) => attrs,
@@ -1029,7 +1029,7 @@ impl Filesystem for SimpleFS {
         reply.ok();
     }
 
-    fn rmdir(&mut self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEmpty) {
+    fn rmdir(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEmpty) {
         debug!("rmdir() called with {parent:?} {name:?}");
         let mut attrs = match self.lookup_name(parent, name) {
             Ok(attrs) => attrs,
@@ -1096,7 +1096,7 @@ impl Filesystem for SimpleFS {
     }
 
     fn symlink(
-        &mut self,
+        &self,
         _req: &Request,
         parent: INodeNo,
         link_name: &OsStr,
@@ -1163,7 +1163,7 @@ impl Filesystem for SimpleFS {
     }
 
     fn rename(
-        &mut self,
+        &self,
         _req: &Request,
         parent: INodeNo,
         name: &OsStr,
@@ -1380,7 +1380,7 @@ impl Filesystem for SimpleFS {
     }
 
     fn link(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         newparent: INodeNo,
@@ -1405,7 +1405,7 @@ impl Filesystem for SimpleFS {
         }
     }
 
-    fn open(&mut self, _req: &Request, _ino: INodeNo, flags: OpenFlags, reply: ReplyOpen) {
+    fn open(&self, _req: &Request, _ino: INodeNo, flags: OpenFlags, reply: ReplyOpen) {
         debug!("open() called for {_ino:?}");
         let (access_mask, read, write) = match flags.acc_mode() {
             OpenAccMode::O_RDONLY => {
@@ -1453,7 +1453,7 @@ impl Filesystem for SimpleFS {
     }
 
     fn read(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         fh: FileHandle,
@@ -1487,7 +1487,7 @@ impl Filesystem for SimpleFS {
     }
 
     fn write(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         fh: FileHandle,
@@ -1535,7 +1535,7 @@ impl Filesystem for SimpleFS {
     }
 
     fn release(
-        &mut self,
+        &self,
         _req: &Request,
         _ino: INodeNo,
         _fh: FileHandle,
@@ -1550,7 +1550,7 @@ impl Filesystem for SimpleFS {
         reply.ok();
     }
 
-    fn opendir(&mut self, _req: &Request, _ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
+    fn opendir(&self, _req: &Request, _ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
         debug!("opendir() called on {_ino:?}");
         let (access_mask, read, write) = match _flags.acc_mode() {
             OpenAccMode::O_RDONLY => {
@@ -1593,7 +1593,7 @@ impl Filesystem for SimpleFS {
     }
 
     fn readdir(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         _fh: FileHandle,
@@ -1628,7 +1628,7 @@ impl Filesystem for SimpleFS {
     }
 
     fn releasedir(
-        &mut self,
+        &self,
         _req: &Request,
         _ino: INodeNo,
         _fh: FileHandle,
@@ -1641,7 +1641,7 @@ impl Filesystem for SimpleFS {
         reply.ok();
     }
 
-    fn statfs(&mut self, _req: &Request, _ino: INodeNo, reply: ReplyStatfs) {
+    fn statfs(&self, _req: &Request, _ino: INodeNo, reply: ReplyStatfs) {
         warn!("statfs() implementation is a stub");
         // TODO: real implementation of this
         reply.statfs(
@@ -1657,7 +1657,7 @@ impl Filesystem for SimpleFS {
     }
 
     fn setxattr(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         name: &OsStr,
@@ -1684,7 +1684,7 @@ impl Filesystem for SimpleFS {
     }
 
     fn getxattr(
-        &mut self,
+        &self,
         request: &Request,
         inode: INodeNo,
         key: &OsStr,
@@ -1716,7 +1716,7 @@ impl Filesystem for SimpleFS {
         }
     }
 
-    fn listxattr(&mut self, _req: &Request, ino: INodeNo, size: u32, reply: ReplyXattr) {
+    fn listxattr(&self, _req: &Request, ino: INodeNo, size: u32, reply: ReplyXattr) {
         if let Ok(attrs) = self.get_inode(ino) {
             let mut bytes = vec![];
             // Convert to concatenated null-terminated strings
@@ -1736,7 +1736,7 @@ impl Filesystem for SimpleFS {
         }
     }
 
-    fn removexattr(&mut self, request: &Request, inode: INodeNo, key: &OsStr, reply: ReplyEmpty) {
+    fn removexattr(&self, request: &Request, inode: INodeNo, key: &OsStr, reply: ReplyEmpty) {
         if let Ok(mut attrs) = self.get_inode(inode) {
             if let Err(error) = xattr_access_check(key.as_bytes(), libc::W_OK, &attrs, request) {
                 reply.error(error);
@@ -1758,7 +1758,7 @@ impl Filesystem for SimpleFS {
         }
     }
 
-    fn access(&mut self, _req: &Request, ino: INodeNo, mask: AccessFlags, reply: ReplyEmpty) {
+    fn access(&self, _req: &Request, ino: INodeNo, mask: AccessFlags, reply: ReplyEmpty) {
         debug!("access() called with {ino:?} {mask:?}");
         match self.get_inode(ino) {
             Ok(attr) => {
@@ -1773,7 +1773,7 @@ impl Filesystem for SimpleFS {
     }
 
     fn create(
-        &mut self,
+        &self,
         req: &Request,
         parent: INodeNo,
         name: &OsStr,
@@ -1880,7 +1880,7 @@ impl Filesystem for SimpleFS {
 
     #[cfg(target_os = "linux")]
     fn fallocate(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         _fh: FileHandle,
@@ -1913,7 +1913,7 @@ impl Filesystem for SimpleFS {
     }
 
     fn copy_file_range(
-        &mut self,
+        &self,
         _req: &Request,
         src_inode: INodeNo,
         src_fh: FileHandle,

--- a/src/experimental.rs
+++ b/src/experimental.rs
@@ -140,7 +140,7 @@ impl<T: AsyncFilesystem> TokioAdapter<T> {
 }
 
 impl<T: AsyncFilesystem> Filesystem for TokioAdapter<T> {
-    fn lookup(&mut self, req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
+    fn lookup(&self, req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
         match self
             .runtime
             .block_on(self.inner.lookup(&req.into(), parent, name))
@@ -154,7 +154,7 @@ impl<T: AsyncFilesystem> Filesystem for TokioAdapter<T> {
         }
     }
 
-    fn getattr(&mut self, req: &Request, ino: INodeNo, fh: Option<FileHandle>, reply: ReplyAttr) {
+    fn getattr(&self, req: &Request, ino: INodeNo, fh: Option<FileHandle>, reply: ReplyAttr) {
         match self
             .runtime
             .block_on(self.inner.getattr(&req.into(), ino, fh))
@@ -165,7 +165,7 @@ impl<T: AsyncFilesystem> Filesystem for TokioAdapter<T> {
     }
 
     fn read(
-        &mut self,
+        &self,
         req: &Request,
         ino: INodeNo,
         fh: FileHandle,
@@ -192,7 +192,7 @@ impl<T: AsyncFilesystem> Filesystem for TokioAdapter<T> {
     }
 
     fn readdir(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         fh: FileHandle,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,7 +409,7 @@ pub trait Filesystem {
     fn destroy(&mut self) {}
 
     /// Look up a directory entry by name and get its attributes.
-    fn lookup(&mut self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
+    fn lookup(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
         warn!("[Not Implemented] lookup(parent: {parent:#x?}, name {name:?})");
         reply.error(Errno::ENOSYS);
     }
@@ -421,25 +421,25 @@ pub trait Filesystem {
     /// each forget. The filesystem may ignore forget calls, if the inodes don't need to
     /// have a limited lifetime. On unmount it is not guaranteed, that all referenced
     /// inodes will receive a forget message.
-    fn forget(&mut self, _req: &Request, _ino: INodeNo, _nlookup: u64) {}
+    fn forget(&self, _req: &Request, _ino: INodeNo, _nlookup: u64) {}
 
     /// Like forget, but take multiple forget requests at once for performance. The default
     /// implementation will fallback to forget.
-    fn batch_forget(&mut self, req: &Request, nodes: &[fuse_forget_one]) {
+    fn batch_forget(&self, req: &Request, nodes: &[fuse_forget_one]) {
         for node in nodes {
             self.forget(req, INodeNo(node.nodeid), node.nlookup);
         }
     }
 
     /// Get file attributes.
-    fn getattr(&mut self, _req: &Request, ino: INodeNo, fh: Option<FileHandle>, reply: ReplyAttr) {
+    fn getattr(&self, _req: &Request, ino: INodeNo, fh: Option<FileHandle>, reply: ReplyAttr) {
         warn!("[Not Implemented] getattr(ino: {ino:#x?}, fh: {fh:#x?})");
         reply.error(Errno::ENOSYS);
     }
 
     /// Set file attributes.
     fn setattr(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         mode: Option<u32>,
@@ -464,7 +464,7 @@ pub trait Filesystem {
     }
 
     /// Read symbolic link.
-    fn readlink(&mut self, _req: &Request, ino: INodeNo, reply: ReplyData) {
+    fn readlink(&self, _req: &Request, ino: INodeNo, reply: ReplyData) {
         warn!("[Not Implemented] readlink(ino: {ino:#x?})");
         reply.error(Errno::ENOSYS);
     }
@@ -472,7 +472,7 @@ pub trait Filesystem {
     /// Create file node.
     /// Create a regular file, character device, block device, fifo or socket node.
     fn mknod(
-        &mut self,
+        &self,
         _req: &Request,
         parent: INodeNo,
         name: &OsStr,
@@ -490,7 +490,7 @@ pub trait Filesystem {
 
     /// Create a directory.
     fn mkdir(
-        &mut self,
+        &self,
         _req: &Request,
         parent: INodeNo,
         name: &OsStr,
@@ -505,20 +505,20 @@ pub trait Filesystem {
     }
 
     /// Remove a file.
-    fn unlink(&mut self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEmpty) {
+    fn unlink(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEmpty) {
         warn!("[Not Implemented] unlink(parent: {parent:#x?}, name: {name:?})",);
         reply.error(Errno::ENOSYS);
     }
 
     /// Remove a directory.
-    fn rmdir(&mut self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEmpty) {
+    fn rmdir(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEmpty) {
         warn!("[Not Implemented] rmdir(parent: {parent:#x?}, name: {name:?})",);
         reply.error(Errno::ENOSYS);
     }
 
     /// Create a symbolic link.
     fn symlink(
-        &mut self,
+        &self,
         _req: &Request,
         parent: INodeNo,
         link_name: &OsStr,
@@ -533,7 +533,7 @@ pub trait Filesystem {
 
     /// Rename a file.
     fn rename(
-        &mut self,
+        &self,
         _req: &Request,
         parent: INodeNo,
         name: &OsStr,
@@ -551,7 +551,7 @@ pub trait Filesystem {
 
     /// Create a hard link.
     fn link(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         newparent: INodeNo,
@@ -572,7 +572,7 @@ pub trait Filesystem {
     /// anything in fh. There are also some flags (`direct_io`, `keep_cache`) which the
     /// filesystem may set, to change the way the file is opened. See `fuse_file_info`
     /// structure in <`fuse_common.h`> for more details.
-    fn open(&mut self, _req: &Request, _ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
+    fn open(&self, _req: &Request, _ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
         reply.opened(0, FopenFlags::empty());
     }
 
@@ -587,7 +587,7 @@ pub trait Filesystem {
     /// flags: these are the file flags, such as `O_SYNC`. Only supported with ABI >= 7.9
     /// `lock_owner`: only supported with ABI >= 7.9
     fn read(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         fh: FileHandle,
@@ -617,7 +617,7 @@ pub trait Filesystem {
     /// flags: these are the file flags, such as `O_SYNC`. Only supported with ABI >= 7.9
     /// `lock_owner`: only supported with ABI >= 7.9
     fn write(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         fh: FileHandle,
@@ -648,7 +648,7 @@ pub trait Filesystem {
     /// filesystem wants to return write errors. If the filesystem supports file locking
     /// operations (`setlk`, `getlk`) it should remove all locks belonging to `lock_owner`.
     fn flush(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         fh: FileHandle,
@@ -668,7 +668,7 @@ pub trait Filesystem {
     /// if the open method didn't set any value. flags will contain the same flags as for
     /// open.
     fn release(
-        &mut self,
+        &self,
         _req: &Request,
         _ino: INodeNo,
         _fh: FileHandle,
@@ -684,7 +684,7 @@ pub trait Filesystem {
     /// If the datasync parameter is non-zero, then only the user data should be flushed,
     /// not the meta data.
     fn fsync(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         fh: FileHandle,
@@ -702,7 +702,7 @@ pub trait Filesystem {
     /// anything in fh, though that makes it impossible to implement standard conforming
     /// directory stream operations in case the contents of the directory can change
     /// between opendir and releasedir.
-    fn opendir(&mut self, _req: &Request, _ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
+    fn opendir(&self, _req: &Request, _ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
         reply.opened(0, FopenFlags::empty());
     }
 
@@ -712,7 +712,7 @@ pub trait Filesystem {
     /// value set by the opendir method, or will be undefined if the opendir method
     /// didn't set any value.
     fn readdir(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         fh: FileHandle,
@@ -729,7 +729,7 @@ pub trait Filesystem {
     /// value set by the opendir method, or will be undefined if the opendir method
     /// didn't set any value.
     fn readdirplus(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         fh: FileHandle,
@@ -745,7 +745,7 @@ pub trait Filesystem {
     /// contain the value set by the opendir method, or will be undefined if the
     /// opendir method didn't set any value.
     fn releasedir(
-        &mut self,
+        &self,
         _req: &Request,
         _ino: INodeNo,
         _fh: FileHandle,
@@ -760,7 +760,7 @@ pub trait Filesystem {
     /// be flushed, not the meta data. fh will contain the value set by the opendir
     /// method, or will be undefined if the opendir method didn't set any value.
     fn fsyncdir(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         fh: FileHandle,
@@ -772,13 +772,13 @@ pub trait Filesystem {
     }
 
     /// Get file system statistics.
-    fn statfs(&mut self, _req: &Request, _ino: INodeNo, reply: ReplyStatfs) {
+    fn statfs(&self, _req: &Request, _ino: INodeNo, reply: ReplyStatfs) {
         reply.statfs(0, 0, 0, 0, 0, 512, 255, 0);
     }
 
     /// Set an extended attribute.
     fn setxattr(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         name: &OsStr,
@@ -798,14 +798,7 @@ pub trait Filesystem {
     /// If `size` is 0, the size of the value should be sent with `reply.size()`.
     /// If `size` is not 0, and the value fits, send it with `reply.data()`, or
     /// `reply.error(ERANGE)` if it doesn't.
-    fn getxattr(
-        &mut self,
-        _req: &Request,
-        ino: INodeNo,
-        name: &OsStr,
-        size: u32,
-        reply: ReplyXattr,
-    ) {
+    fn getxattr(&self, _req: &Request, ino: INodeNo, name: &OsStr, size: u32, reply: ReplyXattr) {
         warn!("[Not Implemented] getxattr(ino: {ino:#x?}, name: {name:?}, size: {size})");
         reply.error(Errno::ENOSYS);
     }
@@ -814,13 +807,13 @@ pub trait Filesystem {
     /// If `size` is 0, the size of the value should be sent with `reply.size()`.
     /// If `size` is not 0, and the value fits, send it with `reply.data()`, or
     /// `reply.error(ERANGE)` if it doesn't.
-    fn listxattr(&mut self, _req: &Request, ino: INodeNo, size: u32, reply: ReplyXattr) {
+    fn listxattr(&self, _req: &Request, ino: INodeNo, size: u32, reply: ReplyXattr) {
         warn!("[Not Implemented] listxattr(ino: {ino:#x?}, size: {size})");
         reply.error(Errno::ENOSYS);
     }
 
     /// Remove an extended attribute.
-    fn removexattr(&mut self, _req: &Request, ino: INodeNo, name: &OsStr, reply: ReplyEmpty) {
+    fn removexattr(&self, _req: &Request, ino: INodeNo, name: &OsStr, reply: ReplyEmpty) {
         warn!("[Not Implemented] removexattr(ino: {ino:#x?}, name: {name:?})");
         reply.error(Errno::ENOSYS);
     }
@@ -829,7 +822,7 @@ pub trait Filesystem {
     /// This will be called for the `access()` system call. If the `default_permissions`
     /// mount option is given, this method is not called. This method is not called
     /// under Linux kernel versions 2.4.x
-    fn access(&mut self, _req: &Request, ino: INodeNo, mask: AccessFlags, reply: ReplyEmpty) {
+    fn access(&self, _req: &Request, ino: INodeNo, mask: AccessFlags, reply: ReplyEmpty) {
         warn!("[Not Implemented] access(ino: {ino:#x?}, mask: {mask})");
         reply.error(Errno::ENOSYS);
     }
@@ -845,7 +838,7 @@ pub trait Filesystem {
     /// this method is not implemented or under Linux kernel versions earlier than
     /// 2.6.15, the `mknod()` and `open()` methods will be called instead.
     fn create(
-        &mut self,
+        &self,
         _req: &Request,
         parent: INodeNo,
         name: &OsStr,
@@ -863,7 +856,7 @@ pub trait Filesystem {
 
     /// Test for a POSIX file lock.
     fn getlk(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         fh: FileHandle,
@@ -889,7 +882,7 @@ pub trait Filesystem {
     /// implemented, the kernel will still allow file locking to work locally.
     /// Hence these are only interesting for network filesystems and similar.
     fn setlk(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         fh: FileHandle,
@@ -911,14 +904,14 @@ pub trait Filesystem {
     /// Map block index within file to block index within device.
     /// Note: This makes sense only for block device backed filesystems mounted
     /// with the 'blkdev' option
-    fn bmap(&mut self, _req: &Request, ino: INodeNo, blocksize: u32, idx: u64, reply: ReplyBmap) {
+    fn bmap(&self, _req: &Request, ino: INodeNo, blocksize: u32, idx: u64, reply: ReplyBmap) {
         warn!("[Not Implemented] bmap(ino: {ino:#x?}, blocksize: {blocksize}, idx: {idx})",);
         reply.error(Errno::ENOSYS);
     }
 
     /// control device
     fn ioctl(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         fh: FileHandle,
@@ -938,7 +931,7 @@ pub trait Filesystem {
 
     /// Poll for events
     fn poll(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         fh: FileHandle,
@@ -956,7 +949,7 @@ pub trait Filesystem {
 
     /// Preallocate or deallocate space to a file
     fn fallocate(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         fh: FileHandle,
@@ -974,7 +967,7 @@ pub trait Filesystem {
 
     /// Reposition read/write file offset
     fn lseek(
-        &mut self,
+        &self,
         _req: &Request,
         ino: INodeNo,
         fh: FileHandle,
@@ -991,7 +984,7 @@ pub trait Filesystem {
 
     /// Copy the specified range from the source inode to the destination inode
     fn copy_file_range(
-        &mut self,
+        &self,
         _req: &Request,
         ino_in: INodeNo,
         fh_in: FileHandle,
@@ -1014,7 +1007,7 @@ pub trait Filesystem {
     /// macOS only: Rename the volume. Set `fuse_init_out.flags` during init to
     /// `FUSE_VOL_RENAME` to enable
     #[cfg(target_os = "macos")]
-    fn setvolname(&mut self, _req: &Request, name: &OsStr, reply: ReplyEmpty) {
+    fn setvolname(&self, _req: &Request, name: &OsStr, reply: ReplyEmpty) {
         warn!("[Not Implemented] setvolname(name: {name:?})");
         reply.error(Errno::ENOSYS);
     }
@@ -1022,7 +1015,7 @@ pub trait Filesystem {
     /// macOS only (undocumented)
     #[cfg(target_os = "macos")]
     fn exchange(
-        &mut self,
+        &self,
         _req: &Request,
         parent: INodeNo,
         name: &OsStr,
@@ -1041,7 +1034,7 @@ pub trait Filesystem {
     /// macOS only: Query extended times (`bkuptime` and `crtime`). Set `fuse_init_out.flags`
     /// during init to `FUSE_XTIMES` to enable
     #[cfg(target_os = "macos")]
-    fn getxtimes(&mut self, _req: &Request, ino: INodeNo, reply: ReplyXTimes) {
+    fn getxtimes(&self, _req: &Request, ino: INodeNo, reply: ReplyXTimes) {
         warn!("[Not Implemented] getxtimes(ino: {ino:#x?})");
         reply.error(Errno::ENOSYS);
     }


### PR DESCRIPTION
Change function signatures to accept `&self` instead of `&mut self`, except `init` and `destroy`.

This is preparation to multithreaded processing of requests with `FUSE_DEV_IOC_CLONE`.