### PR TITLE
Fix corruption of pre-epoch timestamps with fractional seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 * Fix inverted mounted-check during session teardown: after the filesystem had already been
   unmounted externally, fuser would attempt to unmount the mountpoint again, which could
   unmount an unrelated filesystem mounted at the same path in the meantime
+* Fix corruption of pre-1970 timestamps with fractional seconds in `setattr`: the nanoseconds
+  were subtracted from instead of added to the (negative) whole second, shifting times by up
+  to two seconds
 
 ## 0.18.0 - 2026-07-22
 * Remove deprecated feature flags `abi-*`

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -247,11 +247,15 @@ fn time_now() -> (i64, u32) {
     time_from_system_time(&SystemTime::now())
 }
 
+// As in a timespec, nanoseconds count forward from the whole second even when it
+// is negative: the represented time is secs + nsecs / 1e9
 fn system_time_from_time(secs: i64, nsecs: u32) -> SystemTime {
     if secs >= 0 {
         UNIX_EPOCH + Duration::new(secs as u64, nsecs)
+    } else if nsecs == 0 {
+        UNIX_EPOCH - Duration::new(secs.unsigned_abs(), 0)
     } else {
-        UNIX_EPOCH - Duration::new((-secs) as u64, nsecs)
+        UNIX_EPOCH - Duration::new(secs.unsigned_abs() - 1, 1_000_000_000 - nsecs)
     }
 }
 
@@ -259,10 +263,14 @@ fn time_from_system_time(system_time: &SystemTime) -> (i64, u32) {
     // Convert to signed 64-bit time with epoch at 0
     match system_time.duration_since(UNIX_EPOCH) {
         Ok(duration) => (duration.as_secs() as i64, duration.subsec_nanos()),
-        Err(before_epoch_error) => (
-            -(before_epoch_error.duration().as_secs() as i64),
-            before_epoch_error.duration().subsec_nanos(),
-        ),
+        Err(before_epoch_error) => {
+            let d = before_epoch_error.duration();
+            if d.subsec_nanos() == 0 {
+                (-(d.as_secs() as i64), 0)
+            } else {
+                (-(d.as_secs() as i64) - 1, 1_000_000_000 - d.subsec_nanos())
+            }
+        }
     }
 }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -36,14 +36,20 @@ pub(crate) fn time_from_system_time(system_time: &SystemTime) -> (i64, u32) {
 
 /// Converts a tuple of (seconds, nanoseconds) since the Unix epoch to a `SystemTime`.
 ///
-/// This handles negative seconds (times before the Unix epoch).
+/// This handles negative seconds (times before the Unix epoch). As in a timespec,
+/// the nanoseconds count forward from the whole second even when it is negative:
+/// the represented time is `secs + nsecs / 1e9`.
 pub(crate) fn system_time_from_time(secs: i64, nsecs: u32) -> SystemTime {
+    // timespec nanoseconds are in [0, 1e9); clamp to avoid underflow on malformed input
+    let nsecs = nsecs.min(999_999_999);
     if secs >= 0 {
         SystemTime::UNIX_EPOCH + Duration::new(secs as u64, nsecs)
+    } else if nsecs == 0 {
+        SystemTime::UNIX_EPOCH - Duration::new(secs.unsigned_abs(), 0)
     } else {
-        // TODO: overflow
-        // TODO: 1_000_000_000 - nsec
-        SystemTime::UNIX_EPOCH - Duration::new((-secs) as u64, nsecs)
+        // The magnitude before the epoch is |secs| - 1 whole seconds plus the
+        // remainder of the final (partial) second
+        SystemTime::UNIX_EPOCH - Duration::new(secs.unsigned_abs() - 1, 1_000_000_000 - nsecs)
     }
 }
 
@@ -52,6 +58,7 @@ mod test {
     use std::time::Duration;
     use std::time::UNIX_EPOCH;
 
+    use crate::time::system_time_from_time;
     use crate::time::time_from_system_time;
 
     #[test]
@@ -59,6 +66,47 @@ mod test {
         let before_epoch = UNIX_EPOCH - Duration::new(1, 200_000_000);
         let (secs, nanos) = time_from_system_time(&before_epoch);
         assert_eq!((-2, 800_000_000), (secs, nanos));
+    }
+
+    #[test]
+    fn test_system_time_from_time_negative() {
+        // tv_sec = -1, tv_nsec = 5e8 is 0.5s before the epoch
+        assert_eq!(
+            UNIX_EPOCH - Duration::new(0, 500_000_000),
+            system_time_from_time(-1, 500_000_000)
+        );
+        assert_eq!(
+            UNIX_EPOCH - Duration::new(1, 200_000_000),
+            system_time_from_time(-2, 800_000_000)
+        );
+        assert_eq!(
+            UNIX_EPOCH - Duration::new(2, 0),
+            system_time_from_time(-2, 0)
+        );
+    }
+
+    #[test]
+    fn test_time_round_trip() {
+        for (secs, nsecs) in [
+            (0, 0),
+            (0, 1),
+            (1, 999_999_999),
+            (1_700_000_000, 123_456_789),
+            (-1, 0),
+            (-1, 1),
+            (-1, 999_999_999),
+            (-2, 800_000_000),
+            (-1_000_000_000, 500_000_000),
+            (i64::MIN, 0),
+            (i64::MIN, 1),
+            (i64::MAX, 999_999_999),
+        ] {
+            assert_eq!(
+                (secs, nsecs),
+                time_from_system_time(&system_time_from_time(secs, nsecs)),
+                "round trip failed for ({secs}, {nsecs})"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`system_time_from_time()` in `src/time.rs` converted negative timespecs as `UNIX_EPOCH - Duration::new(-secs, nsecs)` - subtracting the nanoseconds - but the kernel's timespec convention is that nanoseconds count *forward* from the whole second (`time = secs + nsecs / 1e9`). The two `TODO` comments in the function marked exactly this.

Consequences:
* A `utimensat()`/`futimens()` setting a pre-1970 time with a nonzero nanosecond component was delivered to `Filesystem::setattr` shifted by up to 2 seconds (e.g. `tv_sec=-1, tv_nsec=5e8`, which is 0.5s before the epoch, arrived as 1.5s before the epoch). The inverse conversion (`time_from_system_time`) is correct, so set/stat round trips visibly returned the wrong time.
* `(-secs)` overflows and panics in debug builds for `tv_sec = i64::MIN`. The fix uses `unsigned_abs()` and clamps out-of-range nanoseconds instead of underflowing.

Whole-second pre-epoch values were unaffected, which is why existing test suites (e.g. xfstests' pre-epoch cases) never caught it.

The `simple` example had its own duplicated copies of both conversions with the same bug (plus a mismatched inverse), fixed to match.

## Testing

* New unit tests: direct negative-conversion cases and a round-trip test over positive, negative, and boundary values including `i64::MIN`/`i64::MAX`.
* End-to-end through a real mount of the `simple` example, setting timestamps with `utimensat` and reading them back with `stat`:
  * **Unfixed:** `atime=-0.5s, mtime=-1.2s` came back as `-1.5s` / `-2.8s`; the whole-second control (`-2s`) was correct.
  * **Fixed:** all values round-trip exactly.
* `cargo test --lib` (56 tests), `cargo fmt --check`, and `cargo clippy --all-targets` with `RUSTFLAGS=--deny warnings` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfPeUUeQKYjo26Y9mQG9sA

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfPeUUeQKYjo26Y9mQG9sA)_