### PR TITLE
Remove Session::run and BackgroundSession::new

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1071,7 +1071,7 @@ pub fn mount2<FS: Filesystem, P: AsRef<Path>>(
     options: &[MountOption],
 ) -> io::Result<()> {
     check_option_conflicts(options)?;
-    Session::new(filesystem, mountpoint.as_ref(), options).and_then(|mut se| se.run())
+    Session::new(filesystem, mountpoint.as_ref(), options).and_then(|se| se.run())
 }
 
 /// Mount the given filesystem to the given mountpoint. This function spawns


### PR DESCRIPTION
Only allow `Session::new()` and then `Session::spawn()`.

For multi-threaded processing, threads are needed, and `Session::run` does not work with it, as `Session::run` after handshake should be running in threads.

With this change, `Session::run` now accepts `self` by value, so after handshake, it can be unpacked into fields, and `Filesystem` value can be converted to `Arc<Filesystem>` to pass to threads.

Additionally, `Session::run` interface is less safe than it could be: it accepts `&mut self`, but it cannot be used more than once.

`BackgroundSession::new` remove is not strictly necessary, but it is removed because it is redundant (two APIs to perform the same operation).