### PR TITLE
Refuse capabilities fuser cannot honor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # FUSE for Rust - Changelog
 
 ## Unreleased
+* `KernelConfig::add_capabilities()` now refuses capabilities fuser cannot honor, rather than
+  requesting them and leaving the filesystem silently broken: `FUSE_SECURITY_CTX`,
+  `FUSE_CREATE_SUPP_GROUP`, `FUSE_HANDLE_KILLPRIV_V2`, `FUSE_ALLOW_IDMAP`, `FUSE_HAS_INODE_DAX`,
+  `FUSE_SUBMOUNTS`, `FUSE_MAP_ALIGNMENT`, `FUSE_OVER_IO_URING`, `FUSE_HAS_RESEND` and
+  `FUSE_REQUEST_TIMEOUT`. Negotiating most of them merely had no effect, but `FUSE_ALLOW_IDMAP`
+  left the filesystem answering `EACCES` to everything but inode creation, and
+  `FUSE_HANDLE_KILLPRIV_V2` left suid and sgid bits surviving a chown, a truncate or an
+  `O_TRUNC` open. Plain `FUSE_HANDLE_KILLPRIV` still works, as do the macFUSE capabilities that
+  share a bit with three of these
 * Add `Notifier::expire_entry()`, which marks a cached directory entry for revalidation
   instead of invalidating it (#367). Unlike `inval_entry()`, expiring leaves anything
   mounted beneath the entry mounted, so it suits an entry merely believed to be stale.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,62 @@ fn default_init_flags(capabilities: InitFlags) -> InitFlags {
     flags
 }
 
+/// Capabilities fuser has no implementation behind, whatever the kernel advertises.
+///
+/// Negotiating one of these makes the kernel change the protocol in a way fuser gets wrong, or
+/// claims a feature fuser cannot provide. Since the negotiated set is only ever echoed back to
+/// the kernel, an unimplemented capability fails silently rather than loudly, so
+/// [`KernelConfig::add_capabilities`] refuses them up front.
+///
+/// Every bit named here is above 31, where macFUSE defines no capability of its own. The refused
+/// bits that do alias one live in `ALIASED_UNSUPPORTED_CAPABILITIES`, which is empty on macOS.
+const UNSUPPORTED_CAPABILITIES: InitFlags = ALIASED_UNSUPPORTED_CAPABILITIES
+    // The kernel appends a fuse_secctx_header extension after the name of a create, mkdir,
+    // symlink or mknod request. fuser stops parsing at the name, so the security context is
+    // dropped and the filesystem creates unlabeled files while believing it labels them
+    .union(InitFlags::FUSE_SECURITY_CTX)
+    // Likewise for the fuse_supp_groups extension. Dropping it leaves the filesystem with the
+    // caller's fsgid in exactly the case the extension exists to correct
+    .union(InitFlags::FUSE_CREATE_SUPP_GROUP)
+    // Without MountOption::DefaultPermissions the kernel refuses the connection. With it, uid
+    // and gid arrive as FUSE_INVALID_UIDGID on every request that does not create an inode,
+    // breaking Request::uid()/gid() and the SessionACL check built on them
+    .union(InitFlags::FUSE_ALLOW_IDMAP)
+    // Selecting DAX per inode requires FUSE_ATTR_DAX in the flags field of fuse_attr, which
+    // fuser sends as padding. Only a DAX-capable transport (virtiofs) advertises this
+    .union(InitFlags::FUSE_HAS_INODE_DAX)
+    // The kernel would route requests to io_uring queues that fuser never creates
+    .union(InitFlags::FUSE_OVER_IO_URING)
+    // Announces that the filesystem copes with requests the kernel resends. fuser cannot send
+    // the FUSE_NOTIFY_RESEND notification that asks for a resend in the first place
+    .union(InitFlags::FUSE_HAS_RESEND)
+    // The timeout is carried by a request_timeout field of fuse_init_out that fuser declares as
+    // reserved and always sends as zero, which the kernel reads as "no timeout requested"
+    .union(InitFlags::FUSE_REQUEST_TIMEOUT);
+
+/// The refused capabilities that occupy a bit below 32, where macFUSE assigns a meaning of its
+/// own. On macOS these bits are `FUSE_EXCHANGE_DATA`, `FUSE_ALLOCATE` and `FUSE_RENAME_EXCL` -
+/// the last of which fuser requests itself - so nothing is refused there.
+#[cfg(not(target_os = "macos"))]
+const ALIASED_UNSUPPORTED_CAPABILITIES: InitFlags = InitFlags::empty()
+    // The kernel stops clearing suid and sgid itself, having set SB_NOSEC, and instead reports
+    // per request whether the caller lacked CAP_FSETID. fuser passes on only one of the three
+    // signals it sends: FUSE_WRITE_KILL_SUIDGID reaches Filesystem::write, but FATTR_KILL_SUIDGID
+    // on a chown or truncate is not among the FattrFlags that setattr decodes, and
+    // FUSE_OPEN_KILL_SUIDGID lives in the open_flags field of fuse_open_in, which fuser does not
+    // read. Those bits would survive operations that must clear them. Unlike v2, plain
+    // FUSE_HANDLE_KILLPRIV needs no such signal, since it asks the filesystem to clear them on
+    // every write, chown and truncate, which it can tell apart by opcode
+    .union(InitFlags::FUSE_HANDLE_KILLPRIV_V2)
+    // Marking a submount root needs FUSE_ATTR_SUBMOUNT in the flags field of fuse_attr, which
+    // fuser sends as padding. Only a transport with submounts (virtiofs) advertises this
+    .union(InitFlags::FUSE_SUBMOUNTS)
+    // Read from a fuse_init_out field fuser leaves zeroed, which makes the kernel refuse the
+    // connection unless that happens to match its DAX alignment. Advertised by virtiofs alone
+    .union(InitFlags::FUSE_MAP_ALIGNMENT);
+#[cfg(target_os = "macos")]
+const ALIASED_UNSUPPORTED_CAPABILITIES: InitFlags = InitFlags::empty();
+
 /// File types
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
@@ -348,11 +404,13 @@ impl KernelConfig {
     /// Add a set of capabilities.
     ///
     /// # Errors
-    /// When the argument includes capabilities not supported by the kernel, returns the bits of the capabilities not supported.
+    /// When the argument includes capabilities the kernel does not support, or ones fuser cannot
+    /// honor, returns the bits of the capabilities that were refused. Nothing is added in that
+    /// case, not even the capabilities that would have been accepted on their own.
     pub fn add_capabilities(&mut self, capabilities_to_add: InitFlags) -> Result<(), InitFlags> {
-        if !self.capabilities.contains(capabilities_to_add) {
-            let unsupported = capabilities_to_add & !self.capabilities;
-            return Err(unsupported);
+        let refused = capabilities_to_add & (!self.capabilities | UNSUPPORTED_CAPABILITIES);
+        if !refused.is_empty() {
+            return Err(refused);
         }
         self.requested |= capabilities_to_add;
         Ok(())
@@ -1116,5 +1174,45 @@ mod tests {
             config.set_max_write(MAX_WRITE_SIZE as u32),
             Ok(MIN_WRITE_SIZE as u32)
         );
+    }
+
+    #[test]
+    fn add_capabilities_refuses_unimplemented() {
+        // A kernel advertising everything, so only fuser's own limits can refuse anything
+        let mut config = KernelConfig::new(InitFlags::all(), 65536, Version(7, 43));
+        let before = config.requested;
+        for capability in UNSUPPORTED_CAPABILITIES {
+            assert_eq!(config.add_capabilities(capability), Err(capability));
+        }
+        // A capability fuser implements is still accepted from the same kernel
+        assert_eq!(config.add_capabilities(InitFlags::FUSE_POSIX_ACL), Ok(()));
+        assert_eq!(config.requested, before | InitFlags::FUSE_POSIX_ACL);
+    }
+
+    #[test]
+    fn refused_capabilities_are_never_requested_by_default() {
+        // Below bit 32 a capability aliases a macFUSE one, some of which fuser requests itself.
+        // Refusing a bit fuser goes on to request would be incoherent, and on macOS would break
+        // the operations built on it, so the two sets must stay disjoint on every platform
+        assert!(UNSUPPORTED_CAPABILITIES.intersection(INIT_FLAGS).is_empty());
+    }
+
+    #[test]
+    fn add_capabilities_refuses_all_or_nothing() {
+        // Advertise everything except one capability fuser does implement
+        let capabilities = InitFlags::all() - InitFlags::FUSE_POSIX_ACL;
+        let mut config = KernelConfig::new(capabilities, 65536, Version(7, 43));
+        let before = config.requested;
+        // Both reasons for refusing are reported together, and a capability that would have
+        // been accepted on its own is not added
+        assert_eq!(
+            config.add_capabilities(
+                InitFlags::FUSE_POSIX_ACL
+                    | InitFlags::FUSE_SECURITY_CTX
+                    | InitFlags::FUSE_ASYNC_DIO
+            ),
+            Err(InitFlags::FUSE_POSIX_ACL | InitFlags::FUSE_SECURITY_CTX)
+        );
+        assert_eq!(config.requested, before);
     }
 }


### PR DESCRIPTION
`KernelConfig::add_capabilities()` only checked whether the kernel advertised a capability, so a filesystem could negotiate one fuser has no implementation behind. The negotiated set is only ever echoed back to the kernel, so there was no way for that to fail loudly: the kernel changed the protocol and fuser carried on reading the old one.

Ten capabilities are now refused alongside the ones the kernel does not support. Together they cover every capability the kernel consumes from the INIT reply that fuser cannot back.

## The one with real-world impact

**`FUSE_HANDLE_KILLPRIV_V2`.** The kernel sets `SB_NOSEC` (`inode.c:1409`) and then skips its own suid/sgid clearing entirely (`dir.c:2136` — "the only sane way to reliably kill suid/sgid is to do it in the userspace filesystem"), delegating it to the server. fuser forwards one of the three signals that make the delegation work:

| signal | where | reaches the filesystem? |
| --- | --- | --- |
| `FUSE_WRITE_KILL_SUIDGID` | `file.c:1134`, `file.c:1646` | yes, via `WriteFlags` on `Filesystem::write` |
| `FATTR_KILL_SUIDGID` on non-directory chown | `dir.c:2022-2024` | no — not among the `FattrFlags` `setattr` decodes |
| `FATTR_KILL_SUIDGID` on truncate without `CAP_FSETID` | `dir.c:2032-2033` | no — same |
| `FUSE_OPEN_KILL_SUIDGID` on `O_TRUNC` open | `file.c:38-41` | no — sits in `fuse_open_in.open_flags`, which fuser never reads |

So setuid/setgid survived a chown, a truncate and an `O_TRUNC` open — a privilege-retention bug rather than the silent no-ops the rest of this PR is about.

Plain `FUSE_HANDLE_KILLPRIV` is unaffected and still accepted: v1's contract is "clear them on write, chown and truncate", which a filesystem can satisfy from the opcode alone, while v2 adds "only when the caller lacked `CAP_FSETID`", which it cannot determine for itself. Verified end-to-end that `examples/simple` still negotiates v1 and mounts.

This is the only refused capability a working filesystem might plausibly be requesting today, so it is the one place this PR changes real behavior. The alternative is implementing v2 properly — adding `FATTR_KILL_SUIDGID` to `FattrFlags`, reading `fuse_open_in.open_flags`, and surfacing both through `Filesystem::setattr` and `open` — which is a breaking signature change and its own PR. Refusing is the interim, in the same spirit as `FUSE_SETXATTR_ACL_KILL_SGID` in #357. Easy to drop if you would rather keep it available.

## The rest

Verified against the running kernel (6.18.5) with a probe filesystem that hexdumps raw requests, and read against `fs/fuse/{inode,dir,dev,file}.c` at v6.18.

**`FUSE_SECURITY_CTX`** — the kernel appends a `fuse_secctx_header` extension after the name of a create, mkdir, symlink or mknod request. A `mkdir` arrived at 99 bytes with `total_extlen=6`, carrying `security.selinux` -> `unlabeled`. fuser stops parsing at the name, so the context is discarded and the filesystem creates unlabeled files while believing it labels them.

**`FUSE_CREATE_SUPP_GROUP`** — same shape, `total_extlen=2`, a `FUSE_EXT_GROUPS` extension carrying the parent directory's gid. Also discarded, which leaves the filesystem with the caller's fsgid in exactly the case the extension exists to correct.

**`FUSE_ALLOW_IDMAP`** — without `MountOption::DefaultPermissions` the kernel sets `ok = false` and refuses the connection (`inode.c:1445-1450`). With it, `dev.c:641-646` sends `FUSE_INVALID_UIDGID` as the uid and gid of every request that does not create an inode; every `GETATTR` in the probe arrived with `ff ff ff ff`. The default `SessionACL::Owner` then rejects all of them with `EACCES`, so nothing but inode creation works.

**`FUSE_OVER_IO_URING`** — the kernel would set `fc->io_uring` and route requests to queues fuser never creates. Advertised only when `fuse_uring_enabled()`.

**`FUSE_REQUEST_TIMEOUT`** — `init_server_timeout()` is called unconditionally, and the flag only controls whether `timeout` is filled from `arg->request_timeout`. fuser's `fuse_init_out` covers that slot with `reserved: [u32; 6]` and always sends zero, so `init_server_timeout(fc, 0)` returns early and negotiating the bit changes nothing while the caller believes timeouts are in effect. Reachable: bit 42 is advertised on the probe kernel.

**`FUSE_HAS_RESEND`** — inert rather than harmful: the kernel never reads it back from the INIT reply. Refused because fuser has no `FUSE_NOTIFY_RESEND` notification to give it meaning. `FUSE_HAS_EXPIRE_ONLY` is announcement-only in the same way but stays accepted, since `Notifier::expire_entry()` implements the feature behind it.

**`FUSE_HAS_INODE_DAX`, `FUSE_SUBMOUNTS`, `FUSE_MAP_ALIGNMENT`** — all virtiofs-only, so a filesystem reaching the kernel through `/dev/fuse` is never offered them; the probe kernel advertises none. fuser could not honor them regardless: per-inode DAX and submount roots need `FUSE_ATTR_DAX` / `FUSE_ATTR_SUBMOUNT` in the `flags` field of `fuse_attr`, which fuser declares as `padding` and always sends as zero, and `FUSE_MAP_ALIGNMENT` is read from a `fuse_init_out` field fuser also leaves zeroed.

## Note on macOS

Below bit 32 every capability aliases a macFUSE one. Three refused bits land there — `FUSE_HANDLE_KILLPRIV_V2`, `FUSE_SUBMOUNTS` and `FUSE_MAP_ALIGNMENT` are `FUSE_EXCHANGE_DATA`, `FUSE_ALLOCATE` and `FUSE_RENAME_EXCL` on macFUSE, the last of which fuser requests itself (the #341 fix). They are refused through a separate `ALIASED_UNSUPPORTED_CAPABILITIES` constant that is empty on macOS, keeping the hazard in the code rather than in a comment. Everything else sits above bit 31, where macFUSE defines nothing.

A test asserts the refused set stays disjoint from the capabilities fuser requests by default. That is what actually makes the aliasing safe, and it fails in `mac-ci` rather than in review if one of these bits is later moved into the unconditional constant.

## Behavior

The all-or-nothing contract is unchanged: a refused call adds nothing, which was already true of the kernel-unsupported path and is now documented. Both reasons for refusing are reported together in the returned bits.

## Testing

- Three unit tests: every entry in the refused set is rejected against a kernel advertising everything, a capability fuser does implement is still accepted, a mixed request reports both refusal reasons while leaving `requested` untouched, and the refused set never overlaps what fuser requests by default.
- `cargo test`, `clippy --all-targets` with and without default features, and `--features=experimental` under `RUSTFLAGS=--deny warnings`.
- Live re-check: all refused capabilities return exactly their own bit, `FUSE_HAS_EXPIRE_ONLY` and `FUSE_PASSTHROUGH` still accept, and create/mkdir/symlink requests come back with `total_extlen=0` and no trailing extension. `examples/simple` exercised end-to-end, including that it still negotiates `FUSE_HANDLE_KILLPRIV`.
- Not run locally: pjdfs, xfstests and `fuser-tests` all require Docker, and the daemon was unavailable in this environment — they run in CI.

Thanks to Codex, whose reviews caught `FUSE_REQUEST_TIMEOUT`, `FUSE_SUBMOUNTS` and `FUSE_HANDLE_KILLPRIV_V2` — all three were real gaps in the rule this PR sets out, and the last was the most consequential thing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjYWzn3mu8Sc2y2eACtJM9