### PR TITLE
Lint the experimental feature in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ pre:
 	cargo deny check licenses
 	cargo clippy --all-targets
 	cargo clippy --all-targets --no-default-features
+	cargo clippy --all-targets --all-features
 
 xfstests:
 	docker build -t fuser:xfstests -f xfstests.Dockerfile .

--- a/src/experimental.rs
+++ b/src/experimental.rs
@@ -228,6 +228,7 @@ impl<T: AsyncFilesystem + Send + Sync + 'static> Filesystem for TokioAdapter<T> 
 
 /// Experimental async API. Expect this to change in the future
 #[async_trait::async_trait]
+#[allow(clippy::too_many_arguments)]
 pub trait AsyncFilesystem: Send + Sync + 'static {
     async fn lookup(
         &self,


### PR DESCRIPTION
`make pre` ran clippy with the default and empty feature sets, and neither enables `experimental`, so `AsyncFilesystem` had never been linted. `serializable` was uncovered for the same reason.

Running clippy over that feature hits a hard error, since CI sets `RUSTFLAGS=--deny warnings`:

```
error: this function has too many arguments (9/7)
   --> src/experimental.rs:230:28
```

`AsyncFilesystem::read` takes the same nine arguments as `Filesystem::read`, because both mirror the argument list of the FUSE read request.

## The fix

`#[allow(clippy::too_many_arguments)]` on the trait, matching what `Filesystem` already carries at `src/lib.rs:467`. The sync twin of this trait made exactly this call for exactly this signature; applying it inconsistently is what left the async trait unlintable.

Worth flagging that `AGENTS.md` says to fix warnings rather than silence them, and this is the silencing branch of that rule. The alternative is folding the arguments into a params struct, which would be an API redesign that diverges the async trait from the sync one — out of proportion to a lint gap, and a decision better made on its own merits than as a side effect of turning the lint on.

## The CI change

Added `cargo clippy --all-targets --all-features` to the Makefile `pre` target, which is what the `ci` job runs. Keeping `make pre` and CI identical is the property whose absence made this invisible, so the new check belongs there rather than as a separate workflow step.

On Linux `--all-features` resolves to libfuse3 + experimental + serializable: `build.rs` picks libfuse3 before libfuse2, and `macos-no-mount` only applies to macOS targets, so the combination is coherent rather than a pile of mutually exclusive flags.

## Verification

The new gate is not vacuous — with the `allow` stashed, it fails as intended:

```
error: this function has too many arguments (9/7)
error: could not compile `fuser` (lib) due to 1 previous error
```

Also green under `RUSTFLAGS=--deny warnings`: all three clippy variants, `cargo fmt --check`, `cargo test --all --all-features` (85 + 2 pass), and `cargo doc --all --no-deps --all-features` with `RUSTDOCFLAGS=--deny warnings`.

The new invocation adds ~3s incrementally. The `ci` job runs in roughly 35s warm against a 10-minute timeout, so there is headroom even on a cold cache that has to build tokio and serde for the first time.

No CHANGELOG entry: this changes no behavior and no API.

`cargo deny check licenses`, the one part of `pre` not run locally, is unaffected — no dependencies changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjYWzn3mu8Sc2y2eACtJM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjYWzn3mu8Sc2y2eACtJM9)_