### PR TITLE
FUSER_TESTS_FUSERMOUNT

### DIFF
--- a/fuser-tests/src/experimental.rs
+++ b/fuser-tests/src/experimental.rs
@@ -18,6 +18,7 @@ use crate::command_utils::command_success;
 use crate::features::Feature;
 use crate::fuse_conf::fuse_conf_remove_user_allow_other;
 use crate::fuse_conf::fuse_conf_write_user_allow_other;
+use crate::fusermount::Fusermount;
 use crate::unmount::Unmount;
 use crate::users::run_as_user;
 use crate::users::run_as_user_status;
@@ -31,12 +32,14 @@ pub(crate) async fn run_experimental_tests() -> anyhow::Result<()> {
         &[Feature::Experimental],
         "without libfuse, with fusermount",
         Unmount::Manual,
+        Fusermount::False,
     )
     .await?;
     run_test(
         &[Feature::Experimental],
         "without libfuse, with fusermount",
         Unmount::Auto,
+        Fusermount::Fusermount,
     )
     .await?;
     test_no_user_allow_other(&[], "without libfuse, with fusermount").await?;
@@ -49,12 +52,14 @@ pub(crate) async fn run_experimental_tests() -> anyhow::Result<()> {
         &[Feature::Experimental],
         "without libfuse, with fusermount3",
         Unmount::Manual,
+        Fusermount::False,
     )
     .await?;
     run_test(
         &[Feature::Experimental],
         "without libfuse, with fusermount3",
         Unmount::Auto,
+        Fusermount::Fusermount3,
     )
     .await?;
     test_no_user_allow_other(&[], "without libfuse, with fusermount3").await?;
@@ -67,12 +72,14 @@ pub(crate) async fn run_experimental_tests() -> anyhow::Result<()> {
         &[Feature::Libfuse2, Feature::Experimental],
         "with libfuse",
         Unmount::Manual,
+        Fusermount::False,
     )
     .await?;
     run_test(
         &[Feature::Libfuse2, Feature::Experimental],
         "with libfuse",
         Unmount::Auto,
+        Fusermount::Fusermount,
     )
     .await?;
 
@@ -84,12 +91,14 @@ pub(crate) async fn run_experimental_tests() -> anyhow::Result<()> {
         &[Feature::Libfuse3, Feature::Experimental],
         "with libfuse3",
         Unmount::Manual,
+        Fusermount::False,
     )
     .await?;
     run_test(
         &[Feature::Libfuse3, Feature::Experimental],
         "with libfuse3",
         Unmount::Auto,
+        Fusermount::Fusermount3,
     )
     .await?;
 
@@ -99,7 +108,12 @@ pub(crate) async fn run_experimental_tests() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn run_test(features: &[Feature], description: &str, unmount: Unmount) -> anyhow::Result<()> {
+async fn run_test(
+    features: &[Feature],
+    description: &str,
+    unmount: Unmount,
+    fusermount: Fusermount,
+) -> anyhow::Result<()> {
     let unmount_desc = match unmount {
         Unmount::Auto => "--auto-unmount",
         Unmount::Manual => "",
@@ -122,6 +136,7 @@ async fn run_test(features: &[Feature], description: &str, unmount: Unmount) -> 
 
     let mut fuse_process = Command::new(&async_hello_exe)
         .args(&run_args)
+        .env(Fusermount::ENV_VAR, fusermount.as_path())
         .kill_on_drop(true)
         .spawn()
         .context("Failed to start async_hello example")?;

--- a/fuser-tests/src/fusermount.rs
+++ b/fuser-tests/src/fusermount.rs
@@ -1,0 +1,19 @@
+/// Override path to `fusermount` for running tests.
+pub(crate) enum Fusermount {
+    Fusermount,
+    Fusermount3,
+    /// `/bin/false`.
+    False,
+}
+
+impl Fusermount {
+    pub(crate) const ENV_VAR: &str = "FUSER_TESTS_FUSERMOUNT";
+
+    pub(crate) fn as_path(&self) -> &'static str {
+        match self {
+            Fusermount::Fusermount => "fusermount",
+            Fusermount::Fusermount3 => "fusermount3",
+            Fusermount::False => "/bin/false",
+        }
+    }
+}

--- a/fuser-tests/src/main.rs
+++ b/fuser-tests/src/main.rs
@@ -7,6 +7,7 @@ mod command_utils;
 mod experimental;
 mod features;
 mod fuse_conf;
+mod fusermount;
 mod mount;
 mod simple;
 mod unmount;

--- a/fuser-tests/src/simple.rs
+++ b/fuser-tests/src/simple.rs
@@ -12,6 +12,7 @@ use crate::ansi::green;
 use crate::cargo::cargo_build_example;
 use crate::command_utils::command_output;
 use crate::command_utils::command_success;
+use crate::fusermount::Fusermount;
 
 pub(crate) async fn run_simple_tests() -> anyhow::Result<()> {
     // Create temp directories
@@ -33,6 +34,7 @@ pub(crate) async fn run_simple_tests() -> anyhow::Result<()> {
             "--mount-point",
             mount_dir.path().to_str().unwrap(),
         ])
+        .env(Fusermount::ENV_VAR, Fusermount::False.as_path())
         .kill_on_drop(true)
         .spawn()
         .context("Failed to start simple example")?;

--- a/src/mnt/fuse_pure.rs
+++ b/src/mnt/fuse_pure.rs
@@ -3,6 +3,7 @@
 //! This is a small set of bindings that are required to mount/unmount FUSE filesystems and
 //! open/close a fd to the FUSE kernel driver.
 
+use std::env;
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::ffi::OsStr;
@@ -152,6 +153,13 @@ fn fuse_unmount_pure(mountpoint: &CStr) {
 }
 
 fn detect_fusermount_bin() -> String {
+    if let Some(fusermount) = env::var_os("FUSER_TESTS_FUSERMOUNT") {
+        return fusermount
+            .to_str()
+            .expect("FUSER_TESTS_FUSERMOUNT is not UTF-8")
+            .to_owned();
+    }
+
     for name in [
         FUSERMOUNT3_BIN.to_string(),
         FUSERMOUNT_BIN.to_string(),


### PR DESCRIPTION
Env var that specifies path to `fusermount`.

The idea is: we can build image once with all libraries and binaries with it, rather than install/uninstall in every run.

For libraries we have features `libfuse2` and `libfuse3`, this adds a way to pick `fusermount`.

I chose env var for simplicity (and simpler build caches), but it can be a compile-time option (e.g. a feature of `--cfg` flag).