### PR TITLE
Implement FUSE_HANDLE_KILLPRIV_V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # FUSE for Rust - Changelog
 
 ## Unreleased
+* Support `InitFlags::FUSE_HANDLE_KILLPRIV_V2`, which the previous release refused. With it
+  negotiated the kernel stops clearing suid and sgid itself and instead tells the filesystem
+  which requests must clear them, so `Filesystem::setattr()`, `open()` and `create()` gain a
+  `kill_suid_gid` argument carrying that signal (`write()` already had it via
+  `WriteFlags::FUSE_WRITE_KILL_SUIDGID`). A filesystem that does not request the capability
+  never sees it set. Note that `kill_suid_gid` covers suid and sgid only: as with plain
+  `FUSE_HANDLE_KILLPRIV`, clearing the `security.capability` xattr on every write, chown and
+  truncate is also the filesystem's job under either capability, and carries no per-request
+  signal. What v2 adds is that suid and sgid are cleared only when the caller lacks
+  `CAP_FSETID`, matching what the kernel would have done itself
 * `KernelConfig::add_capabilities()` now refuses capabilities fuser cannot honor, rather than
   requesting them and leaving the filesystem silently broken: `FUSE_SECURITY_CTX`,
   `FUSE_CREATE_SUPP_GROUP`, `FUSE_HANDLE_KILLPRIV_V2`, `FUSE_ALLOW_IDMAP`, `FUSE_HAS_INODE_DAX`,

--- a/examples/notify_inval_inode.rs
+++ b/examples/notify_inval_inode.rs
@@ -138,7 +138,14 @@ impl Filesystem for ClockFS {
         }
     }
 
