### PR TITLE
Warning -> error for "auto_unmount without ..."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add `FileType` conversion from std `FileType`
 * Rename `BackgroundSession::join` to `umount_and_join`
   and change it to return `io::Result<()>` instead of panicking
+* `allow_root` or `allow_other` must be specified when using `auto_unmount`
 
 ## 0.16.0 - 2025-09-12
 * Add support for passthrough file descriptors

--- a/examples/async_hello.rs
+++ b/examples/async_hello.rs
@@ -175,5 +175,8 @@ fn main() {
     if matches.get_flag("allow-root") {
         options.push(MountOption::AllowRoot);
     }
+    if options.contains(&MountOption::AutoUnmount) && !options.contains(&MountOption::AllowRoot) {
+        options.push(MountOption::AllowOther);
+    }
     fuser::mount2(TokioAdapter::new(HelloFS), mountpoint, &options).unwrap();
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -159,5 +159,8 @@ fn main() {
     if matches.get_flag("allow-root") {
         options.push(MountOption::AllowRoot);
     }
+    if options.contains(&MountOption::AutoUnmount) && !options.contains(&MountOption::AllowRoot) {
+        options.push(MountOption::AllowOther);
+    }
     fuser::mount2(HelloFS, mountpoint, &options).unwrap();
 }

--- a/examples/null.rs
+++ b/examples/null.rs
@@ -10,5 +10,10 @@ impl Filesystem for NullFS {}
 fn main() {
     env_logger::init();
     let mountpoint = env::args_os().nth(1).unwrap();
-    fuser::mount2(NullFS, mountpoint, &[MountOption::AutoUnmount]).unwrap();
+    fuser::mount2(
+        NullFS,
+        mountpoint,
+        &[MountOption::AutoUnmount, MountOption::AllowOther],
+    )
+    .unwrap();
 }

--- a/examples/passthrough.rs
+++ b/examples/passthrough.rs
@@ -279,6 +279,9 @@ fn main() {
     if matches.get_flag("allow-root") {
         options.push(MountOption::AllowRoot);
     }
+    if options.contains(&MountOption::AutoUnmount) && !options.contains(&MountOption::AllowRoot) {
+        options.push(MountOption::AllowOther);
+    }
 
     let fs = PassthroughFs::new();
     fuser::mount2(fs, mountpoint, &options).unwrap();

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -2193,6 +2193,9 @@ fn main() {
     } else {
         eprintln!("Unable to read /etc/fuse.conf");
     }
+    if options.contains(&MountOption::AutoUnmount) && !options.contains(&MountOption::AllowRoot) {
+        options.push(MountOption::AllowOther);
+    }
 
     let data_dir = matches.get_one::<String>("data-dir").unwrap().to_string();
 


### PR DESCRIPTION
FUSE APIs is hard to use correctly, and logging is off by default, so explicit error might be better than `warn!`.