### PR TITLE
Name the file a failed mount could not reach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # FUSE for Rust - Changelog
 
 ## Unreleased
+* Name the file that could not be reached when a mount fails, instead of reporting a bare
+  "No such file or directory" that could equally mean the mountpoint, `/dev/fuse` or the
+  `fusermount` helper (#250)
 * Fix `EBUSY` when unmounting a filesystem that is still in use, as root on Linux (#686).
   The unmount is now lazy, as it already was for unprivileged users and as libfuse does,
   instead of failing and leaving the filesystem mounted with no way to retry

--- a/src/dev_fuse.rs
+++ b/src/dev_fuse.rs
@@ -31,5 +31,57 @@ impl DevFuse {
             .write(true)
             .open(Self::PATH)
             .map(Self)
+            .map_err(open_error)
+    }
+}
+
+/// How the device is provided, and so what to try when it is missing, differs per target
+#[cfg(target_os = "linux")]
+const MISSING_HINT: &str = ", try 'modprobe fuse'";
+#[cfg(target_os = "freebsd")]
+const MISSING_HINT: &str = ", try 'kldload fusefs'";
+#[cfg(target_os = "macos")]
+const MISSING_HINT: &str = "; is macFUSE installed?";
+#[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "macos")))]
+const MISSING_HINT: &str = "";
+
+/// Name the device, so that "No such file or directory" says which file. The error kind is
+/// preserved for callers that match on it
+#[allow(dead_code)] // Not used with every feature.
+fn open_error(err: io::Error) -> io::Error {
+    if err.kind() == io::ErrorKind::NotFound {
+        io::Error::new(
+            err.kind(),
+            format!("{} not found{MISSING_HINT}", DevFuse::PATH),
+        )
+    } else {
+        io::Error::new(err.kind(), format!("opening {}: {err}", DevFuse::PATH))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Opening the FUSE device cannot be made to fail on demand, so check the reporting
+    /// itself: which file is missing, and how to get it, must both survive
+    #[test]
+    fn open_failures_name_the_device() {
+        let err = open_error(io::ErrorKind::NotFound.into());
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        assert!(err.to_string().contains(DevFuse::PATH), "{err}");
+        // The BSDs load a differently named module, and macOS none at all, so advice
+        // for one target must not reach another
+        #[cfg(target_os = "linux")]
+        assert!(err.to_string().contains("modprobe fuse"), "{err}");
+        #[cfg(not(target_os = "linux"))]
+        assert!(!err.to_string().contains("modprobe"), "{err}");
+
+        // Anything else is reported as it came, with the device named
+        let err = open_error(io::ErrorKind::PermissionDenied.into());
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        assert!(err.to_string().contains(DevFuse::PATH), "{err}");
+        // Advice for getting the device belongs only on the branch where it is absent
+        assert!(!err.to_string().contains("not found"), "{err}");
     }
 }

--- a/src/mnt/fuse_pure.rs
+++ b/src/mnt/fuse_pure.rs
@@ -28,7 +28,6 @@ use std::process::Stdio;
 use std::sync::Arc;
 
 use log::debug;
-use log::error;
 use nix::fcntl::FcntlArg;
 use nix::fcntl::FdFlag;
 use nix::fcntl::OFlag;
@@ -63,7 +62,9 @@ impl MountImpl {
         options: &[MountOption],
         acl: SessionACL,
     ) -> io::Result<(Arc<DevFuse>, MountImpl)> {
-        let mountpoint = mountpoint.canonicalize()?;
+        let mountpoint = mountpoint
+            .canonicalize()
+            .map_err(|err| crate::mnt::context(format_args!("{}", mountpoint.display()), err))?;
         let (file, sock) = fuse_mount_pure(mountpoint.as_os_str(), options, acl)?;
         let file = Arc::new(file);
         Ok((
@@ -130,18 +131,18 @@ fn fuse_unmount_pure(mountpoint: &CStr) -> io::Result<()> {
             return Ok(());
         }
     }
-    crate::mnt::fusermount_unmount(&detect_fusermount_bin(), mountpoint)
+    crate::mnt::fusermount_unmount(&detect_fusermount_bin()?, mountpoint)
 }
 
-fn detect_fusermount_bin() -> String {
+fn detect_fusermount_bin() -> io::Result<String> {
     if let Some(fusermount) = env::var_os("FUSERMOUNT_PATH") {
-        return fusermount
+        return Ok(fusermount
             .to_str()
             .expect("FUSERMOUNT_PATH is not UTF-8")
-            .to_owned();
+            .to_owned());
     }
 
-    for name in [
+    let candidates = [
         FUSERMOUNT3_BIN.to_string(),
         FUSERMOUNT_BIN.to_string(),
         MOUNT_FUSEFS_BIN.to_string(),
@@ -150,15 +151,20 @@ fn detect_fusermount_bin() -> String {
         format!("/sbin/{MOUNT_FUSEFS_BIN}"),
         format!("/bin/{FUSERMOUNT3_BIN}"),
         format!("/bin/{FUSERMOUNT_BIN}"),
-    ]
-    .iter()
-    {
+    ];
+    for name in candidates.iter() {
         if Command::new(name).arg("-h").output().is_ok() {
-            return name.to_string();
+            return Ok(name.to_string());
         }
     }
-    // Default to fusermount3
-    FUSERMOUNT3_BIN.to_string()
+    // None of these could be started, so naming a single guessed default would be misleading
+    Err(Error::new(
+        ErrorKind::NotFound,
+        format!(
+            "no FUSE mount helper found, tried {} (set FUSERMOUNT_PATH to override)",
+            candidates.join(", ")
+        ),
+    ))
 }
 
 fn receive_fusermount_message(socket: &UnixStream) -> Result<DevFuse, Error> {
@@ -237,7 +243,7 @@ fn fuse_mount_fusermount(
     options: &[MountOption],
     acl: SessionACL,
 ) -> Result<(DevFuse, Option<UnixStream>), Error> {
-    let fusermount_bin = detect_fusermount_bin();
+    let fusermount_bin = detect_fusermount_bin()?;
 
     if fusermount_bin.ends_with(MOUNT_FUSEFS_BIN) {
         return fuse_mount_mount_fusefs(&fusermount_bin, mountpoint, options, acl);
@@ -262,7 +268,9 @@ fn fuse_mount_fusermount(
         clear_cloexec_in_pre_exec(&mut builder, child_socket.as_fd());
     }
 
-    let fusermount_child = builder.spawn()?;
+    let fusermount_child = builder
+        .spawn()
+        .map_err(|err| crate::mnt::context(format_args!("spawning {fusermount_bin}"), err))?;
 
     drop(child_socket); // close socket in parent
 
@@ -345,7 +353,9 @@ fn fuse_mount_mount_fusefs(
 
     unsafe { clear_cloexec_in_pre_exec(&mut builder, fuse_device.as_fd()) };
 
-    let output = builder.output()?;
+    let output = builder
+        .output()
+        .map_err(|err| crate::mnt::context(format_args!("running {fusermount_bin}"), err))?;
     if !output.status.success() {
         return Err(io::Error::new(
             ErrorKind::Other,
@@ -365,20 +375,16 @@ fn fuse_mount_sys(
 ) -> Result<Option<DevFuse>, Error> {
     use std::os::unix::fs::PermissionsExt;
 
-    let mountpoint_mode = File::open(mountpoint)?.metadata()?.permissions().mode();
+    let mountpoint_mode = File::open(mountpoint)
+        .map_err(|err| crate::mnt::context(Path::new(mountpoint).display(), err))?
+        .metadata()?
+        .permissions()
+        .mode();
 
     // Auto unmount requests must be sent to fusermount binary
     assert!(!options.contains(&MountOption::AutoUnmount));
 
-    let file = match DevFuse::open() {
-        Ok(dev_fuse) => dev_fuse,
-        Err(error) => {
-            if error.kind() == ErrorKind::NotFound {
-                error!("{} not found. Try 'modprobe fuse'", DevFuse::PATH);
-            }
-            return Err(error);
-        }
-    };
+    let file = DevFuse::open()?;
     assert!(
         file.as_raw_fd() > 2,
         "Conflict with stdin/stdout/stderr. fd={}",

--- a/src/mnt/mod.rs
+++ b/src/mnt/mod.rs
@@ -58,6 +58,15 @@ fn with_fuse_args<T, F: FnOnce(&fuse_args) -> T>(
     })
 }
 
+/// Name what could not be reached, so that a bare "No such file or directory" does not
+/// leave the caller guessing between the mountpoint, the FUSE device and the mount
+/// helper. The error kind is preserved for callers that match on it; the OS error
+/// number survives only in the message
+#[allow(dead_code)] // Not used with every feature.
+pub(crate) fn context(what: impl std::fmt::Display, err: io::Error) -> io::Error {
+    io::Error::new(err.kind(), format!("{what}: {err}"))
+}
+
 /// Make a libfuse call that signals failure through its return value, and turn a failure
 /// into an error worth reporting.
 ///
@@ -307,7 +316,9 @@ pub(crate) fn fusermount_unmount(fusermount_bin: &str, mountpoint: &CStr) -> io:
         .arg("--")
         .arg(std::ffi::OsStr::from_bytes(mountpoint.to_bytes()));
 
-    let output = builder.output()?;
+    let output = builder
+        .output()
+        .map_err(|err| context(format_args!("running {fusermount_bin}"), err))?;
     debug!("fusermount: {}", String::from_utf8_lossy(&output.stdout));
     debug!("fusermount: {}", String::from_utf8_lossy(&output.stderr));
     if !output.status.success() {
@@ -395,10 +406,34 @@ mod test {
         let mountpoint = CString::new("/nonexistent").unwrap();
         // Helper exits nonzero (/bin/false ignores its arguments)
         assert!(fusermount_unmount("/bin/false", &mountpoint).is_err());
-        // Helper cannot be executed at all
-        assert!(fusermount_unmount("/nonexistent/fusermount", &mountpoint).is_err());
+        // Helper cannot be executed at all, which must say which helper that was
+        let err = fusermount_unmount("/nonexistent/fusermount", &mountpoint).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        assert!(err.to_string().contains("/nonexistent/fusermount"), "{err}");
         // Helper reports success
         assert!(fusermount_unmount("/bin/true", &mountpoint).is_ok());
+    }
+
+    /// A mount touches the mountpoint, the FUSE device and the mount helper, so "No such
+    /// file or directory" on its own does not say which one is missing (issue #250)
+    #[test]
+    fn context_names_what_failed() {
+        let err = context("/dev/fuse", io::ErrorKind::PermissionDenied.into());
+        // Preserved, so that callers matching on the kind keep working
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        assert!(err.to_string().contains("/dev/fuse"), "{err}");
+        assert!(err.to_string().contains("permission denied"), "{err}");
+    }
+
+    /// The mountpoint is the first thing a mount resolves, and a missing one is what the
+    /// reporter of issue #250 mistook a missing /dev/fuse for
+    #[test]
+    #[cfg(fuser_mount_impl = "pure-rust")]
+    fn missing_mountpoint_is_named() {
+        let err =
+            Mount::new(Path::new("/nonexistent/mountpoint"), &[], SessionACL::Owner).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+        assert!(err.to_string().contains("/nonexistent/mountpoint"), "{err}");
     }
 
     /// A libfuse call that fails without setting errno must not be reported with whatever


### PR DESCRIPTION
Fixes #250.

A mount touches three files that can each be absent in a sandbox — the mountpoint, `/dev/fuse`, and a `fusermount` helper — and all three failures surfaced as the same bare `No such file or directory`. That is what sent the reporter looking at the wrong one.

## Before / after

| what is missing | before | after |
|---|---|---|
| mountpoint | `No such file or directory (os error 2)` | `/nonexistent/mountpoint: No such file or directory (os error 2)` |
| `/dev/fuse` | `No such file or directory (os error 2)` | `/dev/fuse not found, try 'modprobe fuse'` |
| mount helper | `No such file or directory (os error 2)` | `spawning /nonexistent/fusermount3: No such file or directory (os error 2)` |
| helper, on unmount | `No such file or directory (os error 2)` | `running /nonexistent/fusermount: No such file or directory (os error 2)` |
| no helper at all | `fusermount3: No such file or directory` | `no FUSE mount helper found, tried fusermount3, fusermount, mount_fusefs, /sbin/fusermount3, … (set FUSERMOUNT_PATH to override)` |

Two things worth calling out:

The `modprobe fuse` advice already existed, but only as a `log::error!`, so it was lost whenever the caller had no logger installed — which is exactly the situation in the issue, where this showed up in unit tests. It is now part of the error, and the log line is gone rather than duplicated.

`detect_fusermount_bin()` no longer falls back to a guessed `fusermount3` when it finds nothing. That guess could only go on to fail at spawn, naming one binary when eight had been tried. Detection probes by spawning each candidate, so a probe that fails means the later spawn would have failed too — no mount that previously succeeded can start failing because of this.

The error kind is preserved throughout, so callers matching on `ErrorKind::NotFound` keep working. The OS error number now survives only in the message text, since `io::Error` cannot carry both a custom message and a `raw_os_error`.

The `libfuse2`/`libfuse3` backends are untouched here: they hand the path straight to libfuse, and their failures already name the libfuse call that failed, from #406.

## Testing

Three tests: the context helper preserves the kind while naming the file, a missing mountpoint is named (pure-rust, where the path is resolved by fuser), and a mount helper that cannot be executed is named. The `/dev/fuse` message is checked through its formatting function, since the device cannot be made to disappear on demand.

Ran locally on all three backends both as root and unprivileged: the unit suite, `cargo fmt --check`, clippy across feature sets, the musl build, `cargo doc`, `cargo check --target x86_64-apple-darwin --features=macos-no-mount`, and both passthrough example tests.