### PR TITLE
Allowing 'static capture of Request objects

### DIFF
--- a/src/request_param.rs
+++ b/src/request_param.rs
@@ -11,6 +11,23 @@ pub struct Request {
     header: fuse_in_header,
 }
 
+impl Clone for Request {
+    fn clone(&self) -> Self {
+        Request {
+            header: fuse_in_header {
+                len: self.header.len,
+                opcode: self.header.opcode,
+                unique: self.header.unique,
+                nodeid: self.header.nodeid,
+                uid: self.header.uid,
+                gid: self.header.gid,
+                pid: self.header.pid,
+                padding: self.header.padding,
+            },
+        }
+    }
+}
+
 impl Request {
     #[ref_cast_custom]
     pub(crate) fn ref_cast(header: &fuse_in_header) -> &Request;


### PR DESCRIPTION
Request objects cannot be cloned, so there is no way to upgrade the Request references to an owned object for capture in structured error handling.