### PR TITLE
Bump nix to 0.31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ smallvec = "1.6.1"
 async-trait = { version = "0.1", optional = true }
 tokio = { version = "1.48.0", features = ["rt", "rt-multi-thread"], optional = true }
 zerocopy = { version = "0.8", features = ["derive"] }
-nix = { version = "0.30.0", features = ["fs", "user", "poll", "socket", "uio", "mount", "process", "ioctl"] }
+nix = { version = "0.31.0", features = ["fs", "user", "poll", "socket", "uio", "mount", "process", "ioctl"] }
 
 [dev-dependencies]
 env_logger = "0.11.7"
@@ -46,7 +46,7 @@ clap = { version = "4.4", features = ["cargo", "derive"] }
 bincode = "1.3.1"
 serde = { version = "1.0.102", features = ["std", "derive"] }
 tempfile = "3.10.1"
-nix = { version = "0.30.0", features = ["poll", "fs", "ioctl"] }
+nix = { version = "0.31.0", features = ["poll", "fs", "ioctl"] }
 
 [build-dependencies]
 pkg-config = "0.3.14"


### PR DESCRIPTION
Bumps `nix` from 0.30 to 0.31.

This is a pure dependency refresh for fuser. None of the nix 0.31.0 breaking changes touch the modules fuser uses (`fs`, `user`, `poll`, `socket`, `uio`, `mount`, `process`, `ioctl`): the 0.31 changes are limited to `EpollEvent` methods becoming `const`, removal of `Eq`/`PartialEq` on `SigHandler`, NetBSD's `IFF_NOTRAILERS`, and new Android UDP GSO/GRO socket options. No code changes are required; the diff is just the two `Cargo.toml` version specifiers.

Verified locally: `cargo build --all --all-targets`, `cargo clippy --all-targets`, `cargo test --all` (the live-mount test skipped), and `cargo fmt --check` all pass. nix 0.31.3's MSRV is 1.69, so the MSRV job is unaffected.

Motivation: downstream crates that already depend on nix 0.31 currently have to keep a second nix 0.30 in their tree solely for fuser; this lets them resolve to a single nix version.
