### PR TITLE
&mut -> & of session in event loop

### DIFF
--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -1317,11 +1317,6 @@ mod op {
         #[expect(dead_code)]
         header: &'a fuse_in_header,
     }
-    impl<'a> Destroy<'a> {
-        pub(crate) fn reply(&self) -> Response<'a> {
-            Response::new_empty()
-        }
-    }
 
     /// Control device
     #[derive(Debug)]


### PR DESCRIPTION
To process session from multiple threads, we need to use the session as `&session` instead of `&mut session`, so the session can be put into `Arc` or something.

This PR extracts `event_loop` function to handle all requests except init and destroy, and handles `FUSE_DESTROY` outside of event loop.