### PR TITLE
Return io::Result from Filesystem::init

### DIFF
--- a/examples/passthrough.rs
+++ b/examples/passthrough.rs
@@ -172,7 +172,7 @@ impl PassthroughFs {
 }
 
 impl Filesystem for PassthroughFs {
-    fn init(&mut self, _req: &Request, config: &mut KernelConfig) -> Result<(), Errno> {
+    fn init(&mut self, _req: &Request, config: &mut KernelConfig) -> std::io::Result<()> {
         config
             .add_capabilities(InitFlags::FUSE_PASSTHROUGH)
             .unwrap();

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -529,7 +529,7 @@ impl Filesystem for SimpleFS {
         &mut self,
         _req: &Request,
         #[allow(unused_variables)] config: &mut KernelConfig,
-    ) -> Result<(), Errno> {
+    ) -> io::Result<()> {
         if config
             .add_capabilities(InitFlags::FUSE_HANDLE_KILLPRIV)
             .is_err()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,7 +399,7 @@ pub trait Filesystem: Send + Sync + 'static {
     /// Initialize filesystem.
     /// Called before any other filesystem method.
     /// The kernel module connection can be configured using the `KernelConfig` object
-    fn init(&mut self, _req: &Request, _config: &mut KernelConfig) -> Result<(), Errno> {
+    fn init(&mut self, _req: &Request, _config: &mut KernelConfig) -> io::Result<()> {
         Ok(())
     }
 

--- a/src/ll/mod.rs
+++ b/src/ll/mod.rs
@@ -253,7 +253,8 @@ impl Errno {
             .unwrap_or(Errno::EIO)
     }
 
-    pub(crate) fn code(self) -> i32 {
+    /// Errno value.
+    pub fn code(self) -> i32 {
         self.0.get()
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -28,6 +28,7 @@ use log::info;
 use nix::unistd::Uid;
 use nix::unistd::geteuid;
 
+use crate::Errno;
 use crate::Filesystem;
 use crate::KernelConfig;
 use crate::MountOption;
@@ -277,14 +278,15 @@ impl<FS: Filesystem> Session<FS> {
             let mut config = KernelConfig::new(init.capabilities(), init.max_readahead(), v);
 
             // Call filesystem init method and give it a chance to return an error
-            if let Err(errno) = self
+            if let Err(error) = self
                 .filesystem
                 .init(Request::ref_cast(request.header()), &mut config)
             {
+                let errno = Errno::from_i32(error.raw_os_error().unwrap_or(0));
                 let response = Response::new_error(errno);
                 <ReplyRaw as Reply>::new(request.unique(), ReplySender::Channel(self.ch.sender()))
                     .send_ll(&response);
-                return Err(io::Error::from_raw_os_error(errno.code()));
+                return Err(error);
             }
 
             // Remember the ABI version supported by kernel and mark the session initialized.


### PR DESCRIPTION
Expose more information in the error if init fails.