### PR TITLE
Export ForgetOne to allow implementing Filesystem::batch_forget

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ use serde::Serialize;
 
 pub use crate::access_flags::AccessFlags;
 pub use crate::bsd_file_flags::BsdFileFlags;
-use crate::forget_one::ForgetOne;
+pub use crate::forget_one::ForgetOne;
 pub use crate::ll::Errno;
 pub use crate::ll::Generation;
 pub use crate::ll::RequestId;


### PR DESCRIPTION
Implementors of `fuser::Filesystem` cannot implement `batch_forget` because `ForgetOne` is private. This commit makes it public.