### PR TITLE
Parse the extended fuse_setxattr_in layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # FUSE for Rust - Changelog
 
 ## Unreleased
+* Parse the extended `fuse_setxattr_in` layout, making `InitFlags::FUSE_SETXATTR_EXT` usable
+  (#357). Enabling that capability previously panicked the session thread on the first
+  `setxattr` and left the filesystem hung, because fuser kept reading the shorter pre-7.33
+  layout. A `setxattr` whose value length disagrees with its header is now rejected rather
+  than panicking, and one carrying `FUSE_SETXATTR_ACL_KILL_SGID` is refused with `ENOTSUP`,
+  since `Filesystem::setxattr` cannot yet be told to clear SGID
 * Name the file that could not be reached when a mount fails, instead of reporting a bare
   "No such file or directory" that could equally mean the mountpoint, `/dev/fuse` or the
   `fusermount` helper (#250)

--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -462,6 +462,17 @@ pub(crate) struct fuse_setxattr_in {
     pub(crate) padding: u32,
 }
 
+/// Tail of the extended `fuse_setxattr_in`, which the kernel appends to the layout above
+/// once `FUSE_SETXATTR_EXT` has been negotiated. Never sent on macOS, where bit 29 means
+/// `FUSE_CASE_INSENSITIVE` instead
+#[cfg(not(target_os = "macos"))]
+#[repr(C)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
+pub(crate) struct fuse_setxattr_in_ext {
+    pub(crate) setxattr_flags: u32,
+    pub(crate) padding: u32,
+}
+
 #[repr(C)]
 #[derive(Debug, FromBytes, KnownLayout, Immutable)]
 pub(crate) struct fuse_getxattr_in {

--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -21,6 +21,7 @@ use serde::Serialize;
 
 use crate::Errno;
 use crate::ll::argument::ArgumentIterator;
+use crate::ll::flags::init_flags::InitFlags;
 use crate::ll::fuse_abi as abi;
 use crate::ll::fuse_abi::fuse_in_header;
 use crate::ll::fuse_abi::fuse_opcode;
@@ -839,12 +840,19 @@ mod op {
         #[expect(dead_code)]
         header: &'a fuse_in_header,
         arg: &'a fuse_setxattr_in,
+        /// Only carried when `FUSE_SETXATTR_EXT` was negotiated; 0 otherwise
+        setxattr_flags: u32,
         name: &'a OsStr,
         value: &'a [u8],
     }
     impl<'a> SetXAttr<'a> {
         pub(crate) fn name(&self) -> &'a OsStr {
             self.name
+        }
+        /// The `FUSE_SETXATTR_*` flags. Always 0 unless `FUSE_SETXATTR_EXT` has been
+        /// negotiated, which never happens on macOS
+        pub(crate) fn setxattr_flags(&self) -> u32 {
+            self.setxattr_flags
         }
         pub(crate) fn value(&self) -> &'a [u8] {
             self.value
@@ -1642,6 +1650,8 @@ mod op {
         header: &'a fuse_in_header,
         opcode: &fuse_opcode,
         data: &'a [u8],
+        // Only the setxattr layout depends on this, and that is not reachable on macOS
+        #[cfg_attr(target_os = "macos", allow(unused_variables))] negotiated: InitFlags,
     ) -> Option<Operation<'a>> {
         let mut data = ArgumentIterator::new(data);
         Some(match opcode {
@@ -1724,13 +1734,30 @@ mod op {
                 arg: data.fetch()?,
             }),
             fuse_opcode::FUSE_SETXATTR => Operation::SetXAttr({
+                let arg = data.fetch()?;
+                // Once FUSE_SETXATTR_EXT is negotiated the kernel sends an extended
+                // fuse_setxattr_in, whose extra fields sit between the struct and the name
+                #[cfg(not(target_os = "macos"))]
+                let setxattr_flags = if negotiated.contains(InitFlags::FUSE_SETXATTR_EXT) {
+                    let ext: &fuse_setxattr_in_ext = data.fetch()?;
+                    ext.setxattr_flags
+                } else {
+                    0
+                };
+                #[cfg(target_os = "macos")]
+                let setxattr_flags: u32 = 0;
                 let out = SetXAttr {
                     header,
-                    arg: data.fetch()?,
+                    arg,
+                    setxattr_flags,
                     name: data.fetch_str()?,
                     value: data.fetch_all(),
                 };
-                assert!(out.value.len() == out.arg.size as usize);
+                // A value length that disagrees with the header means the layout was
+                // misread; reject the request rather than taking down the session
+                if out.value.len() != out.arg.size as usize {
+                    return None;
+                }
                 out
             }),
             fuse_opcode::FUSE_GETXATTR => Operation::GetXAttr(GetXAttr {
@@ -2133,6 +2160,9 @@ impl fmt::Display for Operation<'_> {
 pub(crate) struct AnyRequest<'a> {
     header: &'a fuse_in_header,
     data: &'a [u8],
+    /// Capabilities negotiated during INIT. Some request layouts depend on them, so a
+    /// request parsed without them (i.e. during the handshake itself) must assume none
+    negotiated: InitFlags,
 }
 
 impl<'a> AnyRequest<'a> {
@@ -2173,7 +2203,14 @@ impl<'a> AnyRequest<'a> {
             |e: num_enum::TryFromPrimitiveError<_>| RequestError::UnknownOperation(e.number),
         )?;
         // Parse/check operation arguments
-        op::parse(self.header, &opcode, self.data).ok_or(RequestError::InsufficientData)
+        op::parse(self.header, &opcode, self.data, self.negotiated)
+            .ok_or(RequestError::InsufficientData)
+    }
+
+    /// Records the capabilities negotiated during INIT, which some later request
+    /// layouts depend on.
+    pub(crate) fn set_negotiated(&mut self, negotiated: InitFlags) {
+        self.negotiated = negotiated;
     }
 
     pub(crate) fn header(&self) -> &fuse_in_header {
@@ -2218,6 +2255,9 @@ impl<'a> TryFrom<&'a [u8]> for AnyRequest<'a> {
         Ok(Self {
             header,
             data: &data[size_of::<fuse_in_header>()..header.len as usize],
+            // The handshake parses INIT itself, whose layout never varies; callers
+            // dispatching later requests set this from the negotiated result
+            negotiated: InitFlags::empty(),
         })
     }
 }
@@ -2408,5 +2448,73 @@ mod tests {
             }
             _ => panic!("Unexpected request operation"),
         }
+    }
+
+    // 40 byte header + 8 byte fuse_setxattr_in + "user.a\0" + "VAL"
+    #[cfg(all(target_endian = "little", not(target_os = "macos")))]
+    const SETXATTR_REQUEST: AlignedData<[u8; 58]> = AlignedData([
+        0x3a, 0x00, 0x00, 0x00, 0x15, 0x00, 0x00, 0x00, // len, opcode
+        0x0d, 0xf0, 0xad, 0xba, 0xef, 0xbe, 0xad, 0xde, // unique
+        0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, // nodeid
+        0x0d, 0xd0, 0x01, 0xc0, 0xfe, 0xca, 0x01, 0xc0, // uid, gid
+        0x5e, 0xba, 0xde, 0xc0, 0x00, 0x00, 0x00, 0x00, // pid, padding
+        0x03, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, // size, flags
+        0x75, 0x73, 0x65, 0x72, 0x2e, 0x61, 0x00, // name "user.a"
+        0x56, 0x41, 0x4c, // value "VAL"
+    ]);
+
+    // The same request in the extended layout the kernel sends once FUSE_SETXATTR_EXT
+    // has been negotiated: 8 further bytes sit between the struct and the name
+    #[cfg(all(target_endian = "little", not(target_os = "macos")))]
+    const SETXATTR_EXT_REQUEST: AlignedData<[u8; 66]> = AlignedData([
+        0x42, 0x00, 0x00, 0x00, 0x15, 0x00, 0x00, 0x00, // len, opcode
+        0x0d, 0xf0, 0xad, 0xba, 0xef, 0xbe, 0xad, 0xde, // unique
+        0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, // nodeid
+        0x0d, 0xd0, 0x01, 0xc0, 0xfe, 0xca, 0x01, 0xc0, // uid, gid
+        0x5e, 0xba, 0xde, 0xc0, 0x00, 0x00, 0x00, 0x00, // pid, padding
+        0x03, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, // size, flags
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // setxattr_flags, padding
+        0x75, 0x73, 0x65, 0x72, 0x2e, 0x61, 0x00, // name "user.a"
+        0x56, 0x41, 0x4c, // value "VAL"
+    ]);
+
+    #[test]
+    #[cfg(all(target_endian = "little", not(target_os = "macos")))]
+    fn setxattr_compat() {
+        let req = AnyRequest::try_from(&SETXATTR_REQUEST[..]).unwrap();
+        match req.operation().unwrap() {
+            Operation::SetXAttr(x) => {
+                assert_eq!(x.name(), OsStr::new("user.a"));
+                assert_eq!(x.value(), b"VAL");
+                assert_eq!(x.flags(), 0x11);
+                assert_eq!(x.setxattr_flags(), 0);
+            }
+            _ => panic!("Unexpected request operation"),
+        }
+    }
+
+    #[test]
+    #[cfg(all(target_endian = "little", not(target_os = "macos")))]
+    fn setxattr_extended() {
+        let mut req = AnyRequest::try_from(&SETXATTR_EXT_REQUEST[..]).unwrap();
+        req.set_negotiated(InitFlags::FUSE_SETXATTR_EXT);
+        match req.operation().unwrap() {
+            Operation::SetXAttr(x) => {
+                assert_eq!(x.name(), OsStr::new("user.a"));
+                assert_eq!(x.value(), b"VAL");
+                assert_eq!(x.flags(), 0x11);
+                assert_eq!(x.setxattr_flags(), 1);
+            }
+            _ => panic!("Unexpected request operation"),
+        }
+    }
+
+    /// Reading an extended request with the compat layout shifts the name and value by
+    /// eight bytes. That must fail the request rather than take down the session.
+    #[test]
+    #[cfg(all(target_endian = "little", not(target_os = "macos")))]
+    fn setxattr_layout_mismatch_is_rejected() {
+        let req = AnyRequest::try_from(&SETXATTR_EXT_REQUEST[..]).unwrap();
+        assert!(req.operation().is_err());
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -20,6 +20,7 @@ use crate::ll;
 use crate::ll::Errno;
 use crate::ll::ResponseData;
 use crate::ll::ResponseErrno;
+use crate::ll::flags::init_flags::InitFlags;
 use crate::reply::Reply;
 use crate::reply::ReplyDirectory;
 use crate::reply::ReplyDirectoryPlus;
@@ -39,14 +40,19 @@ pub(crate) struct RequestWithSender<'a> {
 
 impl<'a> RequestWithSender<'a> {
     /// Create a new request from the given data
-    pub(crate) fn new(ch: ChannelSender, data: &'a [u8]) -> Option<RequestWithSender<'a>> {
-        let request = match ll::AnyRequest::try_from(data) {
+    pub(crate) fn new(
+        ch: ChannelSender,
+        data: &'a [u8],
+        negotiated: InitFlags,
+    ) -> Option<RequestWithSender<'a>> {
+        let mut request = match ll::AnyRequest::try_from(data) {
             Ok(request) => request,
             Err(err) => {
                 error!("{err}");
                 return None;
             }
         };
+        request.set_negotiated(negotiated);
 
         Some(Self { ch, request })
     }
@@ -336,6 +342,14 @@ impl<'a> RequestWithSender<'a> {
                 filesystem.statfs(self.request_header(), self.request.nodeid(), self.reply());
             }
             ll::Operation::SetXAttr(x) => {
+                // The only flag defined here is FUSE_SETXATTR_ACL_KILL_SGID, which asks
+                // the filesystem to drop SGID as part of an ACL update. Filesystem cannot
+                // be told about it yet, and acknowledging a request to drop privileges
+                // without dropping them would leave SGID set on a file the kernel wanted
+                // it cleared on, so refuse the request instead
+                if x.setxattr_flags() != 0 {
+                    return Err(Errno::ENOTSUP);
+                }
                 filesystem.setxattr(
                     self.request_header(),
                     self.request.nodeid(),

--- a/src/session.rs
+++ b/src/session.rs
@@ -143,6 +143,9 @@ pub struct Session<FS: Filesystem> {
     /// FUSE protocol version, as reported by the kernel.
     /// The field is set to `Some` when the init message is received.
     pub(crate) proto_version: Option<Version>,
+    /// Capabilities agreed with the kernel during init. Some request layouts depend on
+    /// them, so the event loops need them to parse correctly
+    pub(crate) negotiated: InitFlags,
     pub(crate) config: Config,
 }
 
@@ -190,6 +193,7 @@ impl<FS: Filesystem> Session<FS> {
             allowed: options.acl,
             session_owner: geteuid(),
             proto_version: None,
+            negotiated: InitFlags::empty(),
             config: options.clone(),
         };
 
@@ -218,6 +222,7 @@ impl<FS: Filesystem> Session<FS> {
             allowed: acl,
             session_owner: geteuid(),
             proto_version: None,
+            negotiated: InitFlags::empty(),
             config,
         };
 
@@ -260,6 +265,7 @@ impl<FS: Filesystem> Session<FS> {
             allowed,
             session_owner,
             proto_version: _,
+            negotiated,
             config,
         } = self;
 
@@ -307,6 +313,7 @@ impl<FS: Filesystem> Session<FS> {
                 ch,
                 allowed,
                 session_owner,
+                negotiated,
             };
             threads.push(
                 thread::Builder::new()
@@ -440,6 +447,7 @@ impl<FS: Filesystem> Session<FS> {
 
             // Remember the ABI version supported by kernel and mark the session initialized.
             self.proto_version = Some(v);
+            self.negotiated = init.capabilities() & config.requested;
 
             // Log capability status for debugging
             for bit in 0..64 {
@@ -527,6 +535,7 @@ pub(crate) struct SessionEventLoop<FS: Filesystem> {
     pub(crate) filesystem: Arc<FilesystemHolder<FS>>,
     pub(crate) allowed: SessionACL,
     pub(crate) session_owner: Uid,
+    pub(crate) negotiated: InitFlags,
 }
 
 impl<FS: Filesystem> SessionEventLoop<FS> {
@@ -539,24 +548,26 @@ impl<FS: Filesystem> SessionEventLoop<FS> {
             // Read the next request from the given channel to kernel driver
             // The kernel driver makes sure that we get exactly one request per read
             match self.ch.receive_retrying(buf) {
-                Ok(size) => match RequestWithSender::new(self.ch.sender(), &buf[..size]) {
-                    // Dispatch request
-                    Some(req) => {
-                        if let Ok(Operation::Destroy(_)) = req.request.operation() {
-                            req.reply::<ReplyEmpty>().ok();
-                            return Ok(());
-                        } else {
-                            req.dispatch(self)
+                Ok(size) => {
+                    match RequestWithSender::new(self.ch.sender(), &buf[..size], self.negotiated) {
+                        // Dispatch request
+                        Some(req) => {
+                            if let Ok(Operation::Destroy(_)) = req.request.operation() {
+                                req.reply::<ReplyEmpty>().ok();
+                                return Ok(());
+                            } else {
+                                req.dispatch(self)
+                            }
+                        }
+                        // Quit loop on illegal request
+                        None => {
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "Invalid request",
+                            ));
                         }
                     }
-                    // Quit loop on illegal request
-                    None => {
-                        return Err(io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            "Invalid request",
-                        ));
-                    }
-                },
+                }
                 // The kernel returns ENODEV when the filesystem was unmounted, or
                 // ECONNABORTED when the connection was aborted with FUSE_ABORT_ERROR
                 // negotiated. Either way the connection is gone: a normal end of the


### PR DESCRIPTION
Fixes #357 (ABI 7.33 milestone).

## The problem

`InitFlags::FUSE_SETXATTR_EXT` is public, and `add_capabilities()` only checks whether the *kernel* supports a capability -- never whether fuser implements its wire format. Enabling it makes the kernel send the 16-byte `fuse_setxattr_in` of ABI 7.33, which fuser kept reading as the 8-byte layout.

The consequence is not a silent mis-parse. Verified against a real mount before writing the fix:

```
[init] FUSE_SETXATTR_EXT negotiated OK
--- calling setxattr("user.myattr", "HELLOVALUE") ---
thread 'fuser-0' panicked at src/ll/request.rs:1733:17:
assertion failed: out.value.len() == out.arg.size as usize
```

The name and value come out shifted by eight bytes, the length assertion panics the session thread, and the `setxattr` that triggered it never gets a reply -- so the calling process hangs indefinitely and the mountpoint is left wedged, needing `fusermount3 -u -z`. Without the flag the identical call parses correctly, so this is reachable purely by opting into an advertised capability.

## The change

Selecting the right layout requires the parser to know what was negotiated, which it had no access to. The capabilities agreed during INIT now flow `Session` -> `SessionEventLoop` -> `AnyRequest` -> `op::parse`, following the existing `proto_version` pattern already stored on `Session` during the handshake. `operation()` keeps its signature, so there is no call-site churn.

The `assert!` is replaced by a parse rejection, so a malformed `setxattr` fails the request rather than taking down the session.

**macOS bit collision.** `FUSE_SETXATTR_EXT` and `FUSE_CASE_INSENSITIVE` are both bit 29, and macOS requests the latter on every mount (`lib.rs:118`). A plain `negotiated.contains(FUSE_SETXATTR_EXT)` would therefore fire on every macOS mount and break setxattr there, so the extended path is gated to non-macOS.

## Testing

- Three parse tests: compat layout, extended layout, and an extended request read without negotiation, which must be rejected rather than panic
- End to end against the real kernel: the run that previously hung now returns cleanly with the name and value intact; the control run is unchanged
- `cargo test --all` (75 lib tests), `fmt`, `clippy --all-targets`, and `clippy --no-default-features` clean under `RUSTFLAGS=--deny warnings`; `x86_64-apple-darwin` checks clean

## Deliberately not included

`setxattr_flags` is parsed but not surfaced on the `Filesystem` trait -- that is #358, and the accessor is in place for it.

More significantly, this bug class is not fixed generally: `FUSE_SECURITY_CTX`, `FUSE_CREATE_SUPP_GROUP`, `FUSE_HAS_INODE_DAX` and `FUSE_HAS_RESEND` are still public flags whose wire-format consequences are unimplemented, so enabling any of them may fail the same way. Worth either implementing them or having `add_capabilities()` reject what fuser cannot honor, but that is a separate change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjYWzn3mu8Sc2y2eACtJM9)_