### PR TITLE
fallocate offset/length parameters are u64

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1900,8 +1900,8 @@ impl Filesystem for SimpleFS {
         _req: &Request,
         ino: INodeNo,
         _fh: FileHandle,
-        offset: i64,
-        length: i64,
+        offset: u64,
+        length: u64,
         mode: i32,
         reply: ReplyEmpty,
     ) {
@@ -1909,13 +1909,13 @@ impl Filesystem for SimpleFS {
         match OpenOptions::new().write(true).open(path) {
             Ok(file) => {
                 unsafe {
-                    libc::fallocate64(file.into_raw_fd(), mode, offset, length);
+                    libc::fallocate64(file.into_raw_fd(), mode, offset as i64, length as i64);
                 }
                 if mode & libc::FALLOC_FL_KEEP_SIZE == 0 {
                     let mut attrs = self.get_inode(ino).unwrap();
                     attrs.last_metadata_changed = time_now();
                     attrs.last_modified = time_now();
-                    if (offset + length) as u64 > attrs.size {
+                    if offset + length > attrs.size {
                         attrs.size = (offset + length) as u64;
                     }
                     self.write_inode(&attrs);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -955,8 +955,8 @@ pub trait Filesystem: Send + Sync + 'static {
         _req: &Request,
         ino: INodeNo,
         fh: FileHandle,
-        offset: i64,
-        length: i64,
+        offset: u64,
+        length: u64,
         mode: i32,
         reply: ReplyEmpty,
     ) {

--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -628,10 +628,8 @@ pub(crate) struct fuse_notify_poll_wakeup_out {
 #[derive(Debug, FromBytes, KnownLayout, Immutable)]
 pub(crate) struct fuse_fallocate_in {
     pub(crate) fh: u64,
-    // NOTE: this field is defined as u64 in fuse_kernel.h in libfuse. However, it is treated as signed
-    pub(crate) offset: i64,
-    // NOTE: this field is defined as u64 in fuse_kernel.h in libfuse. However, it is treated as signed
-    pub(crate) length: i64,
+    pub(crate) offset: u64,
+    pub(crate) length: u64,
     // NOTE: this field is defined as u32 in fuse_kernel.h in libfuse. However, it is treated as signed
     pub(crate) mode: i32,
     pub(crate) padding: u32,

--- a/src/request.rs
+++ b/src/request.rs
@@ -465,8 +465,8 @@ impl<'a> RequestWithSender<'a> {
                     self.request_header(),
                     self.request.nodeid(),
                     x.file_handle(),
-                    x.offset(),
-                    x.len(),
+                    x.offset()?,
+                    x.len()?,
                     x.mode(),
                     self.reply(),
                 );


### PR DESCRIPTION
They are unsigned in proto, but signed in `fallocate` call, the reason must be the same as before: there's no unsigned `off_t` type in POSIX.