### PR TITLE
Enforce the kernel's 4096-byte minimum in KernelConfig::set_max_write()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # FUSE for Rust - Changelog
 
 ## Unreleased
+* `KernelConfig::set_max_write()` now rejects values below 4096 with the nearest valid value,
+  per its documented contract (#327). The kernel clamps `max_write` to at least 4096, so a
+  smaller value was accepted but ineffective: write requests of up to 4096 bytes still arrived
 * Fix inverted mounted-check during session teardown: after the filesystem had already been
   unmounted externally, fuser would attempt to unmount the mountpoint again, which could
   unmount an unrelated filesystem mounted at the same path in the meantime

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ pub use crate::reply::ReplyXattr;
 pub use crate::request_param::Request;
 pub use crate::session::BackgroundSession;
 use crate::session::MAX_WRITE_SIZE;
+use crate::session::MIN_WRITE_SIZE;
 pub use crate::session::Session;
 pub use crate::session::SessionACL;
 pub use crate::session::SessionUnmounter;
@@ -295,10 +296,13 @@ impl KernelConfig {
     ///
     /// On success returns the previous value.
     /// # Errors
-    /// If the argument is too large, returns the nearest value which will succeed.
+    /// If the argument is too small or too large, returns the nearest value which will succeed.
     pub fn set_max_write(&mut self, value: u32) -> Result<u32, u32> {
-        if value == 0 {
-            return Err(1);
+        // The kernel clamps max_write below 4096 up to 4096 (process_init_reply()
+        // in fs/fuse/inode.c), so a smaller advertised value would not take
+        // effect: write requests of up to 4096 bytes would still arrive
+        if value < MIN_WRITE_SIZE as u32 {
+            return Err(MIN_WRITE_SIZE as u32);
         }
         if value > MAX_WRITE_SIZE as u32 {
             return Err(MAX_WRITE_SIZE as u32);
@@ -1071,4 +1075,37 @@ pub fn spawn_mount<'a, FS: Filesystem + Send + 'static + 'a, P: AsRef<Path>>(
     options: &Config,
 ) -> io::Result<BackgroundSession> {
     Session::new(filesystem, mountpoint.as_ref(), options).and_then(session::Session::spawn)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kernel_config_set_max_write_bounds() {
+        let mut config = KernelConfig::new(InitFlags::empty(), 65536, Version(7, 31));
+        // Values the kernel would not honor (it clamps max_write below 4096 up
+        // to 4096) are rejected with the nearest value that will take effect
+        assert_eq!(config.set_max_write(0), Err(MIN_WRITE_SIZE as u32));
+        assert_eq!(
+            config.set_max_write(MIN_WRITE_SIZE as u32 - 1),
+            Err(MIN_WRITE_SIZE as u32)
+        );
+        // Values beyond the session's read buffer are rejected likewise
+        assert_eq!(
+            config.set_max_write(MAX_WRITE_SIZE as u32 + 1),
+            Err(MAX_WRITE_SIZE as u32)
+        );
+        // Rejected calls must leave the configured value unchanged
+        assert_eq!(config.max_write, MAX_WRITE_SIZE as u32);
+        // Both bounds themselves are accepted, returning the previous value
+        assert_eq!(
+            config.set_max_write(MIN_WRITE_SIZE as u32),
+            Ok(MAX_WRITE_SIZE as u32)
+        );
+        assert_eq!(
+            config.set_max_write(MAX_WRITE_SIZE as u32),
+            Ok(MIN_WRITE_SIZE as u32)
+        );
+    }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -54,6 +54,11 @@ use crate::request::RequestWithSender;
 /// and 128k on other systems.
 pub(crate) const MAX_WRITE_SIZE: usize = 16 * 1024 * 1024;
 
+/// The minimum write size the kernel will honor: process_init_reply() in the
+/// kernel's fs/fuse/inode.c clamps a smaller negotiated max_write up to 4096,
+/// so advertising less would not stop larger write requests from arriving.
+pub(crate) const MIN_WRITE_SIZE: usize = 4096;
+
 #[derive(Default, Debug, Eq, PartialEq, Clone, Copy)]
 /// How requests should be filtered based on the calling UID.
 pub enum SessionACL {


### PR DESCRIPTION
Fixes #327

## Problem

`KernelConfig::set_max_write()` documents that an out-of-range argument is rejected with the nearest value which will succeed, but it only checked the upper bound (and zero). Values in `1..4095` were accepted even though the kernel clamps `max_write` to at least 4096 - `process_init_reply()` in `fs/fuse/inode.c`:

```c
fc->max_write = max_t(unsigned, 4096, fc->max_write);
```

So the setting was silently ineffective: a filesystem that configured e.g. `set_max_write(1024)` could still receive write requests of up to 4096 bytes, larger than the limit it believed it had negotiated. (`MAX_WRITE_SIZE`'s documentation already states "The absolute minimum is 4k".)

## Fix

Reject values below a new `MIN_WRITE_SIZE` constant (4096, documented with the kernel reference) with that nearest valid value, per the setter's existing convention. This replaces the previous zero-only check, whose `Err(1)` suggestion was itself a value the kernel would not honor.

## Testing

* New unit test `kernel_config_set_max_write_bounds` covering both bounds, rejection values, that rejected calls leave the configuration unchanged, and that the exact bounds are accepted. Verified to fail against the previous code (`set_max_write(0)` returned `Err(1)`, `set_max_write(4095)` was accepted) and pass with the fix.
* `cargo test --lib`, `cargo fmt --check`, and `cargo clippy --all-targets` with `RUSTFLAGS=--deny warnings` pass for default features, `libfuse2`, and `libfuse3`; `cargo check --target x86_64-apple-darwin --features=macos-no-mount` passes for the macOS configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfPeUUeQKYjo26Y9mQG9sA

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfPeUUeQKYjo26Y9mQG9sA)_