### PR TITLE
Make `mount_point` argument positional in `examples/simple.rs`

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -73,9 +73,7 @@ struct Args {
     #[clap(long, default_value = "/tmp/fuser")]
     data_dir: String,
 
-    // TODO: make positional like other examples.
     /// Act as a client, and mount FUSE at given path
-    #[clap(long, default_value = "")]
     mount_point: String,
 
     /// Mount FUSE with direct IO

--- a/fuser-tests/src/commands/mount.rs
+++ b/fuser-tests/src/commands/mount.rs
@@ -244,7 +244,7 @@ async fn test_no_user_allow_other(features: &[Feature], libfuse: &Libfuse) -> an
 
     // Run the simple example as fusertestnoallow
     let run_command = format!(
-        "{} --auto-unmount -vvv --data-dir {} --mount-point {}",
+        "{} --auto-unmount -vvv --data-dir {} {}",
         simple_exe.display(),
         data_dir.path().display(),
         mount_dir.path().display()

--- a/fuser-tests/src/commands/simple.rs
+++ b/fuser-tests/src/commands/simple.rs
@@ -32,7 +32,6 @@ pub(crate) async fn run_simple_tests() -> anyhow::Result<()> {
             "-vvv",
             "--data-dir",
             data_dir.path().to_str().unwrap(),
-            "--mount-point",
             mount_dir.path().to_str().unwrap(),
         ])
         .env(Fusermount::ENV_VAR, Fusermount::False.as_path())

--- a/fuser-tests/src/experimental.rs
+++ b/fuser-tests/src/experimental.rs
@@ -158,7 +158,7 @@ async fn test_no_user_allow_other(features: &[Feature], libfuse: &Libfuse) -> an
 
     // Run the simple example as fusertestnoallow
     let run_command = format!(
-        "{} --auto-unmount -vvv --data-dir {} --mount-point {}",
+        "{} --auto-unmount -vvv --data-dir {} {}",
         simple_exe.display(),
         data_dir.path().display(),
         mount_dir.path().display()

--- a/pjdfs.sh
+++ b/pjdfs.sh
@@ -13,7 +13,7 @@ export RUST_BACKTRACE=1
 DATA_DIR=$(mktemp --directory)
 DIR=$(mktemp --directory)
 
-fuser -vvv --auto-unmount --suid --data-dir $DATA_DIR --mount-point $DIR > /code/logs/mount.log 2>&1 &
+fuser -vvv --auto-unmount --suid --data-dir $DATA_DIR $DIR > /code/logs/mount.log 2>&1 &
 FUSE_PID=$!
 sleep 0.5
 

--- a/tests/bsd_pjdfs.sh
+++ b/tests/bsd_pjdfs.sh
@@ -18,7 +18,7 @@ DATA_DIR=$(mktemp --directory)
 DIR=$(mktemp --directory)
 
 cargo build --release --example simple
-cargo run --release --example simple -- -vvv --suid --data-dir $DATA_DIR --mount-point $DIR > /tmp/mount.log 2>&1 &
+cargo run --release --example simple -- -vvv --suid --data-dir $DATA_DIR $DIR > /tmp/mount.log 2>&1 &
 FUSE_PID=$!
 sleep 0.5
 

--- a/tests/macos_pjdfs.sh
+++ b/tests/macos_pjdfs.sh
@@ -31,7 +31,7 @@ DATA_DIR=$(mktemp --directory)
 DIR=$(mktemp --directory)
 
 cargo build --release --example simple
-cargo run --release --example simple -- -vvv --suid --data-dir $DATA_DIR --mount-point $DIR > /tmp/mount.log 2>&1 &
+cargo run --release --example simple -- -vvv --suid --data-dir $DATA_DIR $DIR > /tmp/mount.log 2>&1 &
 FUSE_PID=$!
 sleep 0.5
 


### PR DESCRIPTION
Simple change to fix the `TODO` stated for CLI argument `mount_point` in `examples/simple.rs`: To make the argument positional, as is the case for the other examples. This is achieved simply by removing the `#[clap(long, default_value = "")]` line right above `mount_point`, as fields without attributes define positional arguments by default. And by adjusting the tests that use the `simple` example.

Thanks for building and maintaining this useful crate!