### PR TITLE
su wrappers in tests

### DIFF
--- a/fuser-tests/src/experimental.rs
+++ b/fuser-tests/src/experimental.rs
@@ -18,7 +18,9 @@ use crate::libfuse::Libfuse;
 use crate::mount_util::wait_for_fuse_mount;
 use crate::unmount::Unmount;
 use crate::unmount::kill_and_unmount;
-use crate::users::run_as_user;
+use crate::users::assert_can_read_as_user;
+use crate::users::assert_cannot_read_as_user;
+use crate::users::mktempdir_as_user;
 use crate::users::run_as_user_status;
 
 pub(crate) async fn run_experimental_tests(libfuse: Libfuse) -> anyhow::Result<()> {
@@ -146,8 +148,8 @@ async fn test_no_user_allow_other(features: &[Feature], libfuse: &Libfuse) -> an
 
     fuse_conf_remove_user_allow_other().await?;
 
-    let mount_dir = run_as_user("fusertestnoallow", "mktemp --directory").await?;
-    let data_dir = run_as_user("fusertestnoallow", "mktemp --directory").await?;
+    let mount_dir = mktempdir_as_user("fusertestnoallow").await?;
+    let data_dir = mktempdir_as_user("fusertestnoallow").await?;
 
     eprintln!("Mount dir: {}", mount_dir);
     eprintln!("Data dir: {}", data_dir);
@@ -188,7 +190,7 @@ async fn test_no_user_allow_other(features: &[Feature], libfuse: &Libfuse) -> an
 async fn run_allow_root_test() -> anyhow::Result<()> {
     eprintln!("\n=== Running run_allow_root_test ===");
 
-    let mount_dir = run_as_user("fusertest1", "mktemp --directory").await?;
+    let mount_dir = mktempdir_as_user("fusertest1").await?;
     eprintln!("Mount dir: {}", mount_dir);
 
     let async_hello_exe =
@@ -206,28 +208,16 @@ async fn run_allow_root_test() -> anyhow::Result<()> {
 
     // Test: root can read
     let hello_path = format!("{}/hello.txt", mount_dir);
-    let root_content = run_as_user("root", &format!("cat {}", hello_path)).await?;
-    if root_content == "Hello World!" {
-        green!("OK root can read");
-    } else {
-        bail!("root can't read hello.txt");
-    }
+    assert_can_read_as_user("root", &hello_path, "Hello World!\n").await?;
+    green!("OK root can read");
 
     // Test: owner can read
-    let owner_content = run_as_user("fusertest1", &format!("cat {}", hello_path)).await?;
-    if owner_content == "Hello World!" {
-        green!("OK owner can read");
-    } else {
-        bail!("owner can't read hello.txt");
-    }
+    assert_can_read_as_user("fusertest1", &hello_path, "Hello World!\n").await?;
+    green!("OK owner can read");
 
     // Test: other user can't read
-    let other_content = run_as_user("fusertest2", &format!("cat {}", hello_path)).await?;
-    if other_content == "Hello World!" {
-        bail!("other user should not be able to read hello.txt");
-    } else {
-        green!("OK other user can't read");
-    }
+    assert_cannot_read_as_user("fusertest2", &hello_path).await?;
+    green!("OK other user can't read");
 
     // Kill the FUSE process
     fuse_process

--- a/fuser-tests/src/users.rs
+++ b/fuser-tests/src/users.rs
@@ -1,16 +1,39 @@
 //! User management utilities
 
+use std::process::Stdio;
+
 use anyhow::Context;
 use tokio::process::Command;
 
-pub(crate) async fn run_as_user(username: &str, command: &str) -> anyhow::Result<String> {
-    let output = Command::new("su")
+async fn run_as_user(username: &str, command: &str) -> anyhow::Result<String> {
+    let mut child = Command::new("su")
         .args([username, "-c", command])
-        .output()
-        .await
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
         .context(format!("Failed to run command as user {}", username))?;
 
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    let mut stdout = child.stdout.take().context("stdout was piped")?;
+    let mut stdout_buf = Vec::new();
+    tokio::io::AsyncReadExt::read_to_end(&mut stdout, &mut stdout_buf)
+        .await
+        .context("Failed to read stdout")?;
+
+    let status = child
+        .wait()
+        .await
+        .context(format!("Failed to wait for command as user {}", username))?;
+
+    anyhow::ensure!(
+        status.success(),
+        "Command '{}' as user {} failed with exit code {:?}",
+        command,
+        username,
+        status.code()
+    );
+
+    let stdout_str = String::from_utf8(stdout_buf).context("stdout is not valid UTF-8")?;
+    Ok(stdout_str)
 }
 
 pub(crate) async fn run_as_user_status(username: &str, command: &str) -> anyhow::Result<i32> {
@@ -21,4 +44,37 @@ pub(crate) async fn run_as_user_status(username: &str, command: &str) -> anyhow:
         .context(format!("Failed to run command as user {}", username))?;
 
     Ok(status.code().unwrap_or(-1))
+}
+
+pub(crate) async fn assert_can_read_as_user(
+    username: &str,
+    path: &str,
+    expected_content: &str,
+) -> anyhow::Result<()> {
+    let content = run_as_user(username, &format!("cat {}", path)).await?;
+    anyhow::ensure!(
+        content == expected_content,
+        "User {} should be able to read {}: expected '{}', got '{}'",
+        username,
+        path,
+        expected_content,
+        content
+    );
+    Ok(())
+}
+
+pub(crate) async fn assert_cannot_read_as_user(username: &str, path: &str) -> anyhow::Result<()> {
+    let exit_code = run_as_user_status(username, &format!("cat {}", path)).await?;
+    anyhow::ensure!(
+        exit_code != 0,
+        "User {} should not be able to read {}, but cat succeeded",
+        username,
+        path
+    );
+    Ok(())
+}
+
+pub(crate) async fn mktempdir_as_user(username: &str) -> anyhow::Result<String> {
+    let output = run_as_user(username, "mktemp --directory").await?;
+    Ok(output.trim().to_owned())
 }


### PR DESCRIPTION
Mostly to avoid repeated blocks that are now encapsulated as `assert_can_read_as_user`.