### PR TITLE
feat: add low level interrupts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ async-trait = { version = "0.1", optional = true }
 tokio = { version = "1.48.0", features = ["rt", "rt-multi-thread"], optional = true }
 zerocopy = { version = "0.8", features = ["derive"] }
 nix = { version = "0.31.0", features = ["fs", "user", "poll", "socket", "uio", "mount", "process", "ioctl"] }
+threadpool = "1.8.1"
 
 [dev-dependencies]
 env_logger = "0.11.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,6 +409,12 @@ pub trait Filesystem: Send + Sync + 'static {
     /// Called on filesystem exit.
     fn destroy(&mut self) {}
 
+    /// Interrupt an existing request.
+    fn interrupt(&self, _req: &Request, unique: RequestId, reply: ReplyEmpty) {
+        warn!("[Not Implemented] interrupt(unique: {:?})", unique);
+        reply.error(Errno::ENOSYS);
+    }
+
     /// Look up a directory entry by name and get its attributes.
     fn lookup(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
         warn!("[Not Implemented] lookup(parent: {parent:#x?}, name {name:?})");

--- a/src/request.rs
+++ b/src/request.rs
@@ -14,6 +14,7 @@ use log::error;
 use crate::Filesystem;
 use crate::PollNotifier;
 use crate::RenameFlags;
+use crate::ReplyEmpty;
 use crate::Request;
 use crate::channel::ChannelSender;
 use crate::forget_one::ForgetOne;
@@ -115,7 +116,21 @@ impl<'a> RequestWithSender<'a> {
             }
 
             ll::Operation::Interrupt(x) => {
-                filesystem.interrupt(self.request_header(), x.unique(), self.reply());
+                se.interrupt_pool.execute({
+                    let holder = se.filesystem.clone();
+                    let header = self.request_header().clone();
+                    let reply: ReplyEmpty = self.reply();
+                    let unique = x.unique();
+                    move || {
+                        let Some(filesystem) = &holder.fs else {
+                            // This is handled before dispatch call.
+                            error!("bug: filesystem must be initialized in dispatch_req");
+                            reply.error(Errno::ENOSYS);
+                            return;
+                        };
+                        filesystem.interrupt(&header, unique, reply)
+                    }
+                });
             }
             ll::Operation::Lookup(x) => {
                 filesystem.lookup(

--- a/src/request.rs
+++ b/src/request.rs
@@ -114,11 +114,9 @@ impl<'a> RequestWithSender<'a> {
                 return Err(Errno::EIO);
             }
 
-            ll::Operation::Interrupt(_) => {
-                // TODO: handle FUSE_INTERRUPT
-                return Err(Errno::ENOSYS);
+            ll::Operation::Interrupt(x) => {
+                filesystem.interrupt(self.request_header(), x.unique(), self.reply());
             }
-
             ll::Operation::Lookup(x) => {
                 filesystem.lookup(
                     self.request_header(),

--- a/src/request_param.rs
+++ b/src/request_param.rs
@@ -5,10 +5,27 @@ use crate::ll;
 use crate::ll::fuse_abi::fuse_in_header;
 
 /// FUSE request parameters.
-#[derive(Debug, Clone, RefCastCustom)]
+#[derive(Debug, RefCastCustom)]
 #[repr(transparent)]
 pub struct Request {
     header: fuse_in_header,
+}
+
+impl Clone for Request {
+    fn clone(&self) -> Self {
+        Request {
+            header: fuse_in_header {
+                len: self.header.len,
+                opcode: self.header.opcode,
+                unique: self.header.unique,
+                nodeid: self.header.nodeid,
+                uid: self.header.uid,
+                gid: self.header.gid,
+                pid: self.header.pid,
+                padding: self.header.padding,
+            },
+        }
+    }
 }
 
 impl Request {

--- a/src/request_param.rs
+++ b/src/request_param.rs
@@ -5,7 +5,7 @@ use crate::ll;
 use crate::ll::fuse_abi::fuse_in_header;
 
 /// FUSE request parameters.
-#[derive(Debug, RefCastCustom)]
+#[derive(Debug, Clone, RefCastCustom)]
 #[repr(transparent)]
 pub struct Request {
     header: fuse_in_header,

--- a/src/session.rs
+++ b/src/session.rs
@@ -23,6 +23,7 @@ use log::warn;
 use nix::unistd::Uid;
 use nix::unistd::geteuid;
 use parking_lot::Mutex;
+use threadpool::ThreadPool;
 
 use crate::Errno;
 use crate::Filesystem;
@@ -289,6 +290,7 @@ impl<FS: Filesystem> Session<FS> {
         channels.push(ch);
 
         let mut threads = Vec::with_capacity(n_threads);
+        let interrupt_pool = ThreadPool::new((n_threads / 3).max(1usize));
 
         for (i, ch) in channels.into_iter().enumerate() {
             let thread_name = format!("fuser-{i}");
@@ -298,6 +300,7 @@ impl<FS: Filesystem> Session<FS> {
                 ch,
                 allowed,
                 session_owner,
+                interrupt_pool: interrupt_pool.clone(),
             };
             threads.push(
                 thread::Builder::new()
@@ -321,6 +324,7 @@ impl<FS: Filesystem> Session<FS> {
             }
         }
 
+        interrupt_pool.join();
         let Some(filesystem) = Arc::get_mut(&mut filesystem) else {
             return Err(io::Error::other(
                 "BUG: must have one refcount for filesystem",
@@ -518,6 +522,7 @@ pub(crate) struct SessionEventLoop<FS: Filesystem> {
     pub(crate) filesystem: Arc<FilesystemHolder<FS>>,
     pub(crate) allowed: SessionACL,
     pub(crate) session_owner: Uid,
+    pub(crate) interrupt_pool: ThreadPool,
 }
 
 impl<FS: Filesystem> SessionEventLoop<FS> {


### PR DESCRIPTION
This method adds the ability to implement interrupts, and interrupts run in a dedicated thread pool.

This is critical when dealing with cancelling locks that are blocking or stuck. I have just finished a port of ulockmgr that can be used here.