### PR TITLE
Rename feature internal-no-mount -> macos-no-mount

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Build
         run: |
-          cargo check --features=internal-no-mount
+          cargo check --features=macos-no-mount
           cargo build --all --all-targets
           cargo build --all --all-targets --all-features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,8 +63,8 @@ abi-7-36 = []
 abi-7-40 = []
 # Disable mount implementations. Code will compile but won't work.
 # Can be used like this on Linux to check macOS code compiles:
-# cargo check --target x86_64-apple-darwin --features=internal-no-mount
-internal-no-mount = []
+# cargo check --target x86_64-apple-darwin --features=macos-no-mount
+macos-no-mount = []
 
 [[example]]
 name = "async_hello"

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     // Register rustc cfg for switching between mount implementations.
     println!(
-        "cargo::rustc-check-cfg=cfg(fuser_mount_impl, values(\"pure-rust\", \"libfuse2\", \"libfuse3\", \"internal-no-mount\"))"
+        "cargo::rustc-check-cfg=cfg(fuser_mount_impl, values(\"pure-rust\", \"libfuse2\", \"libfuse3\", \"macos-no-mount\"))"
     );
 
     let target_os =
@@ -14,8 +14,8 @@ fn main() {
     {
         println!("cargo::rustc-cfg=fuser_mount_impl=\"pure-rust\"");
     } else if target_os == "macos" {
-        if cfg!(feature = "internal-no-mount") {
-            println!("cargo::rustc-cfg=fuser_mount_impl=\"internal-no-mount\"");
+        if cfg!(feature = "macos-no-mount") {
+            println!("cargo::rustc-cfg=fuser_mount_impl=\"macos-no-mount\"");
         } else {
             pkg_config::Config::new()
                 .atleast_version("2.6.0")

--- a/src/mnt/mod.rs
+++ b/src/mnt/mod.rs
@@ -90,7 +90,7 @@ impl Mount {
             let (dev_fuse, mount) = fuse3::Mount::new(mountpoint, options)?;
             Ok((dev_fuse, Mount::Fuse3(mount)))
         }
-        #[cfg(fuser_mount_impl = "internal-no-mount")]
+        #[cfg(fuser_mount_impl = "macos-no-mount")]
         {
             let _ = (mountpoint, options);
             Err(io::Error::other(
@@ -100,7 +100,7 @@ impl Mount {
     }
 }
 
-#[cfg_attr(fuser_mount_impl = "internal-no-mount", expect(dead_code))]
+#[cfg_attr(fuser_mount_impl = "macos-no-mount", expect(dead_code))]
 fn libc_umount(mnt: &CStr) -> io::Result<()> {
     #[cfg(any(
         target_os = "macos",

--- a/src/mnt/mount_options.rs
+++ b/src/mnt/mount_options.rs
@@ -128,7 +128,7 @@ fn conflicts_with(option: &MountOption) -> Vec<MountOption> {
 }
 
 // Format option to be passed to libfuse or kernel
-#[cfg_attr(fuser_mount_impl = "internal-no-mount", expect(dead_code))]
+#[cfg_attr(fuser_mount_impl = "macos-no-mount", expect(dead_code))]
 pub(crate) fn option_to_string(option: &MountOption) -> String {
     match option {
         MountOption::FSName(name) => format!("fsname={name}"),


### PR DESCRIPTION
We would actually like to use this feature: our system is deployed to Linux, but developers often use macOS for running tests.  Being able to use subset of `fuser`, for example, `FileType` enum, would be convenient.