-    fn open(&self, _req: &Request, ino: INodeNo, flags: OpenFlags, reply: ReplyOpen) {
+    fn open(
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        flags: OpenFlags,
+        _kill_suid_gid: bool,
+        reply: ReplyOpen,
+    ) {
         if ino == INodeNo::ROOT {
             reply.error(Errno::EISDIR);
         } else if flags.acc_mode() != OpenAccMode::O_RDONLY {

--- a/examples/passthrough.rs
+++ b/examples/passthrough.rs
@@ -192,7 +192,14 @@ impl Filesystem for PassthroughFs {
         }
     }
 
-    fn open(&self, _req: &Request, ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
+    fn open(
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        _flags: OpenFlags,
+        _kill_suid_gid: bool,
+        reply: ReplyOpen,
+    ) {
         if ino != INodeNo(2) {
             reply.error(Errno::ENOENT);
             return;

--- a/examples/passthrough_fork.rs
+++ b/examples/passthrough_fork.rs
@@ -185,7 +185,14 @@ impl Filesystem for ForkPassthroughFs {
         }
     }
 
-    fn open(&self, _req: &Request, ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
+    fn open(
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        _flags: OpenFlags,
+        _kill_suid_gid: bool,
+        reply: ReplyOpen,
+    ) {
         if ino != INodeNo(2) {
             reply.error(Errno::ENOENT);
             return;

--- a/examples/poll.rs
+++ b/examples/poll.rs
@@ -199,7 +199,14 @@ impl fuser::Filesystem for FSelFS {
         reply.ok();
     }
 
-    fn open(&self, _req: &Request, ino: INodeNo, flags: OpenFlags, reply: ReplyOpen) {
+    fn open(
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        flags: OpenFlags,
+        _kill_suid_gid: bool,
+        reply: ReplyOpen,
+    ) {
         let idx = FSelData::ino_to_idx(ino);
         if idx >= NUMFILES {
             reply.error(Errno::ENOENT);

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -627,6 +627,7 @@ impl Filesystem for SimpleFS {
         _chgtime: Option<SystemTime>,
         _bkuptime: Option<SystemTime>,
         _flags: Option<BsdFileFlags>,
+        _kill_suid_gid: bool,
         reply: ReplyAttr,
     ) {
         let mut attrs = match self.get_inode(ino) {
@@ -1456,7 +1457,14 @@ impl Filesystem for SimpleFS {
         }
     }
 
-    fn open(&self, _req: &Request, _ino: INodeNo, flags: OpenFlags, reply: ReplyOpen) {
+    fn open(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        flags: OpenFlags,
+        _kill_suid_gid: bool,
+        reply: ReplyOpen,
+    ) {
         debug!("open() called for {_ino:?}");
         let (access_mask, read, write) = match flags.acc_mode() {
             OpenAccMode::O_RDONLY => {
@@ -1843,6 +1851,7 @@ impl Filesystem for SimpleFS {
         mut mode: u32,
         _umask: u32,
         flags: i32,
+        _kill_suid_gid: bool,
         reply: ReplyCreate,
     ) {
         debug!("create() called with {parent:?} {name:?}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,19 +165,10 @@ const UNSUPPORTED_CAPABILITIES: InitFlags = ALIASED_UNSUPPORTED_CAPABILITIES
     .union(InitFlags::FUSE_REQUEST_TIMEOUT);
 
 /// The refused capabilities that occupy a bit below 32, where macFUSE assigns a meaning of its
-/// own. On macOS these bits are `FUSE_EXCHANGE_DATA`, `FUSE_ALLOCATE` and `FUSE_RENAME_EXCL` -
-/// the last of which fuser requests itself - so nothing is refused there.
+/// own. On macOS these bits are `FUSE_ALLOCATE` and `FUSE_RENAME_EXCL` - the latter of which
+/// fuser requests itself - so nothing is refused there.
 #[cfg(not(target_os = "macos"))]
 const ALIASED_UNSUPPORTED_CAPABILITIES: InitFlags = InitFlags::empty()
-    // The kernel stops clearing suid and sgid itself, having set SB_NOSEC, and instead reports
-    // per request whether the caller lacked CAP_FSETID. fuser passes on only one of the three
-    // signals it sends: FUSE_WRITE_KILL_SUIDGID reaches Filesystem::write, but FATTR_KILL_SUIDGID
-    // on a chown or truncate is not among the FattrFlags that setattr decodes, and
-    // FUSE_OPEN_KILL_SUIDGID lives in the open_flags field of fuse_open_in, which fuser does not
-    // read. Those bits would survive operations that must clear them. Unlike v2, plain
-    // FUSE_HANDLE_KILLPRIV needs no such signal, since it asks the filesystem to clear them on
-    // every write, chown and truncate, which it can tell apart by opcode
-    .union(InitFlags::FUSE_HANDLE_KILLPRIV_V2)
     // Marking a submount root needs FUSE_ATTR_SUBMOUNT in the flags field of fuse_attr, which
     // fuser sends as padding. Only a transport with submounts (virtiofs) advertises this
     .union(InitFlags::FUSE_SUBMOUNTS)
@@ -507,6 +498,15 @@ pub trait Filesystem: Send + Sync + 'static {
     }
 
     /// Set file attributes.
+    ///
+    /// `kill_suid_gid` asks the filesystem to clear the suid and sgid bits of the file as part
+    /// of this request, because the caller lacks `CAP_FSETID`. It is only ever set once
+    /// [`InitFlags::FUSE_HANDLE_KILLPRIV_V2`] has been negotiated, since the kernel otherwise
+    /// clears them itself.
+    ///
+    /// Honoring it is necessary but not sufficient: that capability also makes clearing the
+    /// `security.capability` xattr on every write, chown and truncate the filesystem's job,
+    /// and no argument reports that. See [`InitFlags::FUSE_HANDLE_KILLPRIV_V2`].
     fn setattr(
         &self,
         _req: &Request,
@@ -523,11 +523,13 @@ pub trait Filesystem: Send + Sync + 'static {
         _chgtime: Option<SystemTime>,
         _bkuptime: Option<SystemTime>,
         flags: Option<BsdFileFlags>,
+        kill_suid_gid: bool,
         reply: ReplyAttr,
     ) {
         warn!(
             "[Not Implemented] setattr(ino: {ino:#x?}, mode: {mode:?}, uid: {uid:?}, \
-            gid: {gid:?}, size: {size:?}, fh: {fh:?}, flags: {flags:?})"
+            gid: {gid:?}, size: {size:?}, fh: {fh:?}, flags: {flags:?}, \
+            kill_suid_gid: {kill_suid_gid})"
         );
         reply.error(Errno::ENOSYS);
     }
@@ -644,7 +646,23 @@ pub trait Filesystem: Send + Sync + 'static {
     /// anything in fh. There are also some flags (`direct_io`, `keep_cache`) which the
     /// filesystem may set, to change the way the file is opened. See `fuse_file_info`
     /// structure in <`fuse_common.h`> for more details.
-    fn open(&self, _req: &Request, _ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
+    ///
+    /// `kill_suid_gid` asks the filesystem to clear the suid and sgid bits of the file, because
+    /// the open truncates it and the caller lacks `CAP_FSETID`. It is only ever set once
+    /// [`InitFlags::FUSE_HANDLE_KILLPRIV_V2`] has been negotiated, since the kernel otherwise
+    /// clears them itself.
+    ///
+    /// Honoring it is necessary but not sufficient: that capability also makes clearing the
+    /// `security.capability` xattr on every write, chown and truncate the filesystem's job,
+    /// and no argument reports that. See [`InitFlags::FUSE_HANDLE_KILLPRIV_V2`].
+    fn open(
+        &self,
+        _req: &Request,
+        _ino: INodeNo,
+        _flags: OpenFlags,
+        _kill_suid_gid: bool,
+        reply: ReplyOpen,
+    ) {
         reply.opened(FileHandle(0), FopenFlags::empty());
     }
 
@@ -909,6 +927,15 @@ pub trait Filesystem: Send + Sync + 'static {
     /// opened. See `fuse_file_info` structure in <`fuse_common.h`> for more details. If
     /// this method is not implemented or under Linux kernel versions earlier than
     /// 2.6.15, the `mknod()` and `open()` methods will be called instead.
+    ///
+    /// `kill_suid_gid` asks the filesystem to clear the suid and sgid bits of an existing file,
+    /// because the open truncates it and the caller lacks `CAP_FSETID`. It is only ever set once
+    /// [`InitFlags::FUSE_HANDLE_KILLPRIV_V2`] has been negotiated, since the kernel otherwise
+    /// clears them itself.
+    ///
+    /// Honoring it is necessary but not sufficient: that capability also makes clearing the
+    /// `security.capability` xattr on every write, chown and truncate the filesystem's job,
+    /// and no argument reports that. See [`InitFlags::FUSE_HANDLE_KILLPRIV_V2`].
     fn create(
         &self,
         _req: &Request,
@@ -917,11 +944,12 @@ pub trait Filesystem: Send + Sync + 'static {
         mode: u32,
         umask: u32,
         flags: i32,
+        kill_suid_gid: bool,
         reply: ReplyCreate,
     ) {
         warn!(
             "[Not Implemented] create(parent: {parent:#x?}, name: {name:?}, mode: {mode}, \
-            umask: {umask:#x?}, flags: {flags:#x?})"
+            umask: {umask:#x?}, flags: {flags:#x?}, kill_suid_gid: {kill_suid_gid})"
         );
         reply.error(Errno::ENOSYS);
     }
@@ -1184,9 +1212,18 @@ mod tests {
         for capability in UNSUPPORTED_CAPABILITIES {
             assert_eq!(config.add_capabilities(capability), Err(capability));
         }
+        // Now that setattr, open and create carry kill_suid_gid, this one is honored rather
+        // than refused, and must not drift back into the refused set
+        assert_eq!(
+            config.add_capabilities(InitFlags::FUSE_HANDLE_KILLPRIV_V2),
+            Ok(())
+        );
         // A capability fuser implements is still accepted from the same kernel
         assert_eq!(config.add_capabilities(InitFlags::FUSE_POSIX_ACL), Ok(()));
-        assert_eq!(config.requested, before | InitFlags::FUSE_POSIX_ACL);
+        assert_eq!(
+            config.requested,
+            before | InitFlags::FUSE_HANDLE_KILLPRIV_V2 | InitFlags::FUSE_POSIX_ACL
+        );
     }
 
     #[test]

--- a/src/ll/flags/fattr_flags.rs
+++ b/src/ll/flags/fattr_flags.rs
@@ -17,6 +17,9 @@ bitflags! {
         const FATTR_MTIME_NOW = 1 << 8;
         const FATTR_LOCKOWNER = 1 << 9;
         const FATTR_CTIME = 1 << 10;
+        /// The caller lacks `CAP_FSETID`, so the filesystem must clear suid and sgid.
+        /// Only sent once `FUSE_HANDLE_KILLPRIV_V2` has been negotiated
+        const FATTR_KILL_SUIDGID = 1 << 11;
         #[cfg(target_os = "macos")]
         const FATTR_CRTIME = 1 << 28;
         #[cfg(target_os = "macos")]

--- a/src/ll/flags/init_flags.rs
+++ b/src/ll/flags/init_flags.rs
@@ -45,6 +45,10 @@ bitflags! {
         /// allow parallel lookups and readdir
         const FUSE_PARALLEL_DIROPS = 1 << 18;
         /// fs handles killing suid/sgid/cap on write/chown/trunc
+        ///
+        /// The kernel stops removing those privileges itself, so the filesystem must clear
+        /// suid, sgid and the `security.capability` xattr on every write, chown and truncate.
+        /// No per-request signal accompanies this: the operation itself is the signal
         const FUSE_HANDLE_KILLPRIV = 1 << 19;
         /// filesystem supports posix acls
         const FUSE_POSIX_ACL = 1 << 20;
@@ -63,6 +67,19 @@ bitflags! {
         /// filesystem supports submounts
         const FUSE_SUBMOUNTS = 1 << 27;
         /// fs handles killing suid/sgid/cap on write/chown/trunc (v2)
+        ///
+        /// As with [`Self::FUSE_HANDLE_KILLPRIV`], the kernel stops removing those privileges
+        /// itself, so clearing the `security.capability` xattr on every write, chown and
+        /// truncate remains the filesystem's job and carries no per-request signal.
+        ///
+        /// What v2 adds is finer control over suid and sgid alone, matching what the VFS would
+        /// have done: they are cleared on a write or truncate only when the caller lacks
+        /// `CAP_FSETID`, and sgid only when the file is group-executable. The kernel reports
+        /// the cases it wants cleared through the `kill_suid_gid` argument of
+        /// [`Filesystem::setattr`](crate::Filesystem::setattr),
+        /// [`open`](crate::Filesystem::open) and [`create`](crate::Filesystem::create), and
+        /// through [`WriteFlags::FUSE_WRITE_KILL_SUIDGID`](crate::WriteFlags) on a write.
+        /// Honoring those covers suid and sgid only, not file capabilities
         const FUSE_HANDLE_KILLPRIV_V2 = 1 << 28;
         /// extended setxattr support
         const FUSE_SETXATTR_EXT = 1 << 29;

--- a/src/ll/flags/mod.rs
+++ b/src/ll/flags/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod fsync_flags;
 pub(crate) mod getattr_flags;
 pub(crate) mod init_flags;
 pub(crate) mod ioctl_flags;
+pub(crate) mod open_in_flags;
 pub(crate) mod poll_flags;
 pub(crate) mod read_flags;
 pub(crate) mod release_flags;

--- a/src/ll/flags/open_in_flags.rs
+++ b/src/ll/flags/open_in_flags.rs
@@ -1,0 +1,17 @@
+//! Flags the kernel sends with an open or create request.
+//!
+//! These occupy the `open_flags` field of `fuse_open_in` and `fuse_create_in`, which is distinct
+//! from the `flags` field holding the `O_*` flags of the `open()` call.
+
+use bitflags::bitflags;
+
+bitflags! {
+    /// Flags in the `open_flags` field of `fuse_open_in` and `fuse_create_in`.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub(crate) struct OpenInFlags: u32 {
+        /// The open truncates the file and the caller lacks `CAP_FSETID`, so the filesystem
+        /// must clear suid and sgid. Only sent once `FUSE_HANDLE_KILLPRIV_V2` has been
+        /// negotiated
+        const FUSE_OPEN_KILL_SUIDGID = 1 << 0;
+    }
+}

--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -352,7 +352,7 @@ pub(crate) struct fuse_open_in {
     // NOTE: this field is defined as u32 in fuse_kernel.h in libfuse. However, it is then cast
     // to an i32 when invoking the filesystem's open method and this matches the open() syscall
     pub(crate) flags: i32,
-    pub(crate) unused: u32,
+    pub(crate) open_flags: u32,
 }
 
 #[repr(C)]
@@ -363,7 +363,7 @@ pub(crate) struct fuse_create_in {
     pub(crate) flags: i32,
     pub(crate) mode: u32,
     pub(crate) umask: u32,
-    pub(crate) padding: u32,
+    pub(crate) open_flags: u32,
 }
 
 #[repr(C)]

--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -265,6 +265,7 @@ mod op {
     use crate::ll::flags::fsync_flags::FsyncFlags;
     use crate::ll::flags::getattr_flags::GetattrFlags;
     use crate::ll::flags::init_flags::InitFlags;
+    use crate::ll::flags::open_in_flags::OpenInFlags;
     use crate::ll::flags::read_flags::ReadFlags;
     use crate::ll::flags::release_flags::ReleaseFlags;
     use crate::ll::request::FileHandle;
@@ -483,6 +484,13 @@ mod op {
             #[cfg(not(target_os = "macos"))]
             None
         }
+        /// Whether the filesystem must clear suid and sgid as part of this request.
+        ///
+        /// Only ever true once `FUSE_HANDLE_KILLPRIV_V2` has been negotiated, since the kernel
+        /// otherwise clears them itself.
+        pub(crate) fn kill_suid_gid(&self) -> bool {
+            self.valid().contains(FattrFlags::FATTR_KILL_SUIDGID)
+        }
 
         // TODO: Why does *set*attr want to have an attr response?
     }
@@ -672,6 +680,14 @@ mod op {
     impl Open<'_> {
         pub(crate) fn flags(&self) -> OpenFlags {
             OpenFlags(self.arg.flags)
+        }
+        /// Whether the filesystem must clear suid and sgid as part of this request.
+        ///
+        /// Only ever true once `FUSE_HANDLE_KILLPRIV_V2` has been negotiated, since the kernel
+        /// otherwise clears them itself.
+        pub(crate) fn kill_suid_gid(&self) -> bool {
+            OpenInFlags::from_bits_retain(self.arg.open_flags)
+                .contains(OpenInFlags::FUSE_OPEN_KILL_SUIDGID)
         }
     }
 
@@ -1269,6 +1285,14 @@ mod op {
         }
         pub(crate) fn umask(&self) -> u32 {
             self.arg.umask
+        }
+        /// Whether the filesystem must clear suid and sgid as part of this request.
+        ///
+        /// Only ever true once `FUSE_HANDLE_KILLPRIV_V2` has been negotiated, since the kernel
+        /// otherwise clears them itself.
+        pub(crate) fn kill_suid_gid(&self) -> bool {
+            OpenInFlags::from_bits_retain(self.arg.open_flags)
+                .contains(OpenInFlags::FUSE_OPEN_KILL_SUIDGID)
         }
     }
 
@@ -2516,5 +2540,131 @@ mod tests {
     fn setxattr_layout_mismatch_is_rejected() {
         let req = AnyRequest::try_from(&SETXATTR_EXT_REQUEST[..]).unwrap();
         assert!(req.operation().is_err());
+    }
+
+    #[cfg(all(target_endian = "little", not(target_os = "macos")))]
+    const OPEN_KILL_SUIDGID_REQUEST: AlignedData<[u8; 48]> = AlignedData([
+        0x30, 0x00, 0x00, 0x00, 0x0e, 0x00, 0x00, 0x00, // len, opcode
+        0x0d, 0xd0, 0xad, 0xba, 0xef, 0xbe, 0xad, 0xde, // unique
+        0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, // nodeid
+        0x0d, 0xd0, 0x01, 0xc0, 0xfe, 0xca, 0x01, 0xc0, // uid, gid
+        0x5e, 0xba, 0xde, 0xc0, 0x00, 0x00, 0x00, 0x00, // pid, padding
+        0x01, 0x02, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, // flags, open_flags (KILL_SUIDGID)
+    ]);
+
+    #[cfg(all(target_endian = "little", not(target_os = "macos")))]
+    const CREATE_KILL_SUIDGID_REQUEST: AlignedData<[u8; 64]> = AlignedData([
+        0x40, 0x00, 0x00, 0x00, 0x23, 0x00, 0x00, 0x00, // len, opcode
+        0x0d, 0xd0, 0xad, 0xba, 0xef, 0xbe, 0xad, 0xde, // unique
+        0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, // nodeid
+        0x0d, 0xd0, 0x01, 0xc0, 0xfe, 0xca, 0x01, 0xc0, // uid, gid
+        0x5e, 0xba, 0xde, 0xc0, 0x00, 0x00, 0x00, 0x00, // pid, padding
+        0x41, 0x02, 0x00, 0x00, 0xa4, 0x81, 0x00, 0x00, // flags, mode
+        0x12, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, // umask, open_flags (KILL_SUIDGID)
+        0x66, 0x6f, 0x6f, 0x2e, 0x74, 0x78, 0x74, 0x00, // name
+    ]);
+
+    #[cfg(all(target_endian = "little", not(target_os = "macos")))]
+    const SETATTR_KILL_SUIDGID_REQUEST: AlignedData<[u8; 128]> = AlignedData([
+        0x80, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, // len, opcode
+        0x0d, 0xd0, 0xad, 0xba, 0xef, 0xbe, 0xad, 0xde, // unique
+        0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, // nodeid
+        0x0d, 0xd0, 0x01, 0xc0, 0xfe, 0xca, 0x01, 0xc0, // uid, gid
+        0x5e, 0xba, 0xde, 0xc0, 0x00, 0x00, 0x00, 0x00, // pid, padding
+        0x08, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, // valid (SIZE | KILL_SUIDGID), padding
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // fh
+        0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // size
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // lock_owner
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // atime
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // mtime
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // ctime
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // atimensec, mtimensec
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // ctimensec, mode
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // unused4, uid
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // gid, unused5
+    ]);
+
+    /// The three signals that FUSE_HANDLE_KILLPRIV_V2 adds. Each rides in a field fuser used to
+    /// ignore, so a filesystem that negotiated the capability was never told to clear the bits.
+    #[test]
+    #[cfg(all(target_endian = "little", not(target_os = "macos")))]
+    fn kill_suid_gid_is_parsed() {
+        let req = AnyRequest::try_from(&OPEN_KILL_SUIDGID_REQUEST[..]).unwrap();
+        match req.operation().unwrap() {
+            Operation::Open(x) => {
+                assert!(x.kill_suid_gid());
+                // The O_* flags share the request and must not be disturbed by reading it
+                assert_eq!(x.flags().0, 0x201);
+            }
+            _ => panic!("Unexpected request operation"),
+        }
+
+        let req = AnyRequest::try_from(&CREATE_KILL_SUIDGID_REQUEST[..]).unwrap();
+        match req.operation().unwrap() {
+            Operation::Create(x) => {
+                assert!(x.kill_suid_gid());
+                assert_eq!(x.name(), Path::new("foo.txt"));
+                assert_eq!(x.mode(), 0o100644);
+                assert_eq!(x.umask(), 0o22);
+            }
+            _ => panic!("Unexpected request operation"),
+        }
+
+        let req = AnyRequest::try_from(&SETATTR_KILL_SUIDGID_REQUEST[..]).unwrap();
+        match req.operation().unwrap() {
+            Operation::SetAttr(x) => {
+                assert!(x.kill_suid_gid());
+                assert_eq!(x.size(), Some(0x1234));
+                // FATTR_KILL_SUIDGID must not be mistaken for one of the value-carrying bits
+                assert_eq!(x.mode(), None);
+                assert_eq!(x.uid(), None);
+                assert_eq!(x.gid(), None);
+            }
+            _ => panic!("Unexpected request operation"),
+        }
+    }
+
+    /// Without the capability the kernel leaves these fields zero, and every request must then
+    /// report that the filesystem has nothing to clear
+    #[test]
+    #[cfg(all(target_endian = "little", not(target_os = "macos")))]
+    fn kill_suid_gid_defaults_to_false() {
+        let mut open = OPEN_KILL_SUIDGID_REQUEST;
+        open.0[44] = 0;
+        match AnyRequest::try_from(&open[..])
+            .unwrap()
+            .operation()
+            .unwrap()
+        {
+            Operation::Open(x) => assert!(!x.kill_suid_gid()),
+            _ => panic!("Unexpected request operation"),
+        }
+
+        let mut create = CREATE_KILL_SUIDGID_REQUEST;
+        create.0[52] = 0;
+        match AnyRequest::try_from(&create[..])
+            .unwrap()
+            .operation()
+            .unwrap()
+        {
+            Operation::Create(x) => assert!(!x.kill_suid_gid()),
+            _ => panic!("Unexpected request operation"),
+        }
+
+        let mut setattr = SETATTR_KILL_SUIDGID_REQUEST;
+        setattr.0[41] = 0;
+        match AnyRequest::try_from(&setattr[..])
+            .unwrap()
+            .operation()
+            .unwrap()
+        {
+            Operation::SetAttr(x) => {
+                assert!(!x.kill_suid_gid());
+                // Clearing the bit must leave the rest of the valid mask alone
+                assert_eq!(x.size(), Some(0x1234));
+            }
+            _ => panic!("Unexpected request operation"),
+        }
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -159,6 +159,7 @@ impl<'a> RequestWithSender<'a> {
                     x.chgtime(),
                     x.bkuptime(),
                     x.flags(),
+                    x.kill_suid_gid(),
                     self.reply(),
                 );
             }
@@ -242,6 +243,7 @@ impl<'a> RequestWithSender<'a> {
                     self.request_header(),
                     self.request.nodeid(),
                     x.flags(),
+                    x.kill_suid_gid(),
                     self.reply(),
                 );
             }
@@ -401,6 +403,7 @@ impl<'a> RequestWithSender<'a> {
                     x.mode(),
                     x.umask(),
                     x.flags(),
+                    x.kill_suid_gid(),
                     self.reply(),
                 );
             }


### PR DESCRIPTION
Reverses the refusal added in #719. With `FUSE_HANDLE_KILLPRIV_V2` negotiated the kernel sets `SB_NOSEC` and stops clearing suid and sgid itself, telling the filesystem per request when to clear them instead. fuser forwarded one of the three signals it sends, so #719 refused the capability rather than let those bits survive operations that must clear them. This adds the two missing signals and accepts it.

## The three signals

| signal | field | reaches the filesystem as |
| --- | --- | --- |
| `FATTR_KILL_SUIDGID` | `fuse_setattr_in.valid` bit 11 | `setattr(..., kill_suid_gid)` |
| `FUSE_OPEN_KILL_SUIDGID` | `fuse_open_in.open_flags`, `fuse_create_in.open_flags` | `open(..., kill_suid_gid)`, `create(..., kill_suid_gid)` |
| `FUSE_WRITE_KILL_SUIDGID` | `fuse_write_in.write_flags` | `write(..., write_flags)`, unchanged |

The two `open_flags` fields were declared as `unused` and `padding` in fuser's ABI structs, which is why nothing could read them.

The kernel sends `FATTR_KILL_SUIDGID` unconditionally on a non-directory chown (`dir.c:2022-2024`) and, without `CAP_FSETID`, on a truncate (`dir.c:2032-2033`); `FUSE_OPEN_KILL_SUIDGID` when a truncating open comes from a caller without `CAP_FSETID` (`file.c:38-41`, `dir.c:658-660`).

## Verification against a running kernel

Confirmed with a probe filesystem negotiating v2 on 6.18.5, exercised with and without `CAP_FSETID`, rather than only against hand-built buffers:

| operation | as root | as uid 65534 |
| --- | --- | --- |
| chown | `true` | - |
| truncate | `false` | `true` |
| `O_TRUNC` open | `false` | `true` |
| write | - | `true` |

chown is `true` even as root because the kernel does not gate that one on `CAP_FSETID`.

The open row needed a second pass. The first probe never saw `open` fire at all: without `FUSE_ATOMIC_O_TRUNC` the kernel strips `O_TRUNC` and sends a separate setattr instead, so the signal was reaching nothing. Negotiating that capability in the probe surfaced it.

**One path is not covered live.** `create` carrying the flag needs the kernel to take the atomic create-or-open path on a file that already exists, a negative-dentry race I could not force from a shell. Its parsing is unit-tested and the code path is identical to `open`'s, but I have not observed the kernel produce it.

## Breaking change

`Filesystem::setattr`, `open` and `create` each gain a `kill_suid_gid: bool`. Behavior is unchanged for a filesystem that does not request the capability: the kernel leaves those fields zero, so the argument is always false.

## Scope

The examples stay on plain `FUSE_HANDLE_KILLPRIV` and just accept the new argument. Moving `simple.rs` to v2 would mean rewriting its unconditional clearing to be flag-driven, with real xfstests risk around suid semantics, and would conflate an example rewrite with the library change. The consequence is that v2 has unit and probe coverage but no pjdfs/xfstests coverage — worth knowing when weighing this.

## Testing

- Four new unit tests: the three signals parsed from real request layouts, and a negative case proving `kill_suid_gid` is false when the field is zero and that clearing it leaves the rest of the `valid` mask intact. Plus a guard that `add_capabilities` now accepts the capability, so it cannot drift back into the refused set.
- 87 unit tests, all three clippy variants, `cargo fmt --check` and `cargo doc` under `RUSTFLAGS`/`RUSTDOCFLAGS=--deny warnings`.
- Cross-checked `x86_64-apple-darwin` (with `macos-no-mount`), `x86_64-unknown-freebsd` and musl. Bit 11 of the setattr mask and the `open_flags` field are unused on macFUSE, so `kill_suid_gid` is simply always false there.
- `examples/simple` exercised end-to-end: it still sets suid+sgid on `chmod 6755` and clears both on append, its v1 behavior.
- Not run locally: pjdfs, xfstests and `fuser-tests` need Docker, unavailable in this environment — they run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjYWzn3mu8Sc2y2eACtJM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjYWzn3mu8Sc2y2eACtJM9)_