### PR TITLE
Fix read flags

### DIFF
--- a/examples/async_hello.rs
+++ b/examples/async_hello.rs
@@ -11,7 +11,7 @@ use fuser::FileType;
 use fuser::INodeNo;
 use fuser::LockOwner;
 use fuser::MountOption;
-use fuser::ReadFlags;
+use fuser::OpenFlags;
 use fuser::experimental;
 use fuser::experimental::AsyncFilesystem;
 use fuser::experimental::DirEntListBuilder;
@@ -116,7 +116,7 @@ impl AsyncFilesystem for HelloFS {
         _file_handle: FileHandle,
         offset: u64,
         _size: u32,
-        _flags: ReadFlags,
+        _flags: OpenFlags,
         _lock: Option<LockOwner>,
         out_data: &mut Vec<u8>,
     ) -> experimental::Result<()> {

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -12,7 +12,7 @@ use fuser::Filesystem;
 use fuser::INodeNo;
 use fuser::LockOwner;
 use fuser::MountOption;
-use fuser::ReadFlags;
+use fuser::OpenFlags;
 use fuser::ReplyAttr;
 use fuser::ReplyData;
 use fuser::ReplyDirectory;
@@ -100,7 +100,7 @@ impl Filesystem for HelloFS {
         _fh: FileHandle,
         offset: u64,
         _size: u32,
-        _flags: ReadFlags,
+        _flags: OpenFlags,
         _lock_owner: Option<LockOwner>,
         reply: ReplyData,
     ) {

--- a/examples/ioctl.rs
+++ b/examples/ioctl.rs
@@ -17,7 +17,7 @@ use fuser::INodeNo;
 use fuser::IoctlFlags;
 use fuser::LockOwner;
 use fuser::MountOption;
-use fuser::ReadFlags;
+use fuser::OpenFlags;
 use fuser::ReplyAttr;
 use fuser::ReplyData;
 use fuser::ReplyDirectory;
@@ -126,7 +126,7 @@ impl Filesystem for FiocFS {
         _fh: FileHandle,
         offset: u64,
         _size: u32,
-        _flags: ReadFlags,
+        _flags: OpenFlags,
         _lock_owner: Option<LockOwner>,
         reply: ReplyData,
     ) {

--- a/examples/notify_inval_inode.rs
+++ b/examples/notify_inval_inode.rs
@@ -28,7 +28,6 @@ use fuser::LockOwner;
 use fuser::MountOption;
 use fuser::OpenAccMode;
 use fuser::OpenFlags;
-use fuser::ReadFlags;
 use fuser::ReplyAttr;
 use fuser::ReplyData;
 use fuser::ReplyDirectory;
@@ -156,7 +155,7 @@ impl Filesystem for ClockFS {
         _fh: FileHandle,
         offset: u64,
         size: u32,
-        _flags: ReadFlags,
+        _flags: OpenFlags,
         _lock_owner: Option<LockOwner>,
         reply: ReplyData,
     ) {

--- a/examples/poll.rs
+++ b/examples/poll.rs
@@ -42,7 +42,6 @@ use fuser::PollEvents;
 use fuser::PollFlags;
 use fuser::PollHandle;
 use fuser::PollNotifier;
-use fuser::ReadFlags;
 use fuser::ReplyAttr;
 use fuser::ReplyData;
 use fuser::ReplyDirectory;
@@ -252,7 +251,7 @@ impl fuser::Filesystem for FSelFS {
         fh: FileHandle,
         _offset: u64,
         size: u32,
-        _flags: ReadFlags,
+        _flags: OpenFlags,
         _lock_owner: Option<LockOwner>,
         reply: ReplyData,
     ) {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -41,7 +41,6 @@ use fuser::LockOwner;
 use fuser::MountOption;
 use fuser::OpenAccMode;
 use fuser::OpenFlags;
-use fuser::ReadFlags;
 use fuser::RenameFlags;
 use fuser::ReplyAttr;
 use fuser::ReplyCreate;
@@ -1473,7 +1472,7 @@ impl Filesystem for SimpleFS {
         fh: FileHandle,
         offset: u64,
         size: u32,
-        _flags: ReadFlags,
+        _flags: OpenFlags,
         _lock_owner: Option<LockOwner>,
         reply: ReplyData,
     ) {

--- a/src/experimental.rs
+++ b/src/experimental.rs
@@ -12,7 +12,7 @@ use crate::Filesystem;
 use crate::Generation;
 use crate::INodeNo;
 use crate::LockOwner;
-use crate::ReadFlags;
+use crate::OpenFlags;
 use crate::ReplyAttr;
 use crate::ReplyData;
 use crate::ReplyDirectory;
@@ -175,7 +175,7 @@ impl<T: AsyncFilesystem + Send + Sync + 'static> Filesystem for TokioAdapter<T> 
         fh: FileHandle,
         offset: u64,
         size: u32,
-        flags: ReadFlags,
+        flags: OpenFlags,
         lock_owner: Option<LockOwner>,
         reply: ReplyData,
     ) {
@@ -239,7 +239,7 @@ pub trait AsyncFilesystem: Send + Sync + 'static {
         file_handle: FileHandle,
         offset: u64,
         size: u32,
-        flags: ReadFlags,
+        flags: OpenFlags,
         lock: Option<LockOwner>,
         out_data: &mut Vec<u8>,
     ) -> Result<()>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,6 @@ pub use crate::ll::flags::fopen_flags::FopenFlags;
 pub use crate::ll::flags::init_flags::InitFlags;
 pub use crate::ll::flags::ioctl_flags::IoctlFlags;
 pub use crate::ll::flags::poll_flags::PollFlags;
-pub use crate::ll::flags::read_flags::ReadFlags;
 pub use crate::ll::flags::write_flags::WriteFlags;
 pub use crate::ll::fuse_abi::consts;
 pub use crate::ll::request::FileHandle;
@@ -597,7 +596,7 @@ pub trait Filesystem: Send + Sync + 'static {
         fh: FileHandle,
         offset: u64,
         size: u32,
-        flags: ReadFlags,
+        flags: OpenFlags,
         lock_owner: Option<LockOwner>,
         reply: ReplyData,
     ) {

--- a/src/ll/flags/read_flags.rs
+++ b/src/ll/flags/read_flags.rs
@@ -3,7 +3,7 @@ use bitflags::bitflags;
 bitflags! {
     /// Read flags.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct ReadFlags: u32 {
+    pub(crate) struct ReadFlags: u32 {
         /// Indicates that `fuse_read_in.lock_owner` contains lock owner.
         /// Users typically do not need to check this flag.
         const FUSE_READ_LOCKOWNER = 1 << 1;

--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -403,7 +403,9 @@ pub(crate) struct fuse_read_in {
     pub(crate) size: u32,
     pub(crate) read_flags: u32,
     pub(crate) lock_owner: u64,
-    pub(crate) flags: u32,
+    // NOTE: this field is defined as u32 in fuse_kernel.h in libfuse. However, it is then cast
+    // to an i32 when invoking the filesystem's read method
+    pub(crate) flags: i32,
     pub(crate) padding: u32,
 }
 

--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -694,15 +694,18 @@ mod op {
         }
         /// Only supported with ABI >= 7.9
         pub(crate) fn lock_owner(&self) -> Option<LockOwner> {
-            if self.flags().contains(ReadFlags::FUSE_READ_LOCKOWNER) {
+            if self.read_flags().contains(ReadFlags::FUSE_READ_LOCKOWNER) {
                 Some(LockOwner(self.arg.lock_owner))
             } else {
                 None
             }
         }
         /// The file flags, such as `O_SYNC`. Only supported with ABI >= 7.9
-        pub(crate) fn flags(&self) -> ReadFlags {
-            ReadFlags::from_bits_retain(self.arg.flags)
+        pub(crate) fn flags(&self) -> OpenFlags {
+            OpenFlags(self.arg.flags)
+        }
+        pub(crate) fn read_flags(&self) -> ReadFlags {
+            ReadFlags::from_bits_retain(self.arg.read_flags)
         }
     }
 


### PR DESCRIPTION
Pick fix from #593, apply differently: do not expose `ReadFlags` to users, and make `ReadFlags` private instead.

Fixes: #593