### PR TITLE
Skip unmount during teardown when already unmounted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 * Fix inverted mounted-check during session teardown: after the filesystem had already been
   unmounted externally, fuser would attempt to unmount the mountpoint again, which could
   unmount an unrelated filesystem mounted at the same path in the meantime
+* Apply the same already-unmounted check to the `libfuse2` and `libfuse3` mount backends,
+  fixing the spurious "Failed to umount filesystem" warning when a session is dropped after
+  an external unmount (#658). As in libfuse, a connection that was aborted (e.g. via
+  fusectl) also counts as already unmounted; its dead mount is left to `auto_unmount` or
+  `fusermount -u -z`
+* Fix a per-mount memory leak in the `libfuse3` backend: the `fuse_session` is now destroyed
+  on every teardown path, including when mounting fails partway through setup
 * Fix corruption of pre-1970 timestamps with fractional seconds in `setattr`: the nanoseconds
   were subtracted from instead of added to the (negative) whole second, shifting times by up
   to two seconds

--- a/src/mnt/fuse3.rs
+++ b/src/mnt/fuse3.rs
@@ -54,11 +54,14 @@ impl MountImpl {
             if fuse_session.is_null() {
                 return Err(io::Error::last_os_error());
             }
+            // Construct the guard before the fallible setup steps, so an early
+            // return destroys the session via Drop instead of leaking it
             let mount = MountImpl {
                 fuse_session,
-                mountpoint: mnt.clone(),
+                mountpoint: mnt,
             };
-            let result = unsafe { fuse_session_mount(mount.fuse_session, mnt.as_ptr()) };
+            let result =
+                unsafe { fuse_session_mount(mount.fuse_session, mount.mountpoint.as_ptr()) };
             if result != 0 {
                 return Err(ensure_last_os_error());
             }
@@ -81,9 +84,12 @@ impl MountImpl {
             // library go through the setuid-root "fusermount -u" to unmount.
             if err == nix::errno::Errno::EPERM {
                 #[cfg(target_os = "linux")]
-                unsafe {
-                    fuse_session_unmount(self.fuse_session);
-                    fuse_session_destroy(self.fuse_session);
+                {
+                    unsafe {
+                        fuse_session_unmount(self.fuse_session);
+                        fuse_session_destroy(self.fuse_session);
+                    }
+                    self.fuse_session = ptr::null_mut();
                     return Ok(());
                 }
             }
@@ -92,4 +98,20 @@ impl MountImpl {
         Ok(())
     }
 }
+
+impl Drop for MountImpl {
+    fn drop(&mut self) {
+        // Free the session on every teardown path (it may already be gone if
+        // umount_impl went through fuse_session_unmount). This only releases the
+        // session's resources; any unmounting has been done by umount_impl, or was
+        // deliberately skipped because the filesystem is no longer mounted
+        if !self.fuse_session.is_null() {
+            unsafe {
+                fuse_session_destroy(self.fuse_session);
+            }
+            self.fuse_session = ptr::null_mut();
+        }
+    }
+}
+
 unsafe impl Send for MountImpl {}

--- a/src/mnt/fuse_pure.rs
+++ b/src/mnt/fuse_pure.rs
@@ -40,7 +40,6 @@ use nix::sys::socket::recvmsg;
 
 use crate::SessionACL;
 use crate::dev_fuse::DevFuse;
-use crate::mnt::is_mounted;
 use crate::mnt::mount_options::MountOption;
 use crate::mnt::mount_options::MountOptionGroup;
 use crate::mnt::mount_options::option_group;
@@ -56,7 +55,6 @@ const MOUNT_FUSEFS_BIN: &str = "mount_fusefs";
 pub(crate) struct MountImpl {
     mountpoint: CString,
     auto_unmount_socket: Option<UnixStream>,
-    fuse_device: Arc<DevFuse>,
 }
 impl MountImpl {
     pub(crate) fn new(
@@ -68,22 +66,15 @@ impl MountImpl {
         let (file, sock) = fuse_mount_pure(mountpoint.as_os_str(), options, acl)?;
         let file = Arc::new(file);
         Ok((
-            file.clone(),
+            file,
             MountImpl {
                 mountpoint: CString::new(mountpoint.as_os_str().as_bytes())?,
                 auto_unmount_socket: sock,
-                fuse_device: file,
             },
         ))
     }
 
     pub(crate) fn umount_impl(&mut self) -> io::Result<()> {
-        if !is_mounted(&self.fuse_device) {
-            // If the filesystem has already been unmounted, avoid unmounting it again.
-            // Unmounting it a second time could cause a race with a newly mounted filesystem
-            // living at the same mountpoint
-            return Ok(());
-        }
         if let Some(sock) = mem::take(&mut self.auto_unmount_socket) {
             drop(sock);
             // fusermount in auto-unmount mode, no more work to do.

--- a/src/mnt/mod.rs
+++ b/src/mnt/mod.rs
@@ -93,6 +93,9 @@ impl MountImpl {
 pub(crate) struct Mount {
     mount_impl: Option<MountImpl>,
     mount_point: PathBuf,
+    /// The FUSE device fd of this mount's kernel connection.
+    #[cfg_attr(target_os = "macos", allow(dead_code))]
+    fuse_device: Arc<DevFuse>,
 }
 
 impl Mount {
@@ -102,38 +105,20 @@ impl Mount {
         acl: SessionACL,
     ) -> io::Result<(Arc<DevFuse>, Mount)> {
         #[cfg(fuser_mount_impl = "pure-rust")]
-        {
+        let (dev_fuse, mount_impl) = {
             let (dev_fuse, mount) = fuse_pure::MountImpl::new(mountpoint, options, acl)?;
-            Ok((
-                dev_fuse,
-                Mount {
-                    mount_impl: Some(MountImpl::Pure(mount)),
-                    mount_point: mountpoint.to_path_buf(),
-                },
-            ))
-        }
+            (dev_fuse, MountImpl::Pure(mount))
+        };
         #[cfg(fuser_mount_impl = "libfuse2")]
-        {
+        let (dev_fuse, mount_impl) = {
             let (dev_fuse, mount) = fuse2::MountImpl::new(mountpoint, options, acl)?;
-            Ok((
-                dev_fuse,
-                Mount {
-                    mount_impl: Some(MountImpl::Fuse2(mount)),
-                    mount_point: mountpoint.to_path_buf(),
-                },
-            ))
-        }
+            (dev_fuse, MountImpl::Fuse2(mount))
+        };
         #[cfg(fuser_mount_impl = "libfuse3")]
-        {
+        let (dev_fuse, mount_impl) = {
             let (dev_fuse, mount) = fuse3::MountImpl::new(mountpoint, options, acl)?;
-            Ok((
-                dev_fuse,
-                Mount {
-                    mount_impl: Some(MountImpl::Fuse3(mount)),
-                    mount_point: mountpoint.to_path_buf(),
-                },
-            ))
-        }
+            (dev_fuse, MountImpl::Fuse3(mount))
+        };
         #[cfg(fuser_mount_impl = "macos-no-mount")]
         {
             let _ = (mountpoint, options, acl);
@@ -141,11 +126,45 @@ impl Mount {
                 "Mount is not enabled; this is test-only configuration",
             ))
         }
+        #[cfg(not(fuser_mount_impl = "macos-no-mount"))]
+        {
+            Ok((
+                dev_fuse.clone(),
+                Mount {
+                    mount_impl: Some(mount_impl),
+                    mount_point: mountpoint.to_path_buf(),
+                    fuse_device: dev_fuse,
+                },
+            ))
+        }
+    }
+
+    /// Whether teardown should unmount the mountpoint: only if our kernel connection
+    /// is still alive. If it is dead (POLLERR on the FUSE device fd), the filesystem
+    /// was either unmounted externally (issue #658) or the connection was aborted,
+    /// and unmounting by path could hit an unrelated filesystem mounted there in the
+    /// meantime. This is the same check libfuse's fuse_kern_unmount() performs, with
+    /// the same limits: an aborted connection whose dead mount is still in the mount
+    /// table is left behind (auto_unmount or "fusermount -u -z" cleans it up), and a
+    /// lazily detached mount keeps the connection alive, so it is still unmounted by
+    /// path. The decision never accesses the mountpoint through the filesystem,
+    /// which could block on an unresponsive or unserved mount.
+    #[cfg(not(target_os = "macos"))]
+    fn should_unmount(&self) -> bool {
+        is_mounted(&self.fuse_device)
+    }
+
+    #[cfg(target_os = "macos")]
+    fn should_unmount(&self) -> bool {
+        true
     }
 
     pub(crate) fn umount(mut self) -> io::Result<()> {
         match self.mount_impl.take() {
             Some(mut mount) => {
+                if !self.should_unmount() {
+                    return Ok(());
+                }
                 info!("Unmounting {}", self.mount_point.display());
                 mount.umount_impl()
             }
@@ -157,6 +176,9 @@ impl Mount {
 impl Drop for Mount {
     fn drop(&mut self) {
         if let Some(mut mount) = self.mount_impl.take() {
+            if !self.should_unmount() {
+                return;
+            }
             if let Err(err) = mount.umount_impl() {
                 // This is not necessarily an error: may happen if a user called 'umount'.
                 warn!("Unmount failed: {}", err);
@@ -192,7 +214,7 @@ fn libc_umount(mnt: &CStr) -> nix::Result<()> {
 
 /// Warning: This will return true if the filesystem has been detached (lazy unmounted), but not
 /// yet destroyed by the kernel.
-#[cfg(any(all(not(target_os = "macos"), test), fuser_mount_impl = "pure-rust"))]
+#[cfg(not(target_os = "macos"))]
 fn is_mounted(fuse_device: &DevFuse) -> bool {
     use std::os::unix::io::AsFd;
     use std::slice;
@@ -279,9 +301,7 @@ mod test {
     #[test]
     #[cfg(not(target_os = "macos"))]
     fn mount_unmount_external() {
-        use std::ffi::CString;
         use std::mem::ManuallyDrop;
-        use std::os::unix::ffi::OsStrExt;
 
         // We use ManuallyDrop here to leak the directory on test failure.  We don't
         // want to try and clean up the directory if it's a mountpoint otherwise we'll
@@ -290,35 +310,84 @@ mod test {
         let (file, mount) = Mount::new(tmp.path(), &[], SessionACL::default()).unwrap();
         assert!(is_mounted(&file));
 
-        // Unmount externally, without going through `mount`
+        external_unmount(tmp.path());
+        wait_until_not_mounted(&file);
+
+        // Unmounting again must succeed as a no-op now that the filesystem is
+        // already gone, on every mount backend (issue #658: the libfuse backends
+        // used to fail with EINVAL here and log a spurious warning)
+        mount
+            .umount()
+            .expect("unmount after external unmount must succeed");
+        ManuallyDrop::into_inner(tmp);
+    }
+
+    /// After an external unmount, an unrelated replacement filesystem mounted at the
+    /// same path must not be unmounted by the old session's teardown, nor may teardown
+    /// probe the mountpoint through the (unserved) replacement filesystem, which would
+    /// block indefinitely.
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn mount_unmount_replacement() {
+        use std::mem::ManuallyDrop;
+
+        let tmp = ManuallyDrop::new(tempfile::tempdir().unwrap());
+        let (file_a, mount_a) = Mount::new(tmp.path(), &[], SessionACL::default()).unwrap();
+        assert!(is_mounted(&file_a));
+
+        external_unmount(tmp.path());
+        wait_until_not_mounted(&file_a);
+
+        // Mount an unrelated replacement filesystem at the same path. Nothing serves
+        // it, so any teardown path that touches the mountpoint via the filesystem
+        // would block
+        let (file_b, mount_b) = Mount::new(tmp.path(), &[], SessionACL::default()).unwrap();
+        assert!(is_mounted(&file_b));
+
+        mount_a
+            .umount()
+            .expect("unmount after external unmount must succeed");
+        assert!(
+            is_mounted(&file_b),
+            "teardown of the old session must not unmount the replacement filesystem"
+        );
+
+        mount_b.umount().expect("replacement unmount must succeed");
+        ManuallyDrop::into_inner(tmp);
+    }
+
+    /// Unmount externally, without going through `Mount`
+    #[cfg(not(target_os = "macos"))]
+    fn external_unmount(mountpoint: &std::path::Path) {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
         let unmounted = ["fusermount3", "fusermount"].iter().any(|bin| {
             std::process::Command::new(bin)
                 .arg("-u")
-                .arg(tmp.path())
+                .arg(mountpoint)
                 .status()
                 .is_ok_and(|status| status.success())
         });
         if !unmounted {
             // No fusermount binary available; fall back to umount(2), which
             // requires root
-            let mountpoint = CString::new(tmp.path().as_os_str().as_bytes()).unwrap();
+            let mountpoint = CString::new(mountpoint.as_os_str().as_bytes()).unwrap();
             libc_umount(&mountpoint).unwrap();
         }
+    }
 
-        // The kernel may tear down the connection asynchronously, so allow some time
+    /// The kernel may tear the connection down asynchronously, so allow some time
+    #[cfg(not(target_os = "macos"))]
+    fn wait_until_not_mounted(file: &Arc<DevFuse>) {
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-        while is_mounted(&file) && std::time::Instant::now() < deadline {
+        while is_mounted(file) && std::time::Instant::now() < deadline {
             std::thread::sleep(std::time::Duration::from_millis(10));
         }
         assert!(
-            !is_mounted(&file),
-            "is_mounted() must report false after the filesystem was unmounted"
+            !is_mounted(file),
+            "connection must be dead after the filesystem was unmounted"
         );
-
-        // Dropping the mount must not fail even though the filesystem is
-        // already unmounted
-        drop(mount);
-        ManuallyDrop::into_inner(tmp);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #658

## Problem

When a filesystem is unmounted externally (`umount <path>`), session teardown unmounts again. The pure-rust backend has skipped that second unmount since #703, but the `libfuse2` and `libfuse3` backends still called `umount(2)` unconditionally, failing with `EINVAL` and logging the spurious `Failed to umount filesystem: Invalid argument (os error 22)` warning from #658. A second unmount can also hit an unrelated filesystem mounted at the same path in the meantime.

## Fix

Hoist the already-unmounted check out of the pure-rust backend into `Mount`, shared by all three backends: teardown skips the unmount when our kernel connection is dead, detected by a zero-timeout poll for `POLLERR` on the FUSE device fd. This is the same check libfuse's `fuse_kern_unmount()` performs, deliberately with the same semantics and limits:

* an externally unmounted filesystem is detected via our own fd, so teardown never accesses the mountpoint through the filesystem: it cannot block on an unresponsive or unserved replacement mount, and does not unmount it;
* an aborted connection counts as already unmounted, as in libfuse: its dead mount stays in the mount table for `auto_unmount` or `fusermount -u -z` to clean up;
* a lazily detached mount keeps the connection alive and is still unmounted by path.

One small fix rode along: `fuse3::MountImpl` now destroys its `fuse_session` via `Drop` on every teardown path and when mounting fails partway through setup, fixing a pre-existing per-mount memory leak.

An earlier revision of this PR instead verified the mount-table identity (device number, fstype, and fusectl connection inode) before unmounting, which additionally covered aborted-mount cleanup and FUSE replacements that recycle our device number; it was dropped in favor of this simpler libfuse-parity approach at the maintainer's request (see review discussion).

## Testing

Regression tests, verified to fail without the fix, passing on all three mount backends (real mounts through libfuse 2.9.9 and 3.14.0, plus the pure-rust default):

* `mount_unmount_external` - unmount externally, then teardown must succeed as a no-op (#658's case; previously EINVAL under libfuse).
* `mount_unmount_replacement` - external unmount, then an unrelated *unserved* FUSE filesystem mounted at the same path: teardown must neither block on it nor unmount it.

`cargo test --lib`, `cargo fmt --check`, and `cargo clippy --all-targets` with `RUSTFLAGS=--deny warnings` pass for default features, `libfuse2`, and `libfuse3`; `cargo check --target x86_64-apple-darwin --features=macos-no-mount` passes for the macOS configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfPeUUeQKYjo26Y9mQG9sA