### PR TITLE
Unmount lazily on Linux, so a busy filesystem is not left mounted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # FUSE for Rust - Changelog
 
 ## Unreleased
+* Fix `EBUSY` when unmounting a filesystem that is still in use, as root on Linux (#686).
+  The unmount is now lazy, as it already was for unprivileged users and as libfuse does,
+  instead of failing and leaving the filesystem mounted with no way to retry
 * Fix meaningless errors when a mount fails inside libfuse (#406). A failure that libfuse
   reported without setting errno was surfaced with an unrelated errno, most visibly
   `Success (os error 0)`; such a failure now names the libfuse call it came from, alongside

--- a/src/mnt/fuse_pure.rs
+++ b/src/mnt/fuse_pure.rs
@@ -121,13 +121,9 @@ fn fuse_mount_pure(
     fuse_mount_fusermount(mountpoint, options, acl)
 }
 
+/// Only reached once `libc_umount()` has failed with EPERM, i.e. unprivileged, so
+/// there is no point in retrying the same unmount syscall with different flags
 fn fuse_unmount_pure(mountpoint: &CStr) -> io::Result<()> {
-    #[cfg(target_os = "linux")]
-    {
-        if nix::mount::umount2(mountpoint, nix::mount::MntFlags::MNT_DETACH).is_ok() {
-            return Ok(());
-        }
-    }
     #[cfg(target_os = "macos")]
     {
         if nix::mount::unmount(mountpoint, nix::mount::MntFlags::MNT_FORCE).is_ok() {

--- a/src/mnt/mod.rs
+++ b/src/mnt/mod.rs
@@ -242,7 +242,12 @@ fn libc_umount(mnt: &CStr) -> nix::Result<()> {
         target_os = "netbsd"
     )))]
     {
-        nix::mount::umount(mnt)
+        // Detach lazily, as libfuse's fuse_kern_unmount() does. An eager unmount fails
+        // with EBUSY while the filesystem is still in use, and by then the Mount has
+        // been consumed, so the caller has nothing left to retry with and the mount is
+        // left behind. The unprivileged path has always been lazy, going through
+        // "fusermount -u -z", so this also makes privileged teardown agree with it
+        nix::mount::umount2(mnt, nix::mount::MntFlags::MNT_DETACH)
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -779,6 +779,75 @@ mod test {
         ManuallyDrop::into_inner(tmp);
     }
 
+    /// An unmount must not fail merely because the filesystem is still in use. The
+    /// Mount is consumed by the unmount attempt, so a caller that gets EBUSY has
+    /// nothing left to retry with and the filesystem is left mounted (issue #686).
+    #[test]
+    fn umount_succeeds_while_filesystem_is_busy() {
+        use std::time::SystemTime;
+
+        use crate::FileAttr;
+        use crate::FileHandle;
+        use crate::FileType;
+        use crate::INodeNo;
+        use crate::ReplyAttr;
+
+        /// Serves getattr, which is all that opening the mount root needs
+        struct RootDirFs;
+        impl Filesystem for RootDirFs {
+            fn getattr(
+                &self,
+                _req: &Request,
+                ino: INodeNo,
+                _fh: Option<FileHandle>,
+                reply: ReplyAttr,
+            ) {
+                let now = SystemTime::now();
+                reply.attr(
+                    &std::time::Duration::from_secs(1),
+                    &FileAttr {
+                        ino,
+                        size: 0,
+                        blocks: 0,
+                        atime: now,
+                        mtime: now,
+                        ctime: now,
+                        crtime: now,
+                        kind: FileType::Directory,
+                        perm: 0o755,
+                        nlink: 2,
+                        uid: 0,
+                        gid: 0,
+                        rdev: 0,
+                        blksize: 4096,
+                        flags: 0,
+                    },
+                );
+            }
+        }
+
+        let tmp = ManuallyDrop::new(tempfile::tempdir().unwrap());
+        let mountpoint = tmp.path().canonicalize().unwrap();
+        let mut session = Session::new(RootDirFs, &mountpoint, &Config::default()).unwrap();
+        let mut unmounter = session.unmount_callable();
+        let runner = std::thread::spawn(move || session.run());
+        // The kernel forwards requests only after the init reply was processed, so a
+        // completed operation proves the session loop is past the handshake
+        let _ = std::fs::metadata(&mountpoint);
+
+        // An open handle on the mount root makes an eager unmount fail with EBUSY
+        let busy = std::fs::File::open(&mountpoint).unwrap();
+        unmounter
+            .unmount()
+            .expect("unmount must not fail while the filesystem is in use");
+
+        // Releasing the handle lets the lazily detached filesystem go away, ending
+        // the session
+        drop(busy);
+        runner.join().unwrap().unwrap();
+        ManuallyDrop::into_inner(tmp);
+    }
+
     /// The fusectl abort file for the FUSE mount at `mountpoint`: the connection
     /// directory is named after the mount's anonymous device number.
     fn fusectl_abort_path(mountpoint: &Path) -> Option<std::path::PathBuf> {


### PR DESCRIPTION
Fixes #686.

An unprivileged unmount has always been lazy, going through `fusermount -u -z`, but a privileged one called `umount(2)` with no flags, so it failed with `EBUSY` while the filesystem was still in use. By then the `Mount` has been consumed, so the caller has nothing left to retry with and the filesystem stays mounted.

This detaches lazily on Linux instead, which is what libfuse's `fuse_kern_unmount()` does in both cases. `libc_umount()` is shared, so this covers all three backends.

## Behavior, with one open handle on the mount root

| | root, before | unprivileged, before and after | root, after |
|---|---|---|---|
| `SessionUnmounter::unmount()` | **`EBUSY`**, stays mounted | Ok, lazily detached | Ok, lazily detached |
| `umount_and_join()` | **`EBUSY`**, stays mounted | blocks until handles are released | blocks until handles are released |
| `drop(BackgroundSession)` | warns, stays mounted | waits `UNMOUNT_WAIT`, then detaches | waits `UNMOUNT_WAIT`, then detaches |

So this is not purely a fix: privileged `join()`/`umount_and_join()` callers trade an immediate `EBUSY` for waiting on open handles. That seemed worth it, since the alternative leaves a filesystem mounted with no way to retry, and it is what the unprivileged path has always done. Teardown was already built for lazy semantics: `BackgroundSession::drop` waits a bounded time for the connection to end and detaches the session thread if it does not.

The retry of the same unmount syscall in `fuse_unmount_pure()` is dropped. It is only reached once `umount(2)` has failed with `EPERM`, which different flags do not change.

## Testing

`umount_succeeds_while_filesystem_is_busy` holds an open handle on the mount root and asserts the unmount does not fail. It fails with `EBUSY` on master when run as root, and passes with this change. Note that CI runs the unit tests unprivileged, where it passes either way — it only guards the regression when the suite is run as root, which is how I verified it.

Also run locally, on all three backends both as root and unprivileged: the unit suite, `cargo fmt --check`, clippy with and without default features, the musl build, `cargo doc`, `cargo check --target x86_64-apple-darwin --features=macos-no-mount`, and both passthrough example tests.

## Deliberately not included

The issue also asks for `EBUSY` handling on macOS and the BSDs, where there is no lazy unmount. I left both alone: neither is reachable by CI here (`mac-ci` is build/lint only, and `freebsd-ci` runs its `cargo test` step unprivileged and skips the mount tests), so a retry loop or `MNT_FORCE` would ship unverified. `MNT_FORCE` in particular is a much stronger semantic than a lazy detach — it revokes open handles, so in-flight I/O fails and unflushed data can be lost. Happy to take either on if you want it here.

Two points from the issue's follow-up comment are already resolved on master: unprivileged unmount is no longer gated away for libfuse2 on Linux (`fuse2.rs` calls `fusermount_unmount()`), and `Drop for MountImpl` now calls `fuse_session_destroy()` on every path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjYWzn3mu8Sc2y2eACtJM9)_