### PR TITLE
AsyncFilesystem should be spawn, not block_on

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ ref-cast = "1.0.25"
 serde = { version = "1.0.102", features = ["std", "derive"], optional = true }
 smallvec = "1.6.1"
 async-trait = { version = "0.1", optional = true }
-tokio = { version = "1.48.0", features = ["rt"], optional = true }
+tokio = { version = "1.48.0", features = ["rt", "rt-multi-thread"], optional = true }
 zerocopy = { version = "0.8", features = ["derive"] }
 nix = { version = "0.30.0", features = ["fs", "user", "poll", "socket", "uio", "mount", "process", "ioctl"] }
 


### PR DESCRIPTION
Calling `block_on` makes `async` useless, preventing concurrent handling of requests.

Previous draft PR was incorrect, this is correct: mt runtime needs to be used, because we are not calling `block_on`.