### PR TITLE
Fix inverted POLLERR check in is_mounted()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # FUSE for Rust - Changelog
 
+## Unreleased
+* Fix inverted mounted-check during session teardown: after the filesystem had already been
+  unmounted externally, fuser would attempt to unmount the mountpoint again, which could
+  unmount an unrelated filesystem mounted at the same path in the meantime
+
 ## 0.18.0 - 2026-07-22
 * Remove deprecated feature flags `abi-*`
 * Rename `mount2()` to `mount()`

--- a/src/mnt/mod.rs
+++ b/src/mnt/mod.rs
@@ -207,7 +207,9 @@ fn is_mounted(fuse_device: &DevFuse) -> bool {
         let res = poll(slice::from_mut(&mut poll_fd), PollTimeout::ZERO);
         break match res {
             Ok(0) => true,
-            Ok(1) => poll_fd
+            // The kernel reports POLLERR on /dev/fuse if and only if the connection
+            // is no longer alive, i.e. the filesystem has been unmounted or aborted
+            Ok(1) => !poll_fd
                 .revents()
                 .is_some_and(|r| r.contains(PollFlags::POLLERR)),
             Ok(_) => unreachable!(),
@@ -265,6 +267,58 @@ mod test {
         )
         .unwrap()
         .to_owned()
+    }
+
+    /// After the filesystem is unmounted by an external process (e.g. a user
+    /// running 'umount'), `is_mounted()` must report false so that session
+    /// teardown does not attempt a second unmount of the mountpoint.
+    ///
+    /// The `mount_unmount` name prefix keeps this test covered by the
+    /// `--skip=mnt::test::mount_unmount` filter used on platforms where
+    /// unprivileged mounting is unavailable.
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn mount_unmount_external() {
+        use std::ffi::CString;
+        use std::mem::ManuallyDrop;
+        use std::os::unix::ffi::OsStrExt;
+
+        // We use ManuallyDrop here to leak the directory on test failure.  We don't
+        // want to try and clean up the directory if it's a mountpoint otherwise we'll
+        // deadlock.
+        let tmp = ManuallyDrop::new(tempfile::tempdir().unwrap());
+        let (file, mount) = Mount::new(tmp.path(), &[], SessionACL::default()).unwrap();
+        assert!(is_mounted(&file));
+
+        // Unmount externally, without going through `mount`
+        let unmounted = ["fusermount3", "fusermount"].iter().any(|bin| {
+            std::process::Command::new(bin)
+                .arg("-u")
+                .arg(tmp.path())
+                .status()
+                .is_ok_and(|status| status.success())
+        });
+        if !unmounted {
+            // No fusermount binary available; fall back to umount(2), which
+            // requires root
+            let mountpoint = CString::new(tmp.path().as_os_str().as_bytes()).unwrap();
+            libc_umount(&mountpoint).unwrap();
+        }
+
+        // The kernel may tear down the connection asynchronously, so allow some time
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while is_mounted(&file) && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(
+            !is_mounted(&file),
+            "is_mounted() must report false after the filesystem was unmounted"
+        );
+
+        // Dropping the mount must not fail even though the filesystem is
+        // already unmounted
+        drop(mount);
+        ManuallyDrop::into_inner(tmp);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`is_mounted()` in `src/mnt/mod.rs` polls `/dev/fuse` with no requested events and treats `POLLERR` as "mounted". The kernel's `fuse_dev_poll` reports `POLLERR` precisely when the connection is *dead* (unmounted or aborted), so the function returned `true` in every reachable case: `Ok(0)` while mounted, and `POLLERR` after unmount. Verified empirically: after an external `umount`, `is_mounted()` still returned `true`.

This defeated the guard in `fuse_pure::MountImpl::umount_impl()`, whose comment explains it exists to avoid "a race with a newly mounted filesystem living at the same mountpoint". After a user unmounted externally (the most common way a session ends), teardown would proceed to `umount(2)` / `fusermount -u -q -z` on the path anyway - and if a new filesystem had been mounted there in the meantime (e.g. a daemon restart where the new instance mounts before the old process exits), fuser could unmount that unrelated, live filesystem. It also produced spurious "Unmount failed" warnings in the ordinary case.

## Fix

Invert the `Ok(1)` arm: the connection is mounted only if `POLLERR` is *not* set. This matches libfuse's `fuse_kern_unmount()`, which skips the unmount when `poll()` reports `POLLERR`.

Behavioral note: as in libfuse, a connection that was aborted via `/sys/fs/fuse/connections/*/abort` (dead connection, mountpoint still mounted) now also skips the teardown unmount.

## Testing

* New regression test `mnt::test::mount_unmount_external`: mounts, unmounts externally (via `fusermount3`/`fusermount`, falling back to `umount(2)` when running as root), and asserts `is_mounted()` becomes false. The test fails against the previous code and passes with the fix.
* The `mount_unmount` name prefix keeps it covered by the existing `--skip=mnt::test::mount_unmount` substring filters used by the FreeBSD CI and `make test_macos`, where unprivileged mounting is unavailable.
* `cargo test --lib` (54 tests), `cargo fmt --check`, and `cargo clippy --all-targets` with `RUSTFLAGS=--deny warnings` (default features and `--no-default-features`) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfPeUUeQKYjo26Y9mQG9sA

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfPeUUeQKYjo26Y9mQG9sA)_