### PR TITLE
Treat ECONNABORTED from the FUSE device as a clean session end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # FUSE for Rust - Changelog
 
 ## Unreleased
+* Treat `ECONNABORTED` from the FUSE device as a clean session end (#212): with
+  `FUSE_ABORT_ERROR` negotiated, aborting the connection made `Session::run()` and
+  `BackgroundSession::umount_and_join()` return an error instead of ending normally
+  the way an unmount (`ENODEV`) does
 * `KernelConfig::set_max_write()` now rejects values below 4096 with the nearest valid value,
   per its documented contract (#327). The kernel clamps `max_write` to at least 4096, so a
   smaller value was accepted but ineffective: write requests of up to 4096 bytes still arrived

--- a/src/session.rs
+++ b/src/session.rs
@@ -345,7 +345,7 @@ impl<FS: Filesystem> Session<FS> {
             // Read the init request from the kernel
             let size = match self.ch.receive_retrying(buf) {
                 Ok(size) => size,
-                Err(nix::errno::Errno::ENODEV) => {
+                Err(nix::errno::Errno::ENODEV | nix::errno::Errno::ECONNABORTED) => {
                     return Err(io::Error::new(
                         io::ErrorKind::NotConnected,
                         "FUSE device disconnected during handshake",
@@ -553,7 +553,11 @@ impl<FS: Filesystem> SessionEventLoop<FS> {
                         ));
                     }
                 },
-                Err(nix::errno::Errno::ENODEV) => return Ok(()),
+                // The kernel returns ENODEV when the filesystem was unmounted, or
+                // ECONNABORTED when the connection was aborted with FUSE_ABORT_ERROR
+                // negotiated. Either way the connection is gone: a normal end of the
+                // session, not an operation failure (issue #212)
+                Err(nix::errno::Errno::ENODEV | nix::errno::Errno::ECONNABORTED) => return Ok(()),
                 Err(err) => return Err(err.into()),
             }
         }
@@ -595,5 +599,104 @@ impl BackgroundSession {
                     "filesystem background thread panicked",
                 )
             })?
+    }
+}
+
+// The abort test uses fusectl, which only exists on Linux; on other targets the
+// whole module would be dead code
+#[cfg(all(test, target_os = "linux"))]
+mod test {
+    use std::io::Write;
+    use std::mem::ManuallyDrop;
+
+    use super::*;
+    use crate::Config;
+    use crate::InitFlags;
+    use crate::KernelConfig;
+    use crate::Request;
+
+    /// A filesystem that requests FUSE_ABORT_ERROR during init, so that after an
+    /// abort the FUSE device fails reads with ECONNABORTED instead of ENODEV.
+    struct AbortErrorFs;
+
+    impl Filesystem for AbortErrorFs {
+        fn init(&mut self, _req: &Request, config: &mut KernelConfig) -> io::Result<()> {
+            // Ignore the error: on kernels without FUSE_ABORT_ERROR an abort
+            // yields ENODEV, which ends the session cleanly anyway
+            let _ = config.add_capabilities(InitFlags::FUSE_ABORT_ERROR);
+            Ok(())
+        }
+    }
+
+    /// Aborting the connection (via fusectl) with FUSE_ABORT_ERROR negotiated makes
+    /// the FUSE device return ECONNABORTED. The session loop must treat that as a
+    /// normal end of the session, so that umount_and_join() reports success rather
+    /// than an error for an administratively aborted filesystem (issue #212).
+    #[test]
+    fn session_ends_cleanly_after_abort() {
+        // Leak the directory on failure: it may still be a (dead) mountpoint
+        let tmp = ManuallyDrop::new(tempfile::tempdir().unwrap());
+        // The mount table lists the canonical path; resolve while it is a plain dir
+        let mountpoint = tmp.path().canonicalize().unwrap();
+
+        let session = Session::new(AbortErrorFs, &mountpoint, &Config::default()).unwrap();
+        let bg = session.spawn().unwrap();
+
+        // Wait until the handshake completed: the kernel forwards filesystem
+        // requests only after the init reply was processed, so a completed
+        // operation (the errno does not matter) proves the loop is past it
+        let _ = std::fs::metadata(&mountpoint);
+
+        let Some(abort_path) = fusectl_abort_path(&mountpoint) else {
+            eprintln!("skipping session_ends_cleanly_after_abort: fusectl not available");
+            bg.umount_and_join().unwrap();
+            ManuallyDrop::into_inner(tmp);
+            return;
+        };
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(abort_path)
+            .unwrap()
+            .write_all(b"1")
+            .unwrap();
+
+        bg.umount_and_join()
+            .expect("session must end cleanly after the connection was aborted");
+
+        // Teardown intentionally leaves the dead mount in the mount table (the
+        // same as libfuse); detach it so the tempdir can be removed
+        let _ = nix::mount::umount2(&mountpoint, nix::mount::MntFlags::MNT_DETACH);
+        for fusermount in ["fusermount3", "fusermount"] {
+            let _ = std::process::Command::new(fusermount)
+                .args(["-u", "-q", "-z", "--"])
+                .arg(&mountpoint)
+                .status();
+        }
+        ManuallyDrop::into_inner(tmp);
+    }
+
+    /// The fusectl abort file for the FUSE mount at `mountpoint`: the connection
+    /// directory is named after the mount's anonymous device number.
+    fn fusectl_abort_path(mountpoint: &Path) -> Option<std::path::PathBuf> {
+        let mountinfo = std::fs::read_to_string("/proc/self/mountinfo").ok()?;
+        let mut device = None;
+        for line in mountinfo.lines() {
+            let mut fields = line.split(' ');
+            let (Some(dev), Some(path)) = (fields.nth(2), fields.nth(1)) else {
+                continue;
+            };
+            // mountinfo octal-escapes special characters; the tempdir path has none.
+            // Later entries are mounted on top of earlier ones, so the last match wins
+            if Path::new(path) == mountpoint {
+                let (major, minor) = dev.split_once(':')?;
+                let (major, minor): (u64, u64) = (major.parse().ok()?, minor.parse().ok()?);
+                // fusectl names the directory with the raw kernel-internal
+                // device number, (major << 20) | minor: fuse_ctl_add_conn()
+                // prints fc->dev (= sb->s_dev) without re-encoding it
+                device = Some((major << 20) | minor);
+            }
+        }
+        let path = std::path::PathBuf::from(format!("/sys/fs/fuse/connections/{}/abort", device?));
+        path.exists().then_some(path)
     }
 }


