### PR TITLE
Remove trait Request

### DIFF
--- a/src/ll/mod.rs
+++ b/src/ll/mod.rs
@@ -24,7 +24,6 @@ pub(crate) use request::FileHandle;
 pub(crate) use request::INodeNo;
 pub(crate) use request::Lock;
 pub(crate) use request::Operation;
-pub(crate) use request::Request;
 pub use request::RequestId;
 pub(crate) use request::Version;
 

--- a/src/mnt/mod.rs
+++ b/src/mnt/mod.rs
@@ -119,7 +119,6 @@ fn is_mounted(fuse_device: &DevFuse) -> bool {
 #[cfg(test)]
 mod test {
     use std::ffi::CStr;
-    use std::mem::ManuallyDrop;
 
     use super::*;
 
@@ -159,6 +158,8 @@ mod test {
     #[test]
     #[cfg(not(target_os = "macos"))]
     fn mount_unmount() {
+        use std::mem::ManuallyDrop;
+
         // We use ManuallyDrop here to leak the directory on test failure.  We don't
         // want to try and clean up the directory if it's a mountpoint otherwise we'll
         // deadlock.

--- a/src/request.rs
+++ b/src/request.rs
@@ -19,7 +19,6 @@ use crate::Request;
 use crate::channel::ChannelSender;
 use crate::ll;
 use crate::ll::Errno;
-use crate::ll::Request as _;
 use crate::ll::Response;
 use crate::reply::Reply;
 use crate::reply::ReplyDirectory;

--- a/src/session.rs
+++ b/src/session.rs
@@ -37,7 +37,6 @@ use crate::channel::Channel;
 use crate::channel::ChannelSender;
 use crate::dev_fuse::DevFuse;
 use crate::ll;
-use crate::ll::Request as _;
 use crate::ll::Response;
 use crate::ll::Version;
 use crate::ll::fuse_abi as abi;


### PR DESCRIPTION
It does not do much. Implement operations directly on `AnyRequest`, and in a couple places, use header directly.