### PR TITLE
--feature=internal-no-mount

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
 
       - name: Build
         run: |
+          cargo check --features=internal-no-mount
           cargo build --all --all-targets
           cargo build --all --all-targets --all-features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,10 @@ abi-7-30 = ["abi-7-29"]
 abi-7-31 = ["abi-7-30"]
 abi-7-36 = ["abi-7-31"]
 abi-7-40 = ["abi-7-36"]
+# Disable mount implementations. Code will compile but won't work.
+# Can be used like this on Linux to check macOS code compiles:
+# cargo check --target x86_64-apple-darwin --features=internal-no-mount
+internal-no-mount = []
 
 [[example]]
 name = "async_hello"

--- a/src/mnt/mount_options.rs
+++ b/src/mnt/mount_options.rs
@@ -128,6 +128,7 @@ fn conflicts_with(option: &MountOption) -> Vec<MountOption> {
 }
 
 // Format option to be passed to libfuse or kernel
+#[cfg_attr(fuser_mount_impl = "internal-no-mount", expect(dead_code))]
 pub(crate) fn option_to_string(option: &MountOption) -> String {
     match option {
         MountOption::FSName(name) => format!("fsname={name}"),


### PR DESCRIPTION
```
cargo check --target x86_64-apple-darwin --features=internal-no-mount
```

on Linux to check (most) code compiles on macOS.

```
pub(crate) enum Mount { ... }
```

was chosen for additional future benefit of runtime (rather than compile time) switching between libfuse3 and pure.