### PR TITLE
feat: allow experimental multithreading for macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ pkg-config = "0.3.14"
 [features]
 default = []
 experimental = ["async-trait", "tokio"]
+allow-multi-thread = []
 libfuse = []
 libfuse2 = ["libfuse"]
 libfuse3 = ["libfuse"]

--- a/src/session.rs
+++ b/src/session.rs
@@ -256,6 +256,7 @@ impl<FS: Filesystem> Session<FS> {
 
         let n_threads = config.n_threads.unwrap_or(1);
 
+        #[cfg(not(feature = "allow-multi-thread"))]
         if !cfg!(target_os = "linux") && n_threads != 1 {
             // TODO: check whether it works on macOS/FreeBSD and enable if it works.
             return Err(io::Error::other(


### PR DESCRIPTION
This PR allows using multi-threading on unverified OSes with the allow-multi-thread flag.