### PR TITLE
Option to explicitly specify libfuse2 or libfuse3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ pkg-config = "0.3.14"
 default = []
 experimental = ["async-trait", "tokio"]
 libfuse = []
+libfuse2 = ["libfuse"]
+libfuse3 = ["libfuse"]
 serializable = ["serde"]
 macfuse-4-compat = []
 # abi-7-xx feature flags are deprecated and don't do anything.

--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,13 @@ xfstests:
 pjdfs_tests: pjdfs_tests_fuse2 pjdfs_tests_fuse3 pjdfs_tests_pure
 
 pjdfs_tests_fuse2:
-	docker build --build-arg BUILD_FEATURES='--features=libfuse' -t fuser:pjdfs-2 -f pjdfs.Dockerfile .
+	docker build --build-arg BUILD_FEATURES='--features=libfuse2' -t fuser:pjdfs-2 -f pjdfs.Dockerfile .
 	# Additional permissions are needed to be able to mount FUSE
 	docker run --rm -$(INTERACTIVE)t --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined \
 	 -v "$(shell pwd)/logs:/code/logs" fuser:pjdfs-2 bash -c "cd /code/fuser && ./pjdfs.sh"
 
 pjdfs_tests_fuse3:
-	docker build --build-arg BUILD_FEATURES='--features=abi-7-31,libfuse' -t fuser:pjdfs-3 -f pjdfs.Dockerfile .
+	docker build --build-arg BUILD_FEATURES='--features=libfuse3' -t fuser:pjdfs-3 -f pjdfs.Dockerfile .
 	# Additional permissions are needed to be able to mount FUSE
 	docker run --rm -$(INTERACTIVE)t --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined \
 	 -v "$(shell pwd)/logs:/code/logs" fuser:pjdfs-3 bash -c "cd /code/fuser && ./pjdfs.sh"
@@ -60,6 +60,6 @@ test: pre mount_tests pjdfs_tests xfstests
 
 test_macos: pre
 	cargo doc --all --no-deps
-	cargo test --all --all-targets --features=libfuse -- --skip=mnt::test::mount_unmount
+	cargo test --all --all-targets --features=libfuse2 -- --skip=mnt::test::mount_unmount
 	./osx_mount_tests.sh
 	./tests/macos_pjdfs.sh

--- a/build.rs
+++ b/build.rs
@@ -25,23 +25,39 @@ fn main() {
             println!("cargo::rustc-cfg=fuser_mount_impl=\"libfuse2\"");
             println!("cargo::rustc-cfg=feature=\"macfuse-4-compat\"");
         }
+    } else if cfg!(feature = "libfuse2") {
+        configure_libfuse2().unwrap();
+    } else if cfg!(feature = "libfuse3") {
+        configure_libfuse3().unwrap();
     } else {
         // First try to link with libfuse3
-        if pkg_config::Config::new()
-            .atleast_version("3.0.0")
-            .probe("fuse3")
-            .map_err(|e| eprintln!("{e}"))
-            .is_ok()
-        {
-            println!("cargo::rustc-cfg=fuser_mount_impl=\"libfuse3\"");
-        } else {
-            // Fallback to libfuse
-            pkg_config::Config::new()
-                .atleast_version("2.6.0")
-                .probe("fuse")
-                .map_err(|e| eprintln!("{e}"))
-                .unwrap();
-            println!("cargo::rustc-cfg=fuser_mount_impl=\"libfuse2\"");
+        match configure_libfuse3() {
+            Ok(()) => {}
+            Err(e3) => {
+                // Fallback to libfuse
+                match configure_libfuse2() {
+                    Ok(()) => {}
+                    Err(e2) => {
+                        panic!("Failed to configure libfuse3 or libfuse2: {e3}; {e2}");
+                    }
+                }
+            }
         }
     }
+}
+
+fn configure_libfuse3() -> Result<(), pkg_config::Error> {
+    pkg_config::Config::new()
+        .atleast_version("3.0.0")
+        .probe("fuse3")?;
+    println!("cargo::rustc-cfg=fuser_mount_impl=\"libfuse3\"");
+    Ok(())
+}
+
+fn configure_libfuse2() -> Result<(), pkg_config::Error> {
+    pkg_config::Config::new()
+        .atleast_version("2.6.0")
+        .probe("fuse")?;
+    println!("cargo::rustc-cfg=fuser_mount_impl=\"libfuse2\"");
+    Ok(())
 }


### PR DESCRIPTION
- make builds more deterministic
- make more clear what version is used where in CI