### PR TITLE
FUSE_DEV_IOC_CLONE

### DIFF
--- a/examples/common/args.rs
+++ b/examples/common/args.rs
@@ -19,6 +19,12 @@ pub struct CommonArgs {
     /// Number of threads to use
     #[clap(long, default_value_t = 1)]
     pub n_threads: usize,
+
+    /// Use `FUSE_DEV_IOC_CLONE` to give each worker thread its own fd.
+    /// This enables more efficient request processing
+    /// when multiple threads are used. Requires Linux 4.5+.
+    #[clap(long)]
+    pub clone_fd: bool,
 }
 
 impl CommonArgs {
@@ -36,6 +42,7 @@ impl CommonArgs {
             config.acl = SessionACL::All;
         }
         config.n_threads = Some(self.n_threads);
+        config.clone_fd = self.clone_fd;
         config
     }
 }

--- a/fuser-tests/src/commands/mount.rs
+++ b/fuser-tests/src/commands/mount.rs
@@ -40,16 +40,31 @@ async fn run_mount_tests_inner(libfuse: Libfuse) -> anyhow::Result<()> {
     fuse_conf_write_user_allow_other().await?;
 
     // Tests without libfuse feature (pure Rust implementation)
-    run_test(&[], Unmount::Manual, Fusermount::False, 1).await?;
-    run_test(&[], Unmount::Auto, libfuse.fusermount(), 1).await?;
+    run_test(&[], Unmount::Manual, Fusermount::False, 1, false).await?;
+    run_test(&[], Unmount::Auto, libfuse.fusermount(), 1, false).await?;
     test_no_user_allow_other(&[], &libfuse).await?;
 
     // Tests with libfuse
-    run_test(&[libfuse.feature()], Unmount::Manual, Fusermount::False, 1).await?;
-    run_test(&[libfuse.feature()], Unmount::Auto, libfuse.fusermount(), 1).await?;
+    run_test(
+        &[libfuse.feature()],
+        Unmount::Manual,
+        Fusermount::False,
+        1,
+        false,
+    )
+    .await?;
+    run_test(
+        &[libfuse.feature()],
+        Unmount::Auto,
+        libfuse.fusermount(),
+        1,
+        false,
+    )
+    .await?;
 
     // Multi-threaded tests
-    run_test(&[], Unmount::Auto, libfuse.fusermount(), 2).await?;
+    run_test(&[], Unmount::Auto, libfuse.fusermount(), 2, false).await?;
+    run_test(&[], Unmount::Auto, libfuse.fusermount(), 2, true).await?;
 
     if let Libfuse::Libfuse3 = libfuse {
         run_allow_root_test()
@@ -71,6 +86,7 @@ async fn run_test(
     unmount: Unmount,
     fusermount: Fusermount,
     n_threads: usize,
+    clone_fd: bool,
 ) -> anyhow::Result<()> {
     let mut description = String::new();
     match features_to_flags(features) {
@@ -83,10 +99,20 @@ async fn run_test(
         Unmount::Manual => {}
     }
     write!(description, " n_threads={n_threads}").unwrap();
+    if clone_fd {
+        description.push_str(" --clone-fd");
+    }
 
-    run_test_inner(features, unmount, fusermount, n_threads, &description)
-        .await
-        .with_context(|| format!("Tests failed: {description}"))
+    run_test_inner(
+        features,
+        unmount,
+        fusermount,
+        n_threads,
+        clone_fd,
+        &description,
+    )
+    .await
+    .with_context(|| format!("Tests failed: {description}"))
 }
 
 async fn run_test_inner(
@@ -94,6 +120,7 @@ async fn run_test_inner(
     unmount: Unmount,
     fusermount: Fusermount,
     n_threads: usize,
+    clone_fd: bool,
     description: &str,
 ) -> anyhow::Result<()> {
     eprintln!("\n=== Running test: {description} ===");
@@ -110,6 +137,9 @@ async fn run_test_inner(
     eprintln!("Starting hello filesystem...");
     let n_threads_str = n_threads.to_string();
     let mut run_args = vec![mount_path_str, "--n-threads", &n_threads_str];
+    if clone_fd {
+        run_args.push("--clone-fd");
+    }
     if matches!(unmount, Unmount::Auto) {
         run_args.push("--auto-unmount");
     }

--- a/src/ll/ioctl.rs
+++ b/src/ll/ioctl.rs
@@ -6,7 +6,7 @@ pub(crate) struct fuse_backing_map {
 }
 
 pub(crate) const FUSE_DEV_IOC_MAGIC: u8 = 229;
-#[expect(dead_code)]
+#[cfg_attr(not(target_os = "linux"), expect(dead_code))]
 pub(crate) const FUSE_DEV_IOC_CLONE: u8 = 0;
 pub(crate) const FUSE_DEV_IOC_BACKING_OPEN: u8 = 1;
 pub(crate) const FUSE_DEV_IOC_BACKING_CLOSE: u8 = 2;

--- a/src/mnt/mount_options.rs
+++ b/src/mnt/mount_options.rs
@@ -15,6 +15,10 @@ pub struct Config {
     pub acl: SessionACL,
     /// Number of event loop threads. If unspecified, one thread is used.
     pub n_threads: Option<usize>,
+    /// Use `FUSE_DEV_IOC_CLONE` to give each worker thread its own fd.
+    /// This enables more efficient request processing
+    /// when multiple threads are used. Requires Linux 4.5+.
+    pub clone_fd: bool,
 }
 
 /// Mount options accepted by the FUSE filesystem type
@@ -210,6 +214,7 @@ pub(crate) fn parse_options_from_args(args: &[&OsStr]) -> io::Result<Config> {
         mount_options: out,
         acl,
         n_threads: None,
+        clone_fd: false,
     })
 }
 


### PR DESCRIPTION
This is re-submit of #636 with a few tweaks:

- tests converted to `fuser-tests`
- error on attempt to use `clone_fd` on non-Linux
- remove excessive comments
- fix incorrect comment about parallel processing
- small code cleanups

Closes: #636 