### PR TITLE
Fix a descriptor leak in the simple example's fallocate()

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -18,7 +18,7 @@ use std::io::Write;
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::FileExt;
 #[cfg(target_os = "linux")]
-use std::os::unix::io::IntoRawFd;
+use std::os::unix::io::AsRawFd;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicU64;
@@ -583,7 +583,13 @@ impl Filesystem for SimpleFS {
             reply.error(Errno::ENAMETOOLONG);
             return;
         }
-        let parent_attrs = self.get_inode(parent).unwrap();
+        let parent_attrs = match self.get_inode(parent) {
+            Ok(attrs) => attrs,
+            Err(error_code) => {
+                reply.error(error_code);
+                return;
+            }
+        };
         if !check_access(
             parent_attrs.uid,
             parent_attrs.gid,
@@ -1964,8 +1970,14 @@ impl Filesystem for SimpleFS {
         let path = self.content_path(ino);
         match OpenOptions::new().write(true).open(path) {
             Ok(file) => {
-                unsafe {
-                    libc::fallocate64(file.into_raw_fd(), mode, offset as i64, length as i64);
+                // Must not consume `file`, otherwise its descriptor is leaked. Tests that punch
+                // thousands of holes exhaust RLIMIT_NOFILE within a single run.
+                let result = unsafe {
+                    libc::fallocate64(file.as_raw_fd(), mode, offset as i64, length as i64)
+                };
+                if result < 0 {
+                    reply.error(io::Error::last_os_error().into());
+                    return;
                 }
                 if mode & libc::FALLOC_FL_KEEP_SIZE == 0 {
                     let mut attrs = self.get_inode(ino).unwrap();

--- a/xfstests.sh
+++ b/xfstests.sh
@@ -145,7 +145,6 @@ echo "generic/091" >> xfs_excludes.txt
 echo "generic/112" >> xfs_excludes.txt
 echo "generic/310" >> xfs_excludes.txt
 echo "generic/363" >> xfs_excludes.txt
-echo "generic/610" >> xfs_excludes.txt
 echo "generic/631" >> xfs_excludes.txt
 echo "generic/650" >> xfs_excludes.txt
 echo "generic/683" >> xfs_excludes.txt


### PR DESCRIPTION
Picks up `generic/610` from the "Not sure what's wrong with these" block in `xfstests.sh`, root-causes it, and un-excludes it.

## The bug

`examples/simple.rs` `fallocate()` did:

```rust
libc::fallocate64(file.into_raw_fd(), mode, offset as i64, length as i64);
```

`into_raw_fd()` consumes the `File`, so `Drop` never runs and the descriptor leaks — one per `fallocate` call. `generic/610` writes a 100MB file and then runs `punch-alternating`, which punches ~12800 holes. Isolated repro in the xfstests container:

```
open fds before:             5
open fds after pwrite:       5
open fds after punch:     4096   <- RLIMIT_NOFILE
punch-alternating exit=2
stat: Software caused connection abort
```

Once the process is out of descriptors, every `File::open` fails with `EMFILE`. `get_inode()` reports any open failure as `ENOENT`, and `lookup()` did `self.get_inode(parent).unwrap()`, so it panicked and took the whole session down. That reproduces the exact failure signature in `610.out.bad` (`foobar: No such file or directory` from `punch-alternating`'s `perror`, then `stat: Software caused connection abort`), and it also failed every test that ran afterwards in the same run — `generic/754`, for instance, passes on its own in 1s but failed in a batch that had run `610` earlier.

## The change

- Use `as_raw_fd()` so the `File` stays alive and closes normally.
- Return the `fallocate` errno instead of discarding it. Previously a failed syscall was reported to the caller as success.
- `lookup()` returns the error instead of unwrapping, so a transient failure cannot take the mount down.
- Drop `generic/610` from the excludes.

## Verification

|  | before | after |
| --- | --- | --- |
| `generic/610` | output mismatch | passes, ~12s (3/3 runs) |
| fd repro | 5 -> 4096 fds, exit 2 | 5 -> 5 fds, exit 0 |
| 58 quick fallocate/punch/zero tests | — | all 58 pass |

`cargo fmt --check`, `cargo clippy --all-targets` under `RUSTFLAGS=--deny warnings`, and `cargo test` (87 tests) are clean.

Checked the one plausible regression from surfacing fallocate errors: `generic/404`, `485`, `499`, `503` and `735` skip with `xfs_io finsert/fcollapse failed`. Running them against a pre-fix build shows they were already `not run` on master, so no coverage is lost.

## Noted but not addressed here

- `generic/749` hits a second, independent panic at the `self.get_inode(ino).unwrap()` in `write()`, which dies when the content file opens but the inode metadata is gone. Same class of bug, different call site.
- `generic/310`'s only output diff is `dmesg: clear kernel buffer failed: Operation not permitted` — a missing `CAP_SYSLOG` in the container rather than anything in fuser. It also takes ~4 minutes, since the test's 4096-file `touch` loop is O(n^2) against the example's whole-directory read/write, so it stays excluded either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSmtYYZ3resRdsCD1PwqUK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSmtYYZ3resRdsCD1PwqUK)_