### PR TITLE
Multiple event loops

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,6 +1,10 @@
 mod common;
 
+use std::cell::Cell;
 use std::ffi::OsStr;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 use std::time::UNIX_EPOCH;
 
@@ -22,11 +26,19 @@ use fuser::Request;
 
 use crate::common::args::CommonArgs;
 
+thread_local! {
+    static THREAD_INDEX: Cell<Option<usize>> = const { Cell::new(None) };
+}
+
 #[derive(Parser)]
 #[command(version, author = "Christopher Berner")]
 struct Args {
     #[clap(flatten)]
     common_args: CommonArgs,
+
+    /// Number of threads to use
+    #[clap(long, default_value_t = 1)]
+    n_threads: usize,
 }
 
 const TTL: Duration = Duration::from_secs(1); // 1 second
@@ -69,12 +81,49 @@ const HELLO_TXT_ATTR: FileAttr = FileAttr {
     blksize: 512,
 };
 
-struct HelloFS;
+const STATS_PER_THREAD_ATTR: FileAttr = FileAttr {
+    ino: INodeNo(3),
+    size: 0, // Dynamic content, size will be determined at read time
+    blocks: 0,
+    atime: UNIX_EPOCH,
+    mtime: UNIX_EPOCH,
+    ctime: UNIX_EPOCH,
+    crtime: UNIX_EPOCH,
+    kind: FileType::RegularFile,
+    perm: 0o444,
+    nlink: 1,
+    uid: 501,
+    gid: 20,
+    rdev: 0,
+    flags: 0,
+    blksize: 512,
+};
+
+struct HelloFS {
+    reads_per_thread: Vec<AtomicU64>,
+    next_thread_index: AtomicUsize,
+}
+
+impl HelloFS {
+    fn stats_content(&self) -> String {
+        let mut content = String::new();
+        for count in &self.reads_per_thread {
+            content.push_str(&format!("{}\n", count.load(Ordering::Relaxed)));
+        }
+        content
+    }
+}
 
 impl Filesystem for HelloFS {
     fn lookup(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
         if u64::from(parent) == 1 && name.to_str() == Some("hello.txt") {
             reply.entry(&TTL, &HELLO_TXT_ATTR, fuser::Generation(0));
+        } else if u64::from(parent) == 1 && name.to_str() == Some("stats-per-thread") {
+            let content = self.stats_content();
+            let mut attr = STATS_PER_THREAD_ATTR;
+            attr.size = content.len() as u64;
+            // Must use zero TTL, otherwise previous size is cached.
+            reply.entry(&Duration::ZERO, &attr, fuser::Generation(0));
         } else {
             reply.error(Errno::ENOENT);
         }
@@ -84,6 +133,13 @@ impl Filesystem for HelloFS {
         match u64::from(ino) {
             1 => reply.attr(&TTL, &HELLO_DIR_ATTR),
             2 => reply.attr(&TTL, &HELLO_TXT_ATTR),
+            3 => {
+                let content = self.stats_content();
+                let mut attr = STATS_PER_THREAD_ATTR;
+                attr.size = content.len() as u64;
+                // Must use zero TTL, otherwise previous size is cached.
+                reply.attr(&Duration::ZERO, &attr);
+            }
             _ => reply.error(Errno::ENOENT),
         }
     }
@@ -99,8 +155,27 @@ impl Filesystem for HelloFS {
         _lock_owner: Option<LockOwner>,
         reply: ReplyData,
     ) {
+        let thread_idx = THREAD_INDEX.with(|idx| match idx.get() {
+            Some(i) => i,
+            None => {
+                let new_idx = self.next_thread_index.fetch_add(1, Ordering::SeqCst);
+                idx.set(Some(new_idx));
+                new_idx
+            }
+        });
+        if thread_idx < self.reads_per_thread.len() {
+            self.reads_per_thread[thread_idx].fetch_add(1, Ordering::Relaxed);
+        }
         if u64::from(ino) == 2 {
             reply.data(&HELLO_TXT_CONTENT.as_bytes()[offset as usize..]);
+        } else if u64::from(ino) == 3 {
+            let content = self.stats_content();
+            let bytes = content.as_bytes();
+            if offset as usize >= bytes.len() {
+                reply.data(&[]);
+            } else {
+                reply.data(&bytes[offset as usize..]);
+            }
         } else {
             reply.error(Errno::ENOENT);
         }
@@ -123,6 +198,7 @@ impl Filesystem for HelloFS {
             (1, FileType::Directory, "."),
             (1, FileType::Directory, ".."),
             (2, FileType::RegularFile, "hello.txt"),
+            (3, FileType::RegularFile, "stats-per-thread"),
         ];
 
         for (i, entry) in entries.into_iter().enumerate().skip(offset as usize) {
@@ -142,5 +218,10 @@ fn main() {
     let mut cfg = args.common_args.config();
     cfg.mount_options
         .extend([MountOption::RO, MountOption::FSName("hello".to_string())]);
-    fuser::mount2(HelloFS, &args.common_args.mount_point, &cfg).unwrap();
+    cfg.n_threads = Some(args.n_threads);
+    let fs = HelloFS {
+        reads_per_thread: (0..args.n_threads).map(|_| AtomicU64::new(0)).collect(),
+        next_thread_index: AtomicUsize::new(0),
+    };
+    fuser::mount2(fs, &args.common_args.mount_point, &cfg).unwrap();
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -94,6 +94,9 @@ struct Args {
     #[clap(long)]
     suid: bool,
 
+    #[clap(long, default_value_t = 1)]
+    n_threads: usize,
+
     /// Sets the level of verbosity
     #[clap(short, action = clap::ArgAction::Count)]
     v: u8,
@@ -2181,6 +2184,7 @@ fn main() {
         cfg.acl = SessionACL::All;
     }
 
+    cfg.n_threads = Some(args.n_threads);
     let result = fuser::mount2(
         SimpleFS::new(args.data_dir, args.direct_io, args.suid),
         &args.mount_point,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -9,7 +9,7 @@ use crate::dev_fuse::DevFuse;
 use crate::passthrough::BackingId;
 
 /// A raw communication channel to the FUSE kernel driver
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Channel(Arc<DevFuse>);
 
 impl AsFd for Channel {

--- a/src/mnt/mount_options.rs
+++ b/src/mnt/mount_options.rs
@@ -13,6 +13,8 @@ pub struct Config {
     pub mount_options: Vec<MountOption>,
     /// Who can access the filesystem.
     pub acl: SessionACL,
+    /// Number of event loop threads. If unspecified, one thread is used.
+    pub n_threads: Option<usize>,
 }
 
 /// Mount options accepted by the FUSE filesystem type
@@ -207,6 +209,7 @@ pub(crate) fn parse_options_from_args(args: &[&OsStr]) -> io::Result<Config> {
     Ok(Config {
         mount_options: out,
         acl,
+        n_threads: None,
     })
 }
 


### PR DESCRIPTION
For now just add an option to spawn multiple threads. No `fuse_dev_ioc_clone` yet.

Before adding that ioctl, we need to write automated tests for multithreading, e.g. that different threads actually process messages. Some refactoring is desirable for that.

For now I tested by running with debug logs, which contain different thread names:

```
[2026-02-01T22:09:00.875147750Z DEBUG fuser::request] FUSE(7998) ino 0x000000000000044e RELEASE fh FileHandle(4611686018427388903), flags 0x8801, flush false, lock owner None thread=fuser-8
```

Note libfuse can run in multiple threads too in similar way, without ioctl clone fd.