### PR TITLE
Expire a directory entry instead of invalidating it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # FUSE for Rust - Changelog
 
 ## Unreleased
+* Add `Notifier::expire_entry()`, which marks a cached directory entry for revalidation
+  instead of invalidating it (#367). Unlike `inval_entry()`, expiring leaves anything
+  mounted beneath the entry mounted, so it suits an entry merely believed to be stale.
+  Returns `ENOTSUP` on a kernel that does not advertise `InitFlags::FUSE_HAS_EXPIRE_ONLY`,
+  rather than sending a request such a kernel would answer by invalidating the entry and
+  reporting success
 * Add `ReplyDirectory::remaining_capacity()` and `ReplyDirectoryPlus::remaining_capacity()`,
   which report how much room is left for entries (#214). Before the first entry is added this
   is the buffer size the kernel asked for, so a filesystem can size a batch of work to the

--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -702,8 +702,13 @@ pub(crate) struct fuse_notify_inval_inode_out {
 pub(crate) struct fuse_notify_inval_entry_out {
     pub(crate) parent: u64,
     pub(crate) namelen: u32,
-    pub(crate) padding: u32,
+    pub(crate) flags: u32,
 }
+
+/// Expire the entry rather than invalidating it: the kernel marks it for revalidation
+/// on next use instead of forcibly detaching it, which would also detach any submounts
+/// beneath it. Requires `FUSE_HAS_EXPIRE_ONLY`
+pub(crate) const FUSE_EXPIRE_ONLY: u32 = 1 << 0;
 
 #[repr(C)]
 #[derive(Debug, IntoBytes, KnownLayout, Immutable)]

--- a/src/ll/notify.rs
+++ b/src/ll/notify.rs
@@ -68,11 +68,12 @@ impl<'a> Notification<'a> {
     pub(crate) fn new_inval_entry(
         parent: INodeNo,
         name: &'a OsStr,
+        flags: u32,
     ) -> Result<Self, TryFromIntError> {
         let r = abi::fuse_notify_inval_entry_out {
             parent: parent.0,
             namelen: name.len().try_into()?,
-            padding: 0,
+            flags,
         };
         Ok(Self::from_struct_with_name(&r, name.as_bytes()))
     }
@@ -141,7 +142,7 @@ mod test {
 
     #[test]
     fn inval_entry() {
-        let n = Notification::new_inval_entry(INodeNo(0x42), OsStr::new("abc"))
+        let n = Notification::new_inval_entry(INodeNo(0x42), OsStr::new("abc"), 0)
             .unwrap()
             .with_iovec(
                 abi::fuse_notify_code::FUSE_NOTIFY_INVAL_ENTRY,
@@ -152,6 +153,25 @@ mod test {
             0x24, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x61, 0x62, 0x63, 0x00,
+        ];
+        assert_eq!(n, expected);
+    }
+
+    /// The same notification as `inval_entry`, but with FUSE_EXPIRE_ONLY in the flags word.
+    #[test]
+    fn expire_entry() {
+        let n =
+            Notification::new_inval_entry(INodeNo(0x42), OsStr::new("abc"), abi::FUSE_EXPIRE_ONLY)
+                .unwrap()
+                .with_iovec(
+                    abi::fuse_notify_code::FUSE_NOTIFY_INVAL_ENTRY,
+                    ioslice_to_vec,
+                )
+                .unwrap();
+        let expected = vec![
+            0x24, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00,
+            0x01, 0x00, 0x00, 0x00, 0x61, 0x62, 0x63, 0x00,
         ];
         assert_eq!(n, expected);
     }
@@ -189,7 +209,7 @@ mod test {
 
     #[test]
     fn delete() {
-        let n = Notification::new_inval_entry(INodeNo(0x42), OsStr::new("abc"))
+        let n = Notification::new_inval_entry(INodeNo(0x42), OsStr::new("abc"), 0)
             .unwrap()
             .with_iovec(abi::fuse_notify_code::FUSE_NOTIFY_DELETE, ioslice_to_vec)
             .unwrap();

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -6,6 +6,8 @@ use std::io;
 
 use crate::INodeNo;
 use crate::channel::ChannelSender;
+use crate::ll::flags::init_flags::InitFlags;
+use crate::ll::fuse_abi::FUSE_EXPIRE_ONLY;
 use crate::ll::fuse_abi::fuse_notify_code as notify_code;
 use crate::ll::notify::Notification;
 
@@ -22,10 +24,10 @@ pub struct PollNotifier {
 }
 
 impl PollNotifier {
-    pub(crate) fn new(cs: ChannelSender, kh: PollHandle) -> Self {
+    pub(crate) fn new(cs: ChannelSender, kh: PollHandle, kernel_capabilities: InitFlags) -> Self {
         Self {
             handle: kh,
-            notifier: Notifier::new(cs),
+            notifier: Notifier::new(cs, kernel_capabilities),
         }
     }
 
@@ -50,11 +52,20 @@ impl std::fmt::Debug for PollNotifier {
 
 /// A handle by which the application can send notifications to the server
 #[derive(Debug, Clone)]
-pub struct Notifier(ChannelSender);
+pub struct Notifier {
+    sender: ChannelSender,
+    /// Everything the kernel advertised during init. Some notifications are only
+    /// meaningful on a kernel that supports them, and the kernel reports success
+    /// regardless, so they are refused here rather than silently doing something else
+    kernel_capabilities: InitFlags,
+}
 
 impl Notifier {
-    pub(crate) fn new(cs: ChannelSender) -> Self {
-        Self(cs)
+    pub(crate) fn new(cs: ChannelSender, kernel_capabilities: InitFlags) -> Self {
+        Self {
+            sender: cs,
+            kernel_capabilities,
+        }
     }
 
     /// Notify poll clients of I/O readiness
@@ -70,7 +81,33 @@ impl Notifier {
     /// Returns an error if the notification data is too large.
     /// Returns an error if the kernel rejects the notification.
     pub fn inval_entry(&self, parent: INodeNo, name: &OsStr) -> io::Result<()> {
-        let notif = Notification::new_inval_entry(parent, name).map_err(Self::too_big_err)?;
+        let notif = Notification::new_inval_entry(parent, name, 0).map_err(Self::too_big_err)?;
+        self.send_inval(notify_code::FUSE_NOTIFY_INVAL_ENTRY, &notif)
+    }
+
+    /// Expire the kernel cache for a given directory entry, rather than invalidating it.
+    ///
+    /// The entry is marked for revalidation on next use instead of being forcibly
+    /// detached, so anything mounted beneath it stays mounted. Use this in preference to
+    /// [`inval_entry()`](Self::inval_entry) when the entry is merely believed to be stale
+    /// rather than known to be gone.
+    ///
+    /// # Errors
+    /// Returns `ENOTSUP` if the kernel did not advertise `InitFlags::FUSE_HAS_EXPIRE_ONLY`.
+    /// Such a kernel reads the flag as the padding it used to be and invalidates the entry,
+    /// detaching any submounts, while still reporting success, so this refuses to send
+    /// rather than quietly doing the destructive thing this call exists to avoid.
+    /// Returns an error if the notification data is too large.
+    /// Returns an error if the kernel rejects the notification.
+    pub fn expire_entry(&self, parent: INodeNo, name: &OsStr) -> io::Result<()> {
+        if !self
+            .kernel_capabilities
+            .contains(InitFlags::FUSE_HAS_EXPIRE_ONLY)
+        {
+            return Err(io::Error::from_raw_os_error(libc::ENOTSUP));
+        }
+        let notif = Notification::new_inval_entry(parent, name, FUSE_EXPIRE_ONLY)
+            .map_err(Self::too_big_err)?;
         self.send_inval(notify_code::FUSE_NOTIFY_INVAL_ENTRY, &notif)
     }
 
@@ -117,7 +154,7 @@ impl Notifier {
 
     fn send(&self, code: notify_code, notification: &Notification<'_>) -> io::Result<()> {
         notification
-            .with_iovec(code, |iov| self.0.send(iov))
+            .with_iovec(code, |iov| self.sender.send(iov))
             .map_err(Self::too_big_err)?
     }
 
@@ -126,5 +163,49 @@ impl Notifier {
     /// capable of encoding.
     fn too_big_err(tfie: std::num::TryFromIntError) -> io::Error {
         io::Error::new(io::ErrorKind::Other, format!("Data too large: {tfie:?}"))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::fs::File;
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::channel::Channel;
+    use crate::dev_fuse::DevFuse;
+
+    fn notifier(kernel_capabilities: InitFlags) -> Notifier {
+        // /dev/null stands in for the FUSE device: the cases below either return before
+        // sending, or send a notification whose fate is not what is under test
+        let dev = Arc::new(DevFuse(
+            File::options().write(true).open("/dev/null").unwrap(),
+        ));
+        Notifier::new(Channel::new(dev).sender(), kernel_capabilities)
+    }
+
+    /// A kernel that never advertised expiring would invalidate the entry and report
+    /// success, so the request is refused here instead of being sent.
+    #[test]
+    fn expire_entry_refused_without_kernel_support() {
+        let err = notifier(InitFlags::empty())
+            .expire_entry(INodeNo::ROOT, OsStr::new("x"))
+            .unwrap_err();
+        assert_eq!(err.raw_os_error(), Some(libc::ENOTSUP));
+    }
+
+    #[test]
+    fn expire_entry_sent_with_kernel_support() {
+        notifier(InitFlags::FUSE_HAS_EXPIRE_ONLY)
+            .expire_entry(INodeNo::ROOT, OsStr::new("x"))
+            .unwrap();
+    }
+
+    /// Invalidating is unconditional: it does not depend on the expire capability.
+    #[test]
+    fn inval_entry_needs_no_capability() {
+        notifier(InitFlags::empty())
+            .inval_entry(INodeNo::ROOT, OsStr::new("x"))
+            .unwrap();
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -457,7 +457,8 @@ impl<'a> RequestWithSender<'a> {
                 );
             }
             ll::Operation::Poll(x) => {
-                let ph = PollNotifier::new(se.ch.sender(), x.kernel_handle());
+                let ph =
+                    PollNotifier::new(se.ch.sender(), x.kernel_handle(), se.kernel_capabilities);
 
                 filesystem.poll(
                     self.request_header(),

--- a/src/session.rs
+++ b/src/session.rs
@@ -146,6 +146,10 @@ pub struct Session<FS: Filesystem> {
     /// Capabilities agreed with the kernel during init. Some request layouts depend on
     /// them, so the event loops need them to parse correctly
     pub(crate) negotiated: InitFlags,
+    /// Everything the kernel advertised during init, whether or not it was requested.
+    /// Some operations are honoured by the kernel without being negotiated, so this,
+    /// not `negotiated`, says whether the kernel can perform them
+    pub(crate) kernel_capabilities: InitFlags,
     pub(crate) config: Config,
 }
 
@@ -194,6 +198,7 @@ impl<FS: Filesystem> Session<FS> {
             session_owner: geteuid(),
             proto_version: None,
             negotiated: InitFlags::empty(),
+            kernel_capabilities: InitFlags::empty(),
             config: options.clone(),
         };
 
@@ -223,6 +228,7 @@ impl<FS: Filesystem> Session<FS> {
             session_owner: geteuid(),
             proto_version: None,
             negotiated: InitFlags::empty(),
+            kernel_capabilities: InitFlags::empty(),
             config,
         };
 
@@ -238,6 +244,7 @@ impl<FS: Filesystem> Session<FS> {
     pub fn spawn(self) -> io::Result<BackgroundSession> {
         let sender = self.ch.sender();
         let fuse_device = self.ch.device();
+        let kernel_capabilities = self.kernel_capabilities;
         // Take the fuse_session, so that we can unmount it
         let mount = std::mem::take(&mut *self.mount.mount.lock());
         let guard = thread::Builder::new()
@@ -248,6 +255,7 @@ impl<FS: Filesystem> Session<FS> {
             sender,
             fuse_device,
             mount,
+            kernel_capabilities,
         })
     }
 
@@ -266,6 +274,7 @@ impl<FS: Filesystem> Session<FS> {
             session_owner,
             proto_version: _,
             negotiated,
+            kernel_capabilities,
             config,
         } = self;
 
@@ -314,6 +323,7 @@ impl<FS: Filesystem> Session<FS> {
                 allowed,
                 session_owner,
                 negotiated,
+                kernel_capabilities,
             };
             threads.push(
                 thread::Builder::new()
@@ -448,6 +458,7 @@ impl<FS: Filesystem> Session<FS> {
             // Remember the ABI version supported by kernel and mark the session initialized.
             self.proto_version = Some(v);
             self.negotiated = init.capabilities() & config.requested;
+            self.kernel_capabilities = init.capabilities();
 
             // Log capability status for debugging
             for bit in 0..64 {
@@ -508,7 +519,7 @@ impl<FS: Filesystem> Session<FS> {
 
     /// Returns an object that can be used to send notifications to the kernel
     pub fn notifier(&self) -> Notifier {
-        Notifier::new(self.ch.sender())
+        Notifier::new(self.ch.sender(), self.kernel_capabilities)
     }
 }
 
@@ -536,6 +547,7 @@ pub(crate) struct SessionEventLoop<FS: Filesystem> {
     pub(crate) allowed: SessionACL,
     pub(crate) session_owner: Uid,
     pub(crate) negotiated: InitFlags,
+    pub(crate) kernel_capabilities: InitFlags,
 }
 
 impl<FS: Filesystem> SessionEventLoop<FS> {
@@ -602,6 +614,9 @@ pub struct BackgroundSession {
     fuse_device: Arc<DevFuse>,
     /// Ensures the filesystem is unmounted when the session ends
     mount: Option<Mount>,
+    /// Everything the kernel advertised during init, for notifications whose support
+    /// depends on it
+    kernel_capabilities: InitFlags,
 }
 
 /// How long teardown waits for the kernel connection to end after a successful
@@ -629,7 +644,7 @@ impl BackgroundSession {
 
     /// Returns an object that can be used to send notifications to the kernel
     pub fn notifier(&self) -> Notifier {
-        Notifier::new(self.sender.clone())
+        Notifier::new(self.sender.clone(), self.kernel_capabilities)
     }
 
     /// Join the filesystem thread without unmounting first: blocks until


### PR DESCRIPTION
Fixes #367 (ABI 7.38 milestone).

## The problem

`fuse_notify_inval_entry_out` carries a flags word that fuser sent as a hardcoded zero, named `padding`. Its one defined bit, `FUSE_EXPIRE_ONLY`, asks the kernel to mark the entry for revalidation rather than forcibly detaching it -- and detaching also detaches anything mounted beneath it. A filesystem that merely suspects an entry is stale had no way to say so, and had to reach for the destructive form.

## The change

Name the field and add `Notifier::expire_entry()`. This follows libfuse, which exposes the same thing as a separate `fuse_lowlevel_notify_expire_entry()` rather than a flags parameter -- with a single defined bit, a public bitflags type would be more surface than the feature needs.

`expire_entry()` **fails closed**: it returns `ENOTSUP` when the kernel did not advertise `FUSE_HAS_EXPIRE_ONLY`, rather than sending a request such a kernel would answer by invalidating the entry, detaching submounts, and reporting success. Nothing in the reply distinguishes that case, so leaving it to a documented precondition would mean the one call whose purpose is to be non-destructive could silently be the destructive one.

The guard keys on what the kernel **advertised**, not on the negotiated set. That distinction is load-bearing: the kernel honours the flag whether or not it was requested during init, so guarding on `negotiated` would reject every filesystem that never called `add_capabilities`. `Session` kept only the negotiated intersection, so this adds `kernel_capabilities` alongside it, threaded through `SessionEventLoop` and `BackgroundSession` into `Notifier`.

## Verification

Two obvious checks turned out **not** to discriminate, which is worth recording since a reviewer would likely reach for them:

- Sending an undefined bit (`flags=0x2`) returns `Ok`. The kernel does not validate that word at all, so acceptance proves nothing about whether it is read -- and by the same token, nothing could reject `FUSE_EXPIRE_ONLY` on an older kernel either.
- Expiring and invalidating both trigger a fresh `lookup`, so counting lookups proves nothing.

The difference that does show up is submounts. With a bind mount over an entry of a mounted filesystem:

| | submount before | after |
|---|---|---|
| `inval_entry` (flags=0) | present | detached |
| `expire_entry` (`FUSE_EXPIRE_ONLY`) | present | survives |

Separately, running that probe with and without `add_capabilities(FUSE_HAS_EXPIRE_ONLY)` gave identical results, which is what establishes that the capability is an advertisement rather than a gate.

Tests: a byte-level assertion that the flags word is `0x01` where `inval_entry`'s is `0x00`, plus three over a real `Notifier` covering both sides of the guard -- refused with `ENOTSUP` when the capability is absent, sent when present, and `inval_entry()` unaffected since it depends on nothing. The guard was also re-checked end to end against a running kernel with a filesystem that never calls `add_capabilities`, the case a negotiated-set guard would have broken.

`cargo test --all` (82 lib tests), `fmt`, `clippy --all-targets` and `clippy --no-default-features` clean under `RUSTFLAGS=--deny warnings`; all-features build and `x86_64-apple-darwin` check clean.

## Noticed but not fixed

The `delete` test in `src/ll/notify.rs` calls `new_inval_entry` and sends the result under the `FUSE_NOTIFY_DELETE` code, so `new_delete()` and its 24-byte `fuse_notify_delete_out` layout have no coverage. This PR only adds the new `flags` argument to that call so it keeps compiling; correcting the test changes what it asserts, which is unrelated to this change. Happy to do it separately.