### PR TITLE
Remove Filesystem::destroy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,10 +408,6 @@ pub trait Filesystem: Send + Sync + 'static {
         Ok(())
     }
 
-    /// Clean up filesystem.
-    /// Called on filesystem exit.
-    fn destroy(&mut self) {}
-
     /// Look up a directory entry by name and get its attributes.
     fn lookup(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
         warn!("[Not Implemented] lookup(parent: {parent:#x?}, name {name:?})");

--- a/src/session.rs
+++ b/src/session.rs
@@ -171,10 +171,6 @@ impl<FS: Filesystem> Session<FS> {
 
         let ret = self.event_loop();
 
-        if let Some(mut filesystem) = self.filesystem.take() {
-            filesystem.destroy();
-        }
-
         match ret {
             Err(e) => Err(e),
             Ok(None) => Ok(()),
@@ -403,10 +399,6 @@ impl SessionUnmounter {
 
 impl<FS: Filesystem> Drop for Session<FS> {
     fn drop(&mut self) {
-        if let Some(mut filesystem) = self.filesystem.take() {
-            filesystem.destroy();
-        }
-
         if let Some(mount) = std::mem::take(&mut *self.mount.lock()) {
             if let Err(e) = mount.umount() {
                 warn!("Unmount failed: {e}");


### PR DESCRIPTION
We have RAII, so it is not very helpful for cleanup, unlike C.

In theory, `destroy` is called before fuse destroy reply is sent, but I cannot find a situation where it could be necessary.

This specific behavior of `destroy` somewhat complicates implementation of multithreading, so I propose just ditch it for time being, and reintroduce later if needed.

Alternative to this PR is #621 — this is complications I'm talking about.