### PR TITLE
Replace bincode with rmp-serde in the simple example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ nix = { version = "0.31.0", features = ["fs", "user", "poll", "socket", "uio", "
 [dev-dependencies]
 env_logger = "0.11.7"
 clap = { version = "4.4", features = ["cargo", "derive"] }
-bincode = "1.3.1"
+rmp-serde = "1.3.0"
 serde = { version = "1.0.102", features = ["std", "derive"] }
 tempfile = "3.10.1"
 nix = { version = "0.31.0", features = ["poll", "fs", "ioctl"] }

--- a/deny.toml
+++ b/deny.toml
@@ -22,12 +22,7 @@ yanked = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    # RUSTSEC-2025-0141: bincode 1.3.3 is flagged as unmaintained (upstream
-    # ceased development and considers 1.3.3 a complete release). It is only a
-    # dev-dependency used by the test suite and is never shipped to consumers of
-    # the library, so this maintenance advisory is accepted. This is not a
-    # security vulnerability; revisit if the tests move off bincode.
-    "RUSTSEC-2025-0141",
+    #"RUSTSEC-0000-0000",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -338,17 +338,17 @@ impl SimpleFS {
     fn allocate_next_inode(&self) -> INodeNo {
         let path = Path::new(&self.data_dir).join("superblock");
         let current_inode = match File::open(&path) {
-            Ok(file) => INodeNo(bincode::deserialize_from(file).unwrap()),
+            Ok(file) => INodeNo(rmp_serde::from_read(file).unwrap()),
             _ => INodeNo::ROOT,
         };
 
-        let file = OpenOptions::new()
+        let mut file = OpenOptions::new()
             .write(true)
             .create(true)
             .truncate(true)
             .open(&path)
             .unwrap();
-        bincode::serialize_into(file, &(current_inode.0 + 1)).unwrap();
+        rmp_serde::encode::write(&mut file, &(current_inode.0 + 1)).unwrap();
 
         INodeNo(current_inode.0 + 1)
     }
@@ -386,7 +386,7 @@ impl SimpleFS {
             .join("contents")
             .join(inode.to_string());
         match File::open(path) {
-            Ok(file) => Ok(bincode::deserialize_from(file).unwrap()),
+            Ok(file) => Ok(rmp_serde::from_read(file).unwrap()),
             _ => Err(Errno::ENOENT),
         }
     }
@@ -395,13 +395,13 @@ impl SimpleFS {
         let path = Path::new(&self.data_dir)
             .join("contents")
             .join(inode.to_string());
-        let file = OpenOptions::new()
+        let mut file = OpenOptions::new()
             .write(true)
             .create(true)
             .truncate(true)
             .open(path)
             .unwrap();
-        bincode::serialize_into(file, &entries).unwrap();
+        rmp_serde::encode::write(&mut file, &entries).unwrap();
     }
 
     fn get_inode(&self, inode: INodeNo) -> Result<InodeAttributes, Errno> {
@@ -409,7 +409,7 @@ impl SimpleFS {
             .join("inodes")
             .join(inode.to_string());
         match File::open(path) {
-            Ok(file) => Ok(bincode::deserialize_from(file).unwrap()),
+            Ok(file) => Ok(rmp_serde::from_read(file).unwrap()),
             _ => Err(Errno::ENOENT),
         }
     }
@@ -418,13 +418,13 @@ impl SimpleFS {
         let path = Path::new(&self.data_dir)
             .join("inodes")
             .join(inode.inode.to_string());
-        let file = OpenOptions::new()
+        let mut file = OpenOptions::new()
             .write(true)
             .create(true)
             .truncate(true)
             .open(path)
             .unwrap();
-        bincode::serialize_into(file, inode).unwrap();
+        rmp_serde::encode::write(&mut file, inode).unwrap();
     }
 
     // Check whether a file should be removed from storage. Should be called after decrementing


### PR DESCRIPTION
## What

`bincode` is flagged unmaintained by [RUSTSEC-2025-0141](https://rustsec.org/advisories/RUSTSEC-2025-0141) (upstream ceased development). This removes it and switches the `simple` example's on-disk metadata serialization to [`rmp-serde`](https://crates.io/crates/rmp-serde) (MessagePack).

## Why rmp-serde

- Actively maintained, `serde`-based binary format with drop-in reader/writer APIs (`from_read` / `encode::write`).
- Correctly round-trips the example's `BTreeMap<Vec<u8>, _>` metadata maps. The non-string keys rule out `serde_json`.
- MIT-licensed, so it satisfies the restrictive `deny.toml` license allow-list (MIT / BSD-2-Clause).

With `bincode` gone, the `RUSTSEC-2025-0141` exception is removed from `deny.toml` — the advisories check now passes with no whitelist rather than by ignoring the advisory.

## Verification

Run locally against the pinned MSRV toolchain:

- `cargo build --example simple` with `RUSTFLAGS=--deny warnings`: pass
- `cargo fmt --all -- --check`: pass
- `cargo clippy --all-targets` with `--deny warnings`: pass
- `cargo deny check advisories | licenses | bans | sources`: all pass
- Round-trip of the exact types (including binary map keys like `b"weird\xff\x00name"`) validated in isolation

The `simple` mount test in CI exercises this example end to end.

## Note on the base branch

This PR is stacked on `claude/repo-tooling-security-setup-erbnli` (the cargo-deny advisories-check branch) so it can also drop the `RUSTSEC-2025-0141` whitelist that branch introduces. Recommended merge order: the advisories branch first, then this one (GitHub will retarget this PR to `master` automatically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01XLfkeDcDgifMoQXuMByCrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLfkeDcDgifMoQXuMByCrn)_