### PR TITLE
Fix flaky multi-threaded mount test stats race

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -104,7 +104,10 @@ impl HelloFS {
     fn stats_content(&self) -> String {
         let mut content = String::new();
         for count in &self.reads_per_thread {
-            content.push_str(&format!("{}\n", count.load(Ordering::Relaxed)));
+            // Fixed-width so the file size never changes as the counters grow: readers
+            // that observe a size change mid-read can see torn content stitched together
+            // from two different snapshots
+            content.push_str(&format!("{:020}\n", count.load(Ordering::Relaxed)));
         }
         content
     }


### PR DESCRIPTION
## Problem

The `test (mount_tests)` CI job intermittently fails in the fuser-tests multi-threaded stats check, in two manifestations:

* `Failed to parse stats line: cannot parse integer from empty string` - master at `72fafae`, [run 29891505897](https://github.com/cberner/fuser/actions/runs/29891505897)
* ``Condition failed: `stats_per_thread.len() == n_threads` (3 vs 2)`` - #703, [run 30109333704](https://github.com/cberner/fuser/actions/runs/30109333704)

Both are torn reads of the hello example's `stats-per-thread` file. Its content grows as the per-thread read counters climb, and it is served with a zero attribute TTL. When a counter crosses a digit boundary (e.g. `9` -> `10`) between two `read(2)` calls of a single `read_to_string`, the kernel re-fetches the now-larger size and issues another FUSE read at the old EOF offset; the filesystem serves that offset from the *newer* snapshot, so the reader gets fragments of two snapshots stitched together - an empty or extra line.

## Fix

Pad the counters to a fixed 20-digit width in `stats_content()`. The file size is then constant, so a whole-file read is satisfied by a single FUSE read of one consistent snapshot and the second `read(2)` always hits EOF. The fuser-tests parser is unaffected (leading zeros parse fine as `u64`).

## Testing

Verified against a real mount (hello with `--n-threads 2`, 8 concurrent readers hammering `hello.txt`, a tight loop re-reading `stats-per-thread` and checking every read):

* **Unfixed:** reproduced the flake - `b"9\n21\n\n"` (empty third line, the exact `cannot parse integer from empty string` signature from master's CI failure), with observed file sizes varying between 4 and 10 bytes.
* **Fixed:** 110,335 reads over 30s with zero torn reads and a constant 42-byte size, with both event-loop threads serving requests.

`cargo fmt --check` and `cargo clippy --all-targets` with `RUSTFLAGS=--deny warnings` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfPeUUeQKYjo26Y9mQG9sA

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfPeUUeQKYjo26Y9mQG9sA)_