### PR TITLE
Filesystem::release flags parameter typed

### DIFF
--- a/examples/passthrough.rs
+++ b/examples/passthrough.rs
@@ -207,7 +207,7 @@ impl Filesystem for PassthroughFs {
         _req: &Request,
         _ino: INodeNo,
         _fh: FileHandle,
-        _flags: i32,
+        _flags: OpenFlags,
         _lock_owner: Option<LockOwner>,
         _flush: bool,
         reply: ReplyEmpty,

--- a/examples/poll.rs
+++ b/examples/poll.rs
@@ -221,7 +221,7 @@ impl fuser::Filesystem for FSelFS {
         _req: &Request,
         _ino: INodeNo,
         _fh: FileHandle,
-        _flags: i32,
+        _flags: OpenFlags,
         _lock_owner: Option<LockOwner>,
         _flush: bool,
         reply: ReplyEmpty,

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1541,7 +1541,7 @@ impl Filesystem for SimpleFS {
         _req: &Request,
         _ino: INodeNo,
         _fh: FileHandle,
-        _flags: i32,
+        _flags: OpenFlags,
         _lock_owner: Option<LockOwner>,
         _flush: bool,
         reply: ReplyEmpty,
@@ -1637,7 +1637,7 @@ impl Filesystem for SimpleFS {
         _req: &Request,
         _ino: INodeNo,
         _fh: FileHandle,
-        _flags: i32,
+        _flags: OpenFlags,
         reply: ReplyEmpty,
     ) {
         if let Ok(mut attrs) = self.get_inode(_ino) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -673,7 +673,7 @@ pub trait Filesystem {
         _req: &Request,
         _ino: INodeNo,
         _fh: FileHandle,
-        _flags: i32,
+        _flags: OpenFlags,
         _lock_owner: Option<LockOwner>,
         _flush: bool,
         reply: ReplyEmpty,
@@ -750,7 +750,7 @@ pub trait Filesystem {
         _req: &Request,
         _ino: INodeNo,
         _fh: FileHandle,
-        _flags: i32,
+        _flags: OpenFlags,
         reply: ReplyEmpty,
     ) {
         reply.ok();

--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -828,9 +828,8 @@ mod op {
             FileHandle(self.arg.fh)
         }
         /// The same flags as for open.
-        /// TODO: Document what flags are valid, or remove this
-        pub(crate) fn flags(&self) -> i32 {
-            self.arg.flags
+        pub(crate) fn flags(&self) -> OpenFlags {
+            OpenFlags(self.arg.flags)
         }
         pub(crate) fn lock_owner(&self) -> Option<LockOwner> {
             if self
@@ -1163,9 +1162,8 @@ mod op {
                 None
             }
         }
-        /// TODO: Document what values this may take
-        pub(crate) fn flags(&self) -> i32 {
-            self.arg.flags
+        pub(crate) fn flags(&self) -> OpenFlags {
+            OpenFlags(self.arg.flags)
         }
     }
 


### PR DESCRIPTION
LLM:

We know that fuse_release_in.flags are the file open flags based on several pieces of evidence in the libfuse source code and documentation:

1. Code Implementation in lib/fuse_lowlevel.c

In the low-level FUSE implementation, the `_do_release` function (lines 1875-1884) explicitly maps the flags from the incoming kernel message (struct fuse_release_in) to the flags field of `struct fuse_file_info`:

```
static void _do_release(fuse_req_t req, const fuse_ino_t nodeid,
			const void *op_in, const void *in_payload)
{
	const struct fuse_release_in *arg = op_in;
	struct fuse_file_info fi;

	memset(&fi, 0, sizeof(fi));
	fi.flags = arg->flags;  // <--- arg->flags is assigned to fi.flags
	fi.fh = arg->fh;
    // ...
```

2. Definition of struct `fuse_file_info` in `include/fuse_common.h`

The definition of struct fuse_file_info (the structure passed to filesystem implementations) explicitly identifies this field as "Open flags":

```
struct fuse_file_info {
	/** Open flags.  Available in open(), release() and create() */
	int32_t flags;
    // ...
```