### PR TITLE
Report the libfuse call that failed instead of a stale errno

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # FUSE for Rust - Changelog
 
 ## Unreleased
+* Fix meaningless errors when a mount fails inside libfuse (#406). A failure that libfuse
+  reported without setting errno was surfaced with an unrelated errno, most visibly
+  `Success (os error 0)`; such a failure now names the libfuse call it came from, alongside
+  libfuse's own diagnostic on stderr
 * Dropping a `BackgroundSession` now unmounts the filesystem and waits for the session to
   end, guaranteeing that `Filesystem::destroy` has run when drop returns (#239, #411). This
   restores the pre-0.16 blocking drop behavior. Drop does not wait when the session cannot

--- a/src/mnt/fuse2.rs
+++ b/src/mnt/fuse2.rs
@@ -10,16 +10,8 @@ use crate::SessionACL;
 use crate::dev_fuse::DevFuse;
 use crate::mnt::MountOption;
 use crate::mnt::fuse2_sys::*;
+use crate::mnt::libfuse_call;
 use crate::mnt::with_fuse_args;
-
-/// Ensures that an os error is never 0/Success
-fn ensure_last_os_error() -> io::Error {
-    let err = io::Error::last_os_error();
-    match err.raw_os_error() {
-        Some(0) => io::Error::new(io::ErrorKind::Other, "Unspecified Error"),
-        _ => err,
-    }
-}
 
 #[derive(Debug)]
 pub(crate) struct MountImpl {
@@ -33,13 +25,13 @@ impl MountImpl {
     ) -> io::Result<(Arc<DevFuse>, MountImpl)> {
         let mountpoint = CString::new(mountpoint.as_os_str().as_bytes()).unwrap();
         with_fuse_args(options, acl, |args| {
-            let fd = unsafe { fuse_mount_compat25(mountpoint.as_ptr(), args) };
-            if fd < 0 {
-                Err(ensure_last_os_error())
-            } else {
-                let file = unsafe { File::from_raw_fd(fd) };
-                Ok((Arc::new(DevFuse(file)), MountImpl { mountpoint }))
-            }
+            let fd = libfuse_call(
+                "fuse_mount_compat25",
+                || unsafe { fuse_mount_compat25(mountpoint.as_ptr(), args) },
+                |fd| *fd >= 0,
+            )?;
+            let file = unsafe { File::from_raw_fd(fd) };
+            Ok((Arc::new(DevFuse(file)), MountImpl { mountpoint }))
         })
     }
 

--- a/src/mnt/fuse3.rs
+++ b/src/mnt/fuse3.rs
@@ -17,16 +17,8 @@ use crate::mnt::fuse3_sys::fuse_session_fd;
 use crate::mnt::fuse3_sys::fuse_session_mount;
 use crate::mnt::fuse3_sys::fuse_session_new;
 use crate::mnt::fuse3_sys::fuse_session_unmount;
+use crate::mnt::libfuse_call;
 use crate::mnt::with_fuse_args;
-
-/// Ensures that an os error is never 0/Success
-fn ensure_last_os_error() -> io::Error {
-    let err = io::Error::last_os_error();
-    match err.raw_os_error() {
-        Some(0) => io::Error::new(io::ErrorKind::Other, "Unspecified Error"),
-        _ => err,
-    }
-}
 
 #[derive(Debug)]
 pub(crate) struct MountImpl {
@@ -43,32 +35,34 @@ impl MountImpl {
         with_fuse_args(options, acl, |args| {
             let ops = fuse_lowlevel_ops::default();
 
-            let fuse_session = unsafe {
-                fuse_session_new(
-                    args,
-                    &ops as *const _,
-                    size_of::<fuse_lowlevel_ops>(),
-                    ptr::null_mut(),
-                )
-            };
-            if fuse_session.is_null() {
-                return Err(io::Error::last_os_error());
-            }
+            let fuse_session = libfuse_call(
+                "fuse_session_new",
+                || unsafe {
+                    fuse_session_new(
+                        args,
+                        &ops as *const _,
+                        size_of::<fuse_lowlevel_ops>(),
+                        ptr::null_mut(),
+                    )
+                },
+                |session| !session.is_null(),
+            )?;
             // Construct the guard before the fallible setup steps, so an early
             // return destroys the session via Drop instead of leaking it
             let mount = MountImpl {
                 fuse_session,
                 mountpoint: mnt,
             };
-            let result =
-                unsafe { fuse_session_mount(mount.fuse_session, mount.mountpoint.as_ptr()) };
-            if result != 0 {
-                return Err(ensure_last_os_error());
-            }
-            let fd = unsafe { fuse_session_fd(mount.fuse_session) };
-            if fd < 0 {
-                return Err(io::Error::last_os_error());
-            }
+            libfuse_call(
+                "fuse_session_mount",
+                || unsafe { fuse_session_mount(mount.fuse_session, mount.mountpoint.as_ptr()) },
+                |result| *result == 0,
+            )?;
+            let fd = libfuse_call(
+                "fuse_session_fd",
+                || unsafe { fuse_session_fd(mount.fuse_session) },
+                |fd| *fd >= 0,
+            )?;
             let fd = unsafe { BorrowedFd::borrow_raw(fd) };
             // We dup the fd here as the existing fd is owned by the fuse_session, and we
             // don't want it being closed out from under us:

--- a/src/mnt/mod.rs
+++ b/src/mnt/mod.rs
@@ -58,6 +58,34 @@ fn with_fuse_args<T, F: FnOnce(&fuse_args) -> T>(
     })
 }
 
+/// Make a libfuse call that signals failure through its return value, and turn a failure
+/// into an error worth reporting.
+///
+/// libfuse does not set errno to report these failures, and does not clear it beforehand,
+/// so reading `io::Error::last_os_error()` afterwards picks up whatever an unrelated call
+/// left behind: an unrelated error, or errno 0, which renders as the nonsensical
+/// "Success (os error 0)". Clearing errno first makes what remains attributable - anything
+/// non-zero was set during the call, and is worth passing on. When nothing was set, the
+/// only thing to report is which call failed; libfuse writes its own diagnostic to stderr.
+#[cfg(any(test, fuser_mount_impl = "libfuse2", fuser_mount_impl = "libfuse3"))]
+fn libfuse_call<T>(
+    function: &str,
+    call: impl FnOnce() -> T,
+    succeeded: impl FnOnce(&T) -> bool,
+) -> io::Result<T> {
+    nix::errno::Errno::clear();
+    let result = call();
+    if succeeded(&result) {
+        return Ok(result);
+    }
+    Err(match io::Error::last_os_error() {
+        err if err.raw_os_error() == Some(0) => {
+            io::Error::other(format!("libfuse's {function}() failed"))
+        }
+        err => err,
+    })
+}
+
 use std::ffi::CStr;
 use std::path::Path;
 use std::path::PathBuf;
@@ -366,6 +394,47 @@ mod test {
         assert!(fusermount_unmount("/nonexistent/fusermount", &mountpoint).is_err());
         // Helper reports success
         assert!(fusermount_unmount("/bin/true", &mountpoint).is_ok());
+    }
+
+    /// A libfuse call that fails without setting errno must not be reported with whatever
+    /// errno an unrelated call left behind - least of all errno 0, which renders as the
+    /// nonsensical "Success (os error 0)"
+    #[test]
+    fn libfuse_call_reports_only_its_own_errno() {
+        // Stale errno from an unrelated call, which the failing call below does not set
+        nix::errno::Errno::ENOTTY.set();
+        let err = libfuse_call("fuse_session_new", || (), |_| false).unwrap_err();
+        assert_eq!(err.raw_os_error(), None);
+        assert!(err.to_string().contains("fuse_session_new"), "{err}");
+
+        // An errno the call itself set is worth passing on
+        let err = libfuse_call(
+            "fuse_session_mount",
+            || nix::errno::Errno::EPERM.set(),
+            |_| false,
+        )
+        .unwrap_err();
+        assert_eq!(err.raw_os_error(), Some(libc::EPERM));
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+
+        // A call that succeeded is passed through untouched
+        assert_eq!(
+            libfuse_call("fuse_session_fd", || 3, |fd| *fd >= 0).unwrap(),
+            3
+        );
+    }
+
+    /// libfuse rejects this option in fuse_session_new(), which reports the failure without
+    /// setting errno. Reporting whatever errno was left over then surfaced as the
+    /// nonsensical "Success (os error 0)"
+    #[test]
+    #[cfg(fuser_mount_impl = "libfuse3")]
+    fn mount_option_rejected_by_libfuse() {
+        let tmp = tempfile::tempdir().unwrap();
+        let options = [MountOption::CUSTOM("max_read=not_a_number".to_owned())];
+        let err = Mount::new(tmp.path(), &options, SessionACL::default()).unwrap_err();
+        assert_eq!(err.raw_os_error(), None, "{err}");
+        assert!(err.to_string().contains("fuse_session_new"), "{err}");
     }
 
     /// libfuse splits each -o argument on commas, so a comma in a value must reach it


### PR DESCRIPTION
Fixes #406

libfuse signals mount failures through its return values without setting errno, and without clearing it first, so reading errno afterwards reported whatever an unrelated call had left behind. Reproduced on the `libfuse3` backend before changing anything, mounting with an option libfuse rejects:

```
MountOption::CUSTOM("max_read=abc")  =>  "Success (os error 0)"   raw_os_error = Some(0)
```

Nothing had set errno since the process started, so `fuse_session_new()` returning NULL was reported as success.

## Approach

Routing the two unguarded call sites through the existing `ensure_last_os_error()` removes the `Success` case but not the other half of the issue ("or other random errors"): a stale errno is still reported as the cause, and after the fact there is no way to tell it from a real one.

So errno is cleared immediately before each libfuse call instead. What remains is then attributable: a non-zero errno was set during the call and is passed on unchanged, and errno 0 means libfuse failed on its own terms, so the error names the function that failed. A `libfuse_call()` helper in `mnt/mod.rs` wraps clear-call-interpret so a new call site cannot forget the clearing; it also replaces the `ensure_last_os_error()` that was duplicated verbatim in `fuse2.rs` and `fuse3.rs`.

Applied to `fuse_session_new()`, `fuse_session_mount()`, `fuse_session_fd()`, and libfuse2's `fuse_mount_compat25()`, which had the same class of bug.

After the change, the same mount reports `libfuse's fuse_session_new() failed`.

## Two judgement calls worth flagging

**An errno set by a step libfuse retried internally is still passed on.** On the `libfuse2` backend, `max_read=abc` reports `EPERM` both before and after this change. With errno cleared first I could confirm it is set *during* the call, by an internal `mount(2)` attempt that libfuse retried through `fusermount` before failing for an unrelated reason. That is indistinguishable from the errno that caused the failure, so it is passed on rather than discarding a possibly-real cause. libfuse's own diagnostic on stderr remains the fullest explanation. If you would rather suppress errno entirely on the mount calls, that is a one-line change.

**`raw_os_error()` is preserved on pass-through** rather than wrapping the errno with the function name as context, so callers matching on errno or on `ErrorKind` (for instance `PermissionDenied` for the `user_allow_other` case) do not regress.

## Testing

- `libfuse_call_reports_only_its_own_errno` sets a stale `ENOTTY`, then checks that a failing call which sets no errno reports none and names the call, that an errno the call did set passes through with `kind()` intact, and that a successful call is untouched. Runs on every backend.
- `mount_option_rejected_by_libfuse` covers the reported symptom end to end. It is `#[cfg(fuser_mount_impl = "libfuse3")]` on purpose: `max_read=not_a_number` is silently accepted by FreeBSD's `mount_fusefs`, so a backend-agnostic version would be a flake waiting to happen.

Locally green: `cargo fmt --check`, clippy with `--deny warnings` (default and `--no-default-features`), `cargo test --all` with and without `libfuse`, all three mount backends both as root and as an unprivileged user going through `fusermount3`, the musl target, `cargo doc`, `cargo check --target x86_64-apple-darwin --features=macos-no-mount`, and `test_passthrough`. macOS builds the `libfuse2` backend, so `mac-ci` is the real check on that call site: macFUSE is not available here to compile for darwin directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjYWzn3mu8Sc2y2eACtJM9)_