### PR TITLE
struct Config instead of Vec<MountOption>

### DIFF
--- a/examples/async_hello.rs
+++ b/examples/async_hello.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use std::time::UNIX_EPOCH;
 
 use clap::Parser;
+use fuser::Config;
 use fuser::Errno;
 use fuser::FileAttr;
 use fuser::FileHandle;
@@ -160,15 +161,18 @@ fn main() {
     let args = Args::parse();
     env_logger::init();
 
-    let mut options = vec![MountOption::RO, MountOption::FSName("hello".to_string())];
+    let mut cfg = Config::default();
+    cfg.mount_options = vec![MountOption::RO, MountOption::FSName("hello".to_string())];
     if args.auto_unmount {
-        options.push(MountOption::AutoUnmount);
+        cfg.mount_options.push(MountOption::AutoUnmount);
     }
     if args.allow_root {
-        options.push(MountOption::AllowRoot);
+        cfg.mount_options.push(MountOption::AllowRoot);
     }
-    if options.contains(&MountOption::AutoUnmount) && !options.contains(&MountOption::AllowRoot) {
-        options.push(MountOption::AllowOther);
+    if cfg.mount_options.contains(&MountOption::AutoUnmount)
+        && !cfg.mount_options.contains(&MountOption::AllowRoot)
+    {
+        cfg.mount_options.push(MountOption::AllowOther);
     }
-    fuser::mount2(TokioAdapter::new(HelloFS), &args.mount_point, &options).unwrap();
+    fuser::mount2(TokioAdapter::new(HelloFS), &args.mount_point, &cfg).unwrap();
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use std::time::UNIX_EPOCH;
 
 use clap::Parser;
+use fuser::Config;
 use fuser::Errno;
 use fuser::FileAttr;
 use fuser::FileHandle;
@@ -144,15 +145,18 @@ fn main() {
     let args = Args::parse();
     env_logger::init();
 
-    let mut options = vec![MountOption::RO, MountOption::FSName("hello".to_string())];
+    let mut cfg = Config::default();
+    cfg.mount_options = vec![MountOption::RO, MountOption::FSName("hello".to_string())];
     if args.auto_unmount {
-        options.push(MountOption::AutoUnmount);
+        cfg.mount_options.push(MountOption::AutoUnmount);
     }
     if args.allow_root {
-        options.push(MountOption::AllowRoot);
+        cfg.mount_options.push(MountOption::AllowRoot);
     }
-    if options.contains(&MountOption::AutoUnmount) && !options.contains(&MountOption::AllowRoot) {
-        options.push(MountOption::AllowOther);
+    if cfg.mount_options.contains(&MountOption::AutoUnmount)
+        && !cfg.mount_options.contains(&MountOption::AllowRoot)
+    {
+        cfg.mount_options.push(MountOption::AllowOther);
     }
-    fuser::mount2(HelloFS, &args.mount_point, &options).unwrap();
+    fuser::mount2(HelloFS, &args.mount_point, &cfg).unwrap();
 }

--- a/examples/ioctl.rs
+++ b/examples/ioctl.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use std::time::UNIX_EPOCH;
 
 use clap::Parser;
+use fuser::Config;
 use fuser::Errno;
 use fuser::FileAttr;
 use fuser::FileHandle;
@@ -205,14 +206,16 @@ fn main() {
     let args = Args::parse();
     env_logger::init();
 
-    let mut options = vec![MountOption::FSName("fioc".to_string())];
+    let mut cfg = Config::default();
+
+    cfg.mount_options = vec![MountOption::FSName("fioc".to_string())];
     if args.auto_unmount {
-        options.push(MountOption::AutoUnmount);
+        cfg.mount_options.push(MountOption::AutoUnmount);
     }
     if args.allow_root {
-        options.push(MountOption::AllowRoot);
+        cfg.mount_options.push(MountOption::AllowRoot);
     }
 
     let fs = FiocFS::new();
-    fuser::mount2(fs, &args.mount_point, &options).unwrap();
+    fuser::mount2(fs, &args.mount_point, &cfg).unwrap();
 }

--- a/examples/notify_inval_entry.rs
+++ b/examples/notify_inval_entry.rs
@@ -17,6 +17,7 @@ use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
 use clap::Parser;
+use fuser::Config;
 use fuser::Errno;
 use fuser::FileAttr;
 use fuser::FileHandle;
@@ -161,7 +162,8 @@ struct Options {
 
 fn main() {
     let opts = Options::parse();
-    let options = vec![MountOption::RO, MountOption::FSName("clock".to_string())];
+    let mut cfg = Config::default();
+    cfg.mount_options = vec![MountOption::RO, MountOption::FSName("clock".to_string())];
     let fname = Arc::new(Mutex::new(now_filename()));
     let lookup_cnt = Box::leak(Box::new(AtomicU64::new(0)));
     let fs = ClockFS {
@@ -170,7 +172,7 @@ fn main() {
         timeout: Duration::from_secs_f32(opts.timeout),
     };
 
-    let session = fuser::Session::new(fs, opts.mount_point, &options).unwrap();
+    let session = fuser::Session::new(fs, opts.mount_point, &cfg).unwrap();
     let notifier = session.notifier();
     let _bg = session.spawn().unwrap();
 

--- a/examples/notify_inval_inode.rs
+++ b/examples/notify_inval_inode.rs
@@ -17,6 +17,7 @@ use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
 use clap::Parser;
+use fuser::Config;
 use fuser::Errno;
 use fuser::FileAttr;
 use fuser::FileHandle;
@@ -204,7 +205,8 @@ struct Options {
 
 fn main() {
     let opts = Options::parse();
-    let options = vec![MountOption::RO, MountOption::FSName("clock".to_string())];
+    let mut cfg = Config::default();
+    cfg.mount_options = vec![MountOption::RO, MountOption::FSName("clock".to_string())];
     let fdata = Arc::new(Mutex::new(now_string()));
     let lookup_cnt = Box::leak(Box::new(AtomicU64::new(0)));
     let fs = ClockFS {
@@ -212,7 +214,7 @@ fn main() {
         lookup_cnt,
     };
 
-    let session = fuser::Session::new(fs, opts.mount_point, &options).unwrap();
+    let session = fuser::Session::new(fs, opts.mount_point, &cfg).unwrap();
     let notifier = session.notifier();
     let _bg = session.spawn().unwrap();
 

--- a/examples/null.rs
+++ b/examples/null.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use clap::Parser;
+use fuser::Config;
 use fuser::Filesystem;
 use fuser::MountOption;
 
@@ -18,10 +19,7 @@ impl Filesystem for NullFS {}
 fn main() {
     let args = Args::parse();
     env_logger::init();
-    fuser::mount2(
-        NullFS,
-        &args.mount_point,
-        &[MountOption::AutoUnmount, MountOption::AllowOther],
-    )
-    .unwrap();
+    let mut cfg = Config::default();
+    cfg.mount_options = vec![MountOption::AutoUnmount, MountOption::AllowOther];
+    fuser::mount2(NullFS, &args.mount_point, &cfg).unwrap();
 }

--- a/examples/passthrough.rs
+++ b/examples/passthrough.rs
@@ -11,6 +11,7 @@ use std::time::UNIX_EPOCH;
 
 use clap::Parser;
 use fuser::BackingId;
+use fuser::Config;
 use fuser::Errno;
 use fuser::FileAttr;
 use fuser::FileHandle;
@@ -263,17 +264,20 @@ fn main() {
     let args = Args::parse();
     env_logger::init();
 
-    let mut options = vec![MountOption::FSName("passthrough".to_string())];
+    let mut cfg = Config::default();
+    cfg.mount_options = vec![MountOption::FSName("passthrough".to_string())];
     if args.auto_unmount {
-        options.push(MountOption::AutoUnmount);
+        cfg.mount_options.push(MountOption::AutoUnmount);
     }
     if args.allow_root {
-        options.push(MountOption::AllowRoot);
+        cfg.mount_options.push(MountOption::AllowRoot);
     }
-    if options.contains(&MountOption::AutoUnmount) && !options.contains(&MountOption::AllowRoot) {
-        options.push(MountOption::AllowOther);
+    if cfg.mount_options.contains(&MountOption::AutoUnmount)
+        && !cfg.mount_options.contains(&MountOption::AllowRoot)
+    {
+        cfg.mount_options.push(MountOption::AllowOther);
     }
 
     let fs = PassthroughFs::new();
-    fuser::mount2(fs, &args.mount_point, &options).unwrap();
+    fuser::mount2(fs, &args.mount_point, &cfg).unwrap();
 }

--- a/examples/poll.rs
+++ b/examples/poll.rs
@@ -19,6 +19,7 @@ use std::time::Duration;
 use std::time::UNIX_EPOCH;
 
 use clap::Parser;
+use fuser::Config;
 use fuser::Errno;
 use parking_lot::Mutex;
 use parking_lot::MutexGuard;
@@ -361,7 +362,8 @@ fn producer(data: &Mutex<FSelData>, notifier: &fuser::Notifier) {
 fn main() {
     let args = Args::parse();
 
-    let options = vec![MountOption::RO, MountOption::FSName("fsel".to_string())];
+    let mut cfg = Config::default();
+    cfg.mount_options = vec![MountOption::RO, MountOption::FSName("fsel".to_string())];
     let data = Arc::new(Mutex::new(FSelData {
         bytecnt: [0; NUMFILES as usize],
         open_mask: 0,
@@ -369,7 +371,7 @@ fn main() {
     }));
     let fs = FSelFS { data: data.clone() };
 
-    let session = fuser::Session::new(fs, &args.mount_point, &options).unwrap();
+    let session = fuser::Session::new(fs, &args.mount_point, &cfg).unwrap();
     let bg = session.spawn().unwrap();
 
     producer(&data, &bg.notifier());

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -30,6 +30,7 @@ use std::time::UNIX_EPOCH;
 use clap::Parser;
 use fuser::AccessFlags;
 use fuser::BsdFileFlags;
+use fuser::Config;
 use fuser::Errno;
 use fuser::FileHandle;
 use fuser::Filesystem;
@@ -2177,10 +2178,13 @@ fn main() {
         options.push(MountOption::AllowOther);
     }
 
+    let mut cfg = Config::default();
+    cfg.mount_options = options;
+
     let result = fuser::mount2(
         SimpleFS::new(args.data_dir, args.direct_io, args.suid),
         &args.mount_point,
-        &options,
+        &cfg,
     );
     if let Err(e) = result {
         // Return a special error code for permission denied, which usually indicates that


### PR DESCRIPTION
It seems like key-value is more appropriate configuration format than list of options.

For example, configurations like "allow root" or "allow other" could be a field `config.acl` rather than one of `MountOption::{AllowOther,AllowRoot}`.

Similarly, the number of threads for concurrent processing seems like should be integer configuration option.

libfuse has `fuse_loop_config` and `fuse_cmdline_opts`, so I chose `Config`.

For now this PR just introduces `struct Config` without converting some of the options to fields of that struct.