### PR TITLE
Escape and validate special characters in mount option values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@
   an external unmount (#658). As in libfuse, a connection that was aborted (e.g. via
   fusectl) also counts as already unmounted; its dead mount is left to `auto_unmount` or
   `fusermount -u -z`
+* Fix special characters in `MountOption` values being interpreted as further mount options
+  (#424). `MountOption::FSName("foo,ro")` used to mount a filesystem named `foo` that was
+  read-only, instead of one named `foo,ro`. Commas and backslashes in `FSName` are now escaped
+  for libfuse and the fusermount helpers. `Subtype` and `CUSTOM` values containing a comma or
+  backslash, which cannot be escaped consistently, are now rejected by `Session::new()`, as are
+  NUL bytes in any value, which used to panic. On platforms other than Linux the mount helpers
+  support no escaping, so `FSName` is restricted there as well
 * Fix a per-mount memory leak in the `libfuse3` backend: the `fuse_session` is now destroyed
   on every teardown path, including when mounting fails partway through setup
 * Fix corruption of pre-1970 timestamps with fractional seconds in `setattr`: the nanoseconds

--- a/src/mnt/fuse_pure.rs
+++ b/src/mnt/fuse_pure.rs
@@ -43,6 +43,7 @@ use crate::dev_fuse::DevFuse;
 use crate::mnt::mount_options::MountOption;
 use crate::mnt::mount_options::MountOptionGroup;
 use crate::mnt::mount_options::option_group;
+use crate::mnt::mount_options::option_to_escaped_string;
 use crate::mnt::mount_options::option_to_flag;
 use crate::mnt::mount_options::option_to_string;
 
@@ -250,7 +251,7 @@ fn fuse_mount_fusermount(
 
     let mut builder = Command::new(&fusermount_bin);
     builder.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let mut options_strs: Vec<String> = options.iter().map(option_to_string).collect();
+    let mut options_strs: Vec<String> = options.iter().map(option_to_escaped_string).collect();
     options_strs.extend(acl.to_mount_option().map(|s| s.to_owned()));
     if !options_strs.is_empty() {
         builder.arg("-o");
@@ -335,6 +336,8 @@ fn fuse_mount_mount_fusefs(
 
     let mut builder = Command::new(fusermount_bin);
     builder.stdout(Stdio::piped()).stderr(Stdio::piped());
+    // Unlike fusermount, mount_fusefs decodes no escapes. That is why the platforms
+    // using it reject comma and backslash in option values outright
     let mut options_strs: Vec<String> = options.iter().map(option_to_string).collect();
     options_strs.extend(acl.to_mount_option().map(|s| s.to_owned()));
     if !options_strs.is_empty() {

--- a/src/mnt/mod.rs
+++ b/src/mnt/mod.rs
@@ -22,6 +22,7 @@ use fuse2_sys::fuse_args;
 use log::info;
 use log::warn;
 use mount_options::MountOption;
+use mount_options::check_option_values;
 
 use crate::dev_fuse::DevFuse;
 
@@ -35,13 +36,14 @@ fn with_fuse_args<T, F: FnOnce(&fuse_args) -> T>(
 ) -> T {
     use std::ffi::CString;
 
-    use mount_options::option_to_string;
+    use mount_options::option_to_escaped_string;
 
     let mut args = vec![CString::new("rust-fuse").unwrap()];
     for x in options {
         args.extend_from_slice(&[
             CString::new("-o").unwrap(),
-            CString::new(option_to_string(x)).unwrap(),
+            CString::new(option_to_escaped_string(x))
+                .expect("option values are checked for NUL by check_option_values()"),
         ]);
     }
     if let Some(acl) = acl.to_mount_option() {
@@ -104,6 +106,10 @@ impl Mount {
         options: &[MountOption],
         acl: SessionACL,
     ) -> io::Result<(Arc<DevFuse>, Mount)> {
+        // Checked here, rather than in Session, so that every formatting of an option
+        // value below can rely on it
+        check_option_values(options)?;
+
         #[cfg(fuser_mount_impl = "pure-rust")]
         let (dev_fuse, mount_impl) = {
             let (dev_fuse, mount) = fuse_pure::MountImpl::new(mountpoint, options, acl)?;
@@ -360,6 +366,63 @@ mod test {
         assert!(fusermount_unmount("/nonexistent/fusermount", &mountpoint).is_err());
         // Helper reports success
         assert!(fusermount_unmount("/bin/true", &mountpoint).is_ok());
+    }
+
+    /// libfuse splits each -o argument on commas, so a comma in a value must reach it
+    /// escaped
+    #[test]
+    fn fuse_args_escaping() {
+        with_fuse_args(
+            &[MountOption::FSName("foo,ro".into())],
+            SessionACL::Owner,
+            |args| {
+                let v: Vec<_> = (0..args.argc)
+                    .map(|n| unsafe {
+                        CStr::from_ptr(*args.argv.offset(n as isize))
+                            .to_str()
+                            .unwrap()
+                    })
+                    .collect();
+                assert_eq!(*v, ["rust-fuse", "-o", "fsname=foo\\,ro"]);
+            },
+        );
+    }
+
+    /// A comma in `FSName` must end up in the source name of the mount, rather than
+    /// being interpreted as a separate mount option
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn mount_unmount_fsname_with_comma() {
+        use std::mem::ManuallyDrop;
+
+        let tmp = ManuallyDrop::new(tempfile::tempdir().unwrap());
+        let options = [MountOption::FSName("fuser,ro".to_owned())];
+        let (_file, mount) = Mount::new(tmp.path(), &options, SessionACL::default()).unwrap();
+
+        let mounts = std::fs::read_to_string("/proc/self/mounts").unwrap();
+        let fields: Vec<&str> = mounts
+            .lines()
+            .map(|line| line.split(' ').collect::<Vec<_>>())
+            .find(|fields| fields[1] == tmp.path().to_str().unwrap())
+            .unwrap_or_else(|| panic!("{:?} not found in:\n{}", tmp.path(), mounts));
+        assert_eq!(fields[0], "fuser,ro");
+        assert!(
+            !fields[3].split(',').any(|option| option == "ro"),
+            "the comma in the source name leaked into the mount options: {}",
+            fields[3]
+        );
+
+        mount.umount().unwrap();
+        ManuallyDrop::into_inner(tmp);
+    }
+
+    /// A NUL in an option value must be reported as an error, rather than panicking
+    #[test]
+    fn mount_option_with_nul() {
+        let tmp = tempfile::tempdir().unwrap();
+        let options = [MountOption::FSName("no\0name".to_owned())];
+        let err = Mount::new(tmp.path(), &options, SessionACL::default()).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
 
     #[cfg(not(target_os = "macos"))]

--- a/src/mnt/mount_options.rs
+++ b/src/mnt/mount_options.rs
@@ -26,10 +26,17 @@ pub struct Config {
 #[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub enum MountOption {
     /// Set the name of the source in mtab
+    ///
+    /// On Linux the value may contain any character except NUL. On other platforms it may
+    /// contain neither comma nor backslash, because the mount helpers there cannot escape them.
     FSName(String),
     /// Set the filesystem subtype in mtab
+    ///
+    /// The value may not contain NUL, comma, or backslash.
     Subtype(String),
     /// Allows passing an option which is not otherwise supported in these enums
+    ///
+    /// The value may not contain NUL, comma, or backslash.
     #[allow(clippy::upper_case_acronyms)]
     CUSTOM(String),
 
@@ -125,6 +132,46 @@ pub(crate) fn check_option_conflicts(options: &Config) -> Result<(), io::Error> 
     }
 }
 
+/// Option values reach the kernel, libfuse, or a fusermount helper inside a comma
+/// separated list, so an unescaped comma in a value is read as the start of the next
+/// option. libfuse and fusermount decode backslash escapes, but of the values fuser sends
+/// them only `fsname` is re-escaped by libfuse when it forwards options to fusermount, so
+/// every other value must be free of both characters. NUL terminates the list and can
+/// never be represented.
+pub(crate) fn check_option_values(options: &[MountOption]) -> Result<(), io::Error> {
+    for option in options {
+        match option {
+            // Linux is the only platform where every consumer of fsname either takes it
+            // verbatim (as the mount(2) source) or decodes the escapes added by
+            // option_to_escaped_string
+            MountOption::FSName(name) if cfg!(target_os = "linux") => {
+                check_option_value(option, name, &['\0'])?;
+            }
+            MountOption::FSName(value)
+            | MountOption::Subtype(value)
+            | MountOption::CUSTOM(value) => {
+                check_option_value(option, value, &['\0', ',', '\\'])?;
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn check_option_value(
+    option: &MountOption,
+    value: &str,
+    invalid: &[char],
+) -> Result<(), io::Error> {
+    match value.chars().find(|c| invalid.contains(c)) {
+        Some(c) => Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            format!("Mount option {option:?} contains an invalid character: {c:?}"),
+        )),
+        None => Ok(()),
+    }
+}
+
 fn conflicts_with(option: &MountOption) -> Vec<MountOption> {
     match option {
         MountOption::FSName(_)
@@ -171,6 +218,30 @@ pub(crate) fn option_to_string(option: &MountOption) -> String {
         MountOption::Sync => "sync".to_string(),
         MountOption::Async => "async".to_string(),
     }
+}
+
+// Format option to be passed to libfuse or a fusermount helper, both of which split the
+// option list on commas and decode backslash escapes, unlike the kernel, which takes
+// option values verbatim
+#[allow(dead_code)]
+pub(crate) fn option_to_escaped_string(option: &MountOption) -> String {
+    match option {
+        // fsname is the only value allowed to contain characters that need escaping,
+        // see check_option_values()
+        MountOption::FSName(name) => format!("fsname={}", escape_option_value(name)),
+        option => option_to_string(option),
+    }
+}
+
+fn escape_option_value(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for c in value.chars() {
+        if c == ',' || c == '\\' {
+            escaped.push('\\');
+        }
+        escaped.push(c);
+    }
+    escaped
 }
 
 #[allow(dead_code)]
@@ -308,6 +379,58 @@ mod test {
             .is_ok()
         );
     }
+    #[test]
+    fn option_value_checking() {
+        use crate::mnt::mount_options::MountOption::*;
+
+        for option in [FSName, Subtype, CUSTOM] {
+            assert!(check_option_values(&[option("no\0name".to_owned())]).is_err());
+        }
+        for option in [Subtype, CUSTOM] {
+            assert!(check_option_values(&[option("comma,injected".to_owned())]).is_err());
+            assert!(check_option_values(&[option("back\\slash".to_owned())]).is_err());
+        }
+        // Only on Linux can fsname be escaped everywhere it is used
+        assert_eq!(
+            check_option_values(&[FSName("comma,and\\backslash".to_owned())]).is_ok(),
+            cfg!(target_os = "linux")
+        );
+        assert!(
+            check_option_values(&[FSName("plain".to_owned()), CUSTOM("plain".to_owned())]).is_ok()
+        );
+    }
+
+    /// A comma in an option value must not be read as the start of another option by
+    /// libfuse or fusermount
+    #[test]
+    fn option_escaping() {
+        use crate::mnt::mount_options::MountOption::*;
+
+        assert_eq!(
+            option_to_escaped_string(&FSName("foo,ro".to_owned())),
+            "fsname=foo\\,ro"
+        );
+        assert_eq!(
+            option_to_escaped_string(&FSName("back\\slash".to_owned())),
+            "fsname=back\\\\slash"
+        );
+        // A backslash escape must survive libfuse's octal decoding: "\\123" decodes to
+        // a literal backslash followed by "123", not to the byte 0o123
+        assert_eq!(
+            option_to_escaped_string(&FSName("\\123".to_owned())),
+            "fsname=\\\\123"
+        );
+        assert_eq!(
+            option_to_escaped_string(&FSName("plain".to_owned())),
+            "fsname=plain"
+        );
+        assert_eq!(
+            option_to_escaped_string(&Subtype("plain".to_owned())),
+            "subtype=plain"
+        );
+        assert_eq!(option_to_escaped_string(&RO), "ro");
+    }
+
     #[test]
     fn option_round_trip() {
         use crate::mnt::mount_options::MountOption::*;


### PR DESCRIPTION
Fixes #424

Mount option values are passed to the kernel, libfuse, and the fusermount helpers inside a comma separated list, so a comma in a value was read as the start of another option: `MountOption::FSName("foo,ro")` mounted a read-only filesystem named `foo`. A NUL in a value panicked instead of returning an error.

Following the analysis in the issue:

- `fsname` is escaped (`,` -> `\,`, `\` -> `\\`) for the consumers that decode backslash escapes, and passed verbatim as the `mount(2)` source, which needs no escaping.
- Values that cannot be escaped consistently across those consumers are rejected with `InvalidInput` from `Session::new()`: comma and backslash in `Subtype` and `CUSTOM` (libfuse does not re-escape them when forwarding to fusermount), and in `fsname` too on platforms whose mount helpers decode no escapes.
- NUL is rejected in every value, replacing the panic.

The check lives in `Mount::new()` rather than `Session::new()` so that every formatting of an option value can rely on it, including the direct `Mount::new()` calls in tests.

The deprecated escaping question for `fuser::mount`/`spawn_mount` raised at the end of the issue is left alone, as suggested there.

## Testing

Unit tests cover the escaping and the per-platform validation rules. A new mount test asserts that the comma in `FSName("fuser,ro")` reaches `/proc/self/mounts` as part of the source name and does not appear among the mount options.

Ran green on all three mount backends (pure-rust, libfuse2, libfuse3), both as root (direct `mount(2)`) and as an unprivileged user going through a real `fusermount3`, whose argv I logged to confirm it receives `-o fsname=fuser\,ro`. Reverting just the escaping call makes the new test fail with `left: "fuser", right: "fuser,ro"`, so it does catch the reported bug.

Also clean locally: `cargo fmt --check`, clippy with `--deny warnings` (default and `--no-default-features`), `cargo test --all` with and without `libfuse`, `cargo doc`, the musl target, `cargo check --target x86_64-apple-darwin --features=macos-no-mount`, and both `test_passthrough` scripts. The Docker suites (`mount_tests`, `pjdfs_tests`, `xfstests`) could not run in my environment (no Docker daemon), so they are covered only by CI here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjYWzn3mu8Sc2y2eACtJM9)_