### PR DESCRIPTION
Fixes #212

## Problem

#212 reported `BackgroundSession::join` panicking with `Os { code: 103, kind: ConnectionAborted }` when teardown raced concurrent filesystem access. The panicking half was fixed in 0.17 (`umount_and_join()` returns `io::Result`). The remaining half is the error itself: when `FUSE_ABORT_ERROR` has been negotiated, the kernel fails reads on the FUSE device with `ECONNABORTED` instead of `ENODEV` once the connection is aborted - `fuse_dev_do_read()` in `fs/fuse/dev.c` picks between exactly those two errnos. The session event loop only recognized `ENODEV` as the end of the session, so an abort surfaced as an `Err` from `Session::run()` / `umount_and_join()` for what is a normal administrative teardown. Without the flag the very same abort yields `ENODEV` and ends the session cleanly - the errno difference is informational, not a different condition.

## Fix

* `SessionEventLoop::event_loop()`: return `Ok(())` for `ENODEV | ECONNABORTED` (with a comment explaining the pairing).
* Handshake loop: map the same pair to the existing "FUSE device disconnected during handshake" `NotConnected` error, instead of leaking a raw `ECONNABORTED` for an abort that lands mid-handshake.

## Testing

New regression test `session_ends_cleanly_after_abort`: mounts a filesystem whose `init` requests `FUSE_ABORT_ERROR`, waits for the handshake to complete (via a filesystem operation, so the abort deterministically hits the main event loop), aborts the connection through fusectl, and asserts `umount_and_join()` succeeds. It self-skips with a message when fusectl is unavailable, and detaches the (intentionally left, matching libfuse) dead mount afterwards so the tempdir can be removed. The mountinfo/fusectl lookup involved is test-only scaffolding - it is the only way to trigger an abort - and none of it is production code.

Verified to fail without the fix (`umount_and_join()` returned `Err(Os { code: 103 })`) and pass with it, on all three mount backends. `cargo test --lib`, `cargo fmt --check`, and `cargo clippy --all-targets` with `RUSTFLAGS=--deny warnings` pass for default features, `libfuse2`, and `libfuse3`; `cargo check --target x86_64-apple-darwin --features=macos-no-mount` passes for the macOS configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfPeUUeQKYjo26Y9mQG9sA

---
_Generated by [Claude Code](https://claude.ai/code/session_01TfPeUUeQKYjo26Y9mQG9sA)_