### PR TITLE
Remove Drop for Session

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -97,7 +97,7 @@ impl<'a> RequestWithSender<'a> {
             }
         }
 
-        let Some(filesystem) = &se.filesystem else {
+        let Some(filesystem) = &se.filesystem.fs else {
             // This is handled before dispatch call.
             error!("bug: filesystem must be initialized in dispatch_req");
             return Err(Errno::EIO);


### PR DESCRIPTION
To spawn threads for session we likely need to destructure `Session` into fields, modify some, e.g. filesystem to `Arc` and file descriptor clone or ioctl-clone.

Destructure does not work if there's drop, so remove `Drop`.

Alternative to this PR is #620 — I prefer that PR.