### PR TITLE
Add sync_fs() to service FUSE_SYNCFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # FUSE for Rust - Changelog
 
 ## 0.18.0 - Unreleased
+* Add `Filesystem::sync_fs()` to service `FUSE_SYNCFS` (`syncfs(2)`/`sync(2)`), plus the
+  `InitFlags::FUSE_HAS_SYNCFS` opt-in capability a privileged server requests via
+  `KernelConfig::add_capabilities()`
 * Remove deprecated feature flags `abi-*`
 * Rename `mount2()` to `mount()`
 * Rename `spawn_mount2()` to `spawn_mount()`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -777,6 +777,22 @@ pub trait Filesystem: Send + Sync + 'static {
         reply.statfs(0, 0, 0, 0, 0, 512, 255, 0);
     }
 
+    /// Synchronize the file system.
+    ///
+    /// Called when userspace issues `syncfs(2)` (or `sync(2)`) against the mount,
+    /// giving the server a chance to flush any state it has buffered before
+    /// replying. The kernel only forwards this once the server has opted in by
+    /// requesting [`InitFlags::FUSE_HAS_SYNCFS`] in [`Filesystem::init`]
+    /// (via [`KernelConfig::add_capabilities`]), and only honors that opt-in for
+    /// servers that opened `/dev/fuse` with `CAP_SYS_ADMIN` in the initial user
+    /// namespace — otherwise this is never called. Reply with `reply.ok()` once the
+    /// data is durable; replying [`Errno::ENOSYS`] tells the kernel to stop sending
+    /// `FUSE_SYNCFS` (treated as a permanent success), which is the default.
+    fn sync_fs(&self, _req: &Request, ino: INodeNo, reply: ReplyEmpty) {
+        warn!("[Not Implemented] sync_fs(ino: {ino:#x?})");
+        reply.error(Errno::ENOSYS);
+    }
+
     /// Set an extended attribute.
     fn setxattr(
         &self,

--- a/src/ll/flags/init_flags.rs
+++ b/src/ll/flags/init_flags.rs
@@ -92,6 +92,8 @@ bitflags! {
         const FUSE_OVER_IO_URING = 1 << 41;
         /// kernel supports request timeout
         const FUSE_REQUEST_TIMEOUT = 1 << 42;
+        /// server wants syncfs()/sync() propagated as `FUSE_SYNCFS` requests
+        const FUSE_HAS_SYNCFS = 1 << 43;
 
         /// pre-allocate space for a file
         #[cfg(target_os = "macos")]

--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -161,6 +161,7 @@ pub(crate) enum fuse_opcode {
     FUSE_RENAME2 = 45,
     FUSE_LSEEK = 46,
     FUSE_COPY_FILE_RANGE = 47,
+    FUSE_SYNCFS = 50,
 
     #[cfg(target_os = "macos")]
     FUSE_SETVOLNAME = 61,

--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -765,6 +765,17 @@ mod op {
         header: &'a fuse_in_header,
     }
 
+    /// Synchronize the file system.
+    ///
+    /// Sent by the kernel in response to `syncfs(2)`/`sync(2)` when the server
+    /// opted in with `InitFlags::FUSE_HAS_SYNCFS`. Filesystem-wide, so there is no
+    /// meaningful argument (the wire payload is a single reserved `u64` padding word).
+    #[derive(Debug)]
+    pub(crate) struct SyncFs<'a> {
+        #[expect(dead_code)]
+        header: &'a fuse_in_header,
+    }
+
     /// Release an open file.
     ///
     /// Release is called when there are no more references to an open file: all file
@@ -1708,6 +1719,7 @@ mod op {
                 out
             }),
             fuse_opcode::FUSE_STATFS => Operation::StatFs(StatFs { header }),
+            fuse_opcode::FUSE_SYNCFS => Operation::SyncFs(SyncFs { header }),
             fuse_opcode::FUSE_RELEASE => Operation::Release(Release {
                 header,
                 arg: data.fetch()?,
@@ -1898,6 +1910,7 @@ pub(crate) enum Operation<'a> {
     Read(Read<'a>),
     Write(Write<'a>),
     StatFs(#[expect(dead_code)] StatFs<'a>),
+    SyncFs(#[expect(dead_code)] SyncFs<'a>),
     Release(Release<'a>),
     FSync(FSync<'a>),
     SetXAttr(SetXAttr<'a>),
@@ -1983,6 +1996,7 @@ impl fmt::Display for Operation<'_> {
                 x.write_flags()
             ),
             Operation::StatFs(_) => write!(f, "STATFS"),
+            Operation::SyncFs(_) => write!(f, "SYNCFS"),
             Operation::Release(x) => write!(
                 f,
                 "RELEASE fh {:?}, flags {:#x}, flush {}, lock owner {:?}",
@@ -2330,6 +2344,30 @@ mod tests {
                 assert_eq!(x.umask(), 0o755);
                 assert_eq!(x.name(), OsStr::new("foo.txt"));
             }
+            _ => panic!("Unexpected request operation"),
+        }
+    }
+
+    // len 48 = header (40) + fuse_syncfs_in.padding (8); opcode 50 = 0x32.
+    #[cfg(target_endian = "little")]
+    const SYNCFS_REQUEST: AlignedData<[u8; 48]> = AlignedData([
+        0x30, 0x00, 0x00, 0x00, 0x32, 0x00, 0x00, 0x00, // len, opcode
+        0x0d, 0xf0, 0xad, 0xba, 0xef, 0xbe, 0xad, 0xde, // unique
+        0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, // nodeid
+        0x0d, 0xd0, 0x01, 0xc0, 0xfe, 0xca, 0x01, 0xc0, // uid, gid
+        0x5e, 0xba, 0xde, 0xc0, 0x00, 0x00, 0x00, 0x00, // pid, padding
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // fuse_syncfs_in.padding
+    ]);
+
+    #[test]
+    #[cfg(target_endian = "little")]
+    fn syncfs() {
+        let req = AnyRequest::try_from(&SYNCFS_REQUEST[..]).unwrap();
+        assert_eq!(req.header.len, 48);
+        assert_eq!(req.header.opcode, 50);
+        assert_eq!(req.nodeid(), INodeNo(0x1122_3344_5566_7788));
+        match req.operation().unwrap() {
+            Operation::SyncFs(_) => (),
             _ => panic!("Unexpected request operation"),
         }
     }

--- a/src/request.rs
+++ b/src/request.rs
@@ -330,6 +330,9 @@ impl<'a> RequestWithSender<'a> {
             ll::Operation::StatFs(_) => {
                 filesystem.statfs(self.request_header(), self.request.nodeid(), self.reply());
             }
+            ll::Operation::SyncFs(_) => {
+                filesystem.sync_fs(self.request_header(), self.request.nodeid(), self.reply());
+            }
             ll::Operation::SetXAttr(x) => {
                 filesystem.setxattr(
                     self.request_header(),


### PR DESCRIPTION
## Summary
Adds support for servicing `FUSE_SYNCFS` — the opcode the kernel issues for `syncfs(2)`/`sync(2)` — plus the opt-in `FUSE_HAS_SYNCFS` INIT capability that lets a privileged `/dev/fuse` server receive it.

- New `Filesystem::sync_fs(&self, req, ino, ReplyEmpty)` trait method; defaults to `ENOSYS`, which the kernel treats as a permanent success (same convention as `fsync`/`statfs`).
- `FUSE_SYNCFS = 50` opcode, a header-only `SyncFs` request, its `Operation` variant, and request parsing/dispatch/`Display`.
- `InitFlags::FUSE_HAS_SYNCFS = 1 << 43` (protocol 7.46), requested by a server via `KernelConfig::add_capabilities()`.

## Dependency on the Linux VFS fuse driver (please read)
This is the important caveat. Although the `FUSE_SYNCFS` opcode has existed for a while (added for virtiofs), the in-kernel fuse driver only *propagates* `syncfs()`/`sync()` to the userspace server (`fc->sync_fs`) for **virtiofs** and **fuseblk** mounts. A plain `/dev/fuse` server never receives it today — regardless of what it advertises — because an untrusted server could stall `sync()` indefinitely.

Consequences:
- On **current released kernels**, this PR immediately benefits **fuseblk** `fuser` servers (they already receive `FUSE_SYNCFS`), and is a harmless no-op for plain servers.
- For **plain `/dev/fuse` servers** to receive it, the kernel needs the in-flight opt-in: a new `FUSE_HAS_SYNCFS` INIT flag, honored only when the server opened `/dev/fuse` with `CAP_SYS_ADMIN` in the initial user namespace (the same privilege that mounting virtiofs/fuseblk already requires). That series — *"fuse: allow FUSE_SYNCFS for privileged userspace servers"* — is on LKML ([patch](https://lists.openwall.net/linux-kernel/2026/06/19/1124), [LWN summary](https://lwn.net/Articles/1078768/)) and **not yet merged**. The `1 << 43` bit and protocol minor 7.46 here match that patch's UAPI.

Because `KernelConfig::add_capabilities(InitFlags::FUSE_HAS_SYNCFS)` returns `Err` when the running kernel doesn't offer the flag, a server can cleanly detect an unsupporting kernel and fall back (e.g. to an out-of-band flush) rather than silently never being called.

## Design notes
- `FUSE_KERNEL_MINOR_VERSION` is intentionally left at 40. The kernel gates this flag on the opener's privilege rather than the negotiated minor, and it rides in the high-32 `flags2` (already carried via `FUSE_INIT_EXT`), so it works without claiming the intervening 7.41–7.45 features `fuser` doesn't yet implement. Happy to bump the minor if you'd prefer.
- `SyncFs` is modeled on `StatFs`: filesystem-wide and header-only (the wire `fuse_syncfs_in` is a single reserved `u64` padding word, so there's no argument to expose).
- Mirrors libfuse's low-level `syncfs` op, which likewise replies `ENOSYS` when unimplemented.

## Testing
`cargo test` (including a new `FUSE_SYNCFS` parse test), `cargo clippy --all-targets`, `cargo fmt --check`, and `cargo doc` (with `-D rustdoc::broken_intra_doc_links`) all pass on Linux (aarch64, toolchain 1.85). Not exercised against a live mount, since the privileged-plain-server kernel path isn't in a shipping kernel yet (see above).
