### PR TITLE
Assert fuser-tests only run in Docker

### DIFF
--- a/fuser-tests/src/main.rs
+++ b/fuser-tests/src/main.rs
@@ -44,6 +44,14 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn main_inner() -> anyhow::Result<()> {
+    // Validate that we're running inside Docker
+    if std::env::var("FUSER_TESTS_IN_DOCKER").as_deref() != Ok("true") {
+        bail!(
+            "FUSER_TESTS_IN_DOCKER environment variable is not set to 'true'. \
+            Tests must be run inside Docker."
+        );
+    }
+
     let FuserTests { command } = FuserTests::parse();
     match command {
         FuserCommand::Experimental => experimental::run_experimental_tests().await?,

--- a/mount_tests.Dockerfile
+++ b/mount_tests.Dockerfile
@@ -9,5 +9,6 @@ ADD rust-toolchain /code/fuser/rust-toolchain
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=$(cat /code/fuser/rust-toolchain)
 
 ENV PATH=/root/.cargo/bin:$PATH
+ENV FUSER_TESTS_IN_DOCKER=true
 
 ADD . /code/fuser/


### PR DESCRIPTION
Avoid mistake of trying to run them as is.

Eventually we may want to allow running these tests without Docker on FreeBSD or macOS, we can lift restriction then.