### PR TITLE
Check mountpoint instead of device in tests

### DIFF
--- a/fuser-tests/src/commands/mount.rs
+++ b/fuser-tests/src/commands/mount.rs
@@ -3,6 +3,7 @@
 use std::convert::Infallible;
 use std::fmt::Write;
 use std::io;
+use std::path::Path;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -121,7 +122,7 @@ async fn run_test_inner(
         .spawn()
         .context("Failed to start hello example")?;
 
-    wait_for_fuse_mount("hello").await?;
+    wait_for_fuse_mount(mount_dir.path()).await?;
 
     // Read hello.txt
     let hello_path = mount_dir.path().join("hello.txt");
@@ -180,7 +181,7 @@ async fn run_test_inner(
         green!("OK multi-threaded tests passed: {stats_per_thread:?}");
     }
 
-    kill_and_unmount(fuse_process, unmount, "hello", mount_path).await?;
+    kill_and_unmount(fuse_process, unmount, mount_path).await?;
 
     green!("OK {description}");
 
@@ -228,7 +229,7 @@ async fn test_no_user_allow_other(features: &[Feature], libfuse: &Libfuse) -> an
         bail!("Expected exit code 2, got {}", exit_code);
     }
 
-    assert_no_fuse_mount("hello").await?;
+    assert_no_fuse_mount(Path::new(&mount_dir)).await?;
     green!("OK Mount does not exist: {}", description);
 
     // Restore fuse.conf
@@ -253,7 +254,7 @@ async fn run_allow_root_test() -> anyhow::Result<()> {
         .spawn()
         .context("Failed to start hello example")?;
 
-    wait_for_fuse_mount("hello").await?;
+    wait_for_fuse_mount(Path::new(&mount_dir)).await?;
 
     // Test: root can read
     let hello_path = format!("{}/hello.txt", mount_dir);
@@ -268,7 +269,7 @@ async fn run_allow_root_test() -> anyhow::Result<()> {
     assert_cannot_read_as_user("fusertest2", &hello_path).await?;
     green!("OK other user can't read");
 
-    kill_and_unmount(fuse_process, Unmount::Manual, "hello", &mount_dir).await?;
+    kill_and_unmount(fuse_process, Unmount::Manual, &mount_dir).await?;
 
     green!("OK run_allow_root_test");
 

--- a/fuser-tests/src/commands/simple.rs
+++ b/fuser-tests/src/commands/simple.rs
@@ -67,7 +67,6 @@ pub(crate) async fn run_simple_tests() -> anyhow::Result<()> {
     kill_and_unmount(
         fuse_process,
         Unmount::Manual,
-        "fuser",
         mount_dir.path().to_str().unwrap(),
     )
     .await?;

--- a/fuser-tests/src/experimental.rs
+++ b/fuser-tests/src/experimental.rs
@@ -1,6 +1,7 @@
 //! Experimental mount tests
 
 use std::fmt::Write;
+use std::path::Path;
 
 use anyhow::Context;
 use anyhow::bail;
@@ -107,7 +108,7 @@ async fn run_test_inner(
         .spawn()
         .context("Failed to start async_hello example")?;
 
-    wait_for_fuse_mount("hello").await?;
+    wait_for_fuse_mount(mount_dir.path()).await?;
 
     // Read hello.txt
     let hello_path = mount_dir.path().join("hello.txt");
@@ -124,7 +125,7 @@ async fn run_test_inner(
         );
     }
 
-    kill_and_unmount(fuse_process, unmount, "hello", mount_path).await?;
+    kill_and_unmount(fuse_process, unmount, mount_path).await?;
 
     green!("OK {description}");
 
@@ -204,7 +205,7 @@ async fn run_allow_root_test() -> anyhow::Result<()> {
         .spawn()
         .context("Failed to start async_hello example")?;
 
-    wait_for_fuse_mount("hello").await?;
+    wait_for_fuse_mount(Path::new(&mount_dir)).await?;
 
     // Test: root can read
     let hello_path = format!("{}/hello.txt", mount_dir);

--- a/fuser-tests/src/unmount.rs
+++ b/fuser-tests/src/unmount.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use anyhow::Context;
 use tokio::process::Child;
 
@@ -18,10 +20,10 @@ pub(crate) enum Unmount {
 pub(crate) async fn kill_and_unmount(
     mut fuse_process: Child,
     unmount: Unmount,
-    device: &str,
     mount_path: &str,
 ) -> anyhow::Result<()> {
-    assert_single_fuse_mount(device).await?;
+    let mountpoint = Path::new(mount_path);
+    assert_single_fuse_mount(mountpoint).await?;
 
     fuse_process
         .kill()
@@ -30,11 +32,11 @@ pub(crate) async fn kill_and_unmount(
 
     match unmount {
         Unmount::Auto => {
-            wait_for_fuse_umount(device).await?;
+            wait_for_fuse_umount(mountpoint).await?;
         }
         Unmount::Manual => {
             command_success(["umount", mount_path]).await?;
-            assert_no_fuse_mount(device).await?;
+            assert_no_fuse_mount(mountpoint).await?;
         }
     }
 


### PR DESCRIPTION
Device may be not unique if previous test did not clear it correctly.

Mount point in test is in temp directory, so it is unique. There's potential problem with path normalization here, we'll see.