### PR TITLE
Switch the simple example to killpriv v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # FUSE for Rust - Changelog
 
 ## Unreleased
+* The `simple` example now negotiates `FUSE_HANDLE_KILLPRIV_V2` instead of
+  `FUSE_HANDLE_KILLPRIV`, and clears suid and sgid only when the kernel asks rather than on
+  every write, chown and truncate. That fixes two cases where it diverged from a native
+  filesystem: a write or truncate by a caller holding `CAP_FSETID` no longer strips the bits.
+  The unconditional clearing could not be made conditional under `FUSE_HANDLE_KILLPRIV`,
+  because the kernel only sets `FUSE_WRITE_KILL_SUIDGID` on a buffered write once v2 has been
+  negotiated
 * Support `InitFlags::FUSE_HANDLE_KILLPRIV_V2`, which the previous release refused. With it
   negotiated the kernel stops clearing suid and sgid itself and instead tells the filesystem
   which requests must clear them, so `Filesystem::setattr()`, `open()` and `create()` gain a

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -185,6 +185,13 @@ fn clear_suid_sgid(attr: &mut InodeAttributes) {
     }
 }
 
+/// Both killpriv capabilities make the kernel stop removing file capabilities, so they have to
+/// go on every write, chown and truncate. Unlike suid and sgid, no request flag reports this:
+/// the operation is itself the signal
+fn clear_file_capabilities(attr: &mut InodeAttributes) {
+    attr.xattrs.remove(b"security.capability".as_slice());
+}
+
 fn creation_gid(parent: &InodeAttributes, gid: u32) -> u32 {
     if parent.mode & libc::S_ISGID as u16 != 0 {
         return parent.gid;
@@ -460,6 +467,7 @@ impl SimpleFS {
         new_length: u64,
         uid: u32,
         gid: u32,
+        kill_suid_gid: bool,
     ) -> Result<InodeAttributes, Errno> {
         if new_length > MAX_FILE_SIZE {
             return Err(Errno::EFBIG);
@@ -486,8 +494,12 @@ impl SimpleFS {
         attrs.last_metadata_changed = time_now();
         attrs.last_modified = time_now();
 
-        // Clear SETUID & SETGID on truncate
-        clear_suid_sgid(&mut attrs);
+        // Clear SETUID & SETGID on truncate, but only when the kernel asks: under killpriv v2
+        // it does so exactly when the caller lacks CAP_FSETID
+        if kill_suid_gid {
+            clear_suid_sgid(&mut attrs);
+        }
+        clear_file_capabilities(&mut attrs);
 
         self.write_inode(&attrs);
 
@@ -544,11 +556,13 @@ impl Filesystem for SimpleFS {
         _req: &Request,
         #[allow(unused_variables)] config: &mut KernelConfig,
     ) -> io::Result<()> {
+        // v2 reports per request whether suid and sgid must go, rather than asking for them to
+        // be cleared on every write, chown and truncate as FUSE_HANDLE_KILLPRIV does
         if config
-            .add_capabilities(InitFlags::FUSE_HANDLE_KILLPRIV)
+            .add_capabilities(InitFlags::FUSE_HANDLE_KILLPRIV_V2)
             .is_err()
         {
-            info!("FUSE_HANDLE_KILLPRIV not supported");
+            info!("FUSE_HANDLE_KILLPRIV_V2 not supported");
             self.suid_support = false;
         }
 
@@ -627,7 +641,7 @@ impl Filesystem for SimpleFS {
         _chgtime: Option<SystemTime>,
         _bkuptime: Option<SystemTime>,
         _flags: Option<BsdFileFlags>,
-        _kill_suid_gid: bool,
+        kill_suid_gid: bool,
         reply: ReplyAttr,
     ) {
         let mut attrs = match self.get_inode(ino) {
@@ -695,22 +709,18 @@ impl Filesystem for SimpleFS {
                 return;
             }
 
-            if attrs.mode & (libc::S_IXUSR | libc::S_IXGRP | libc::S_IXOTH) as u16 != 0 {
-                // SUID & SGID are suppose to be cleared when chown'ing an executable file
+            // Under killpriv v2 the kernel sends this for every chown of a non-directory, so
+            // the filesystem no longer has to work out when the bits should go
+            if kill_suid_gid {
                 clear_suid_sgid(&mut attrs);
             }
+            clear_file_capabilities(&mut attrs);
 
             if let Some(uid) = uid {
                 attrs.uid = uid;
-                // Clear SETUID on owner change
-                attrs.mode &= !libc::S_ISUID as u16;
             }
             if let Some(gid) = gid {
                 attrs.gid = gid;
-                // Clear SETGID unless user is root
-                if _req.uid() != 0 {
-                    attrs.mode &= !libc::S_ISGID as u16;
-                }
             }
             attrs.last_metadata_changed = time_now();
             self.write_inode(&attrs);
@@ -726,7 +736,7 @@ impl Filesystem for SimpleFS {
                 // with W_OK will never fail to truncate, even if the file has been subsequently
                 // chmod'ed
                 if Self::check_file_handle_write(handle.into()) {
-                    if let Err(error_code) = self.truncate(ino, size, 0, 0) {
+                    if let Err(error_code) = self.truncate(ino, size, 0, 0, kill_suid_gid) {
                         reply.error(error_code);
                         return;
                     }
@@ -734,7 +744,9 @@ impl Filesystem for SimpleFS {
                     reply.error(Errno::EACCES);
                     return;
                 }
-            } else if let Err(error_code) = self.truncate(ino, size, _req.uid(), _req.gid()) {
+            } else if let Err(error_code) =
+                self.truncate(ino, size, _req.uid(), _req.gid(), kill_suid_gid)
+            {
                 reply.error(error_code);
                 return;
             }
@@ -1555,7 +1567,7 @@ impl Filesystem for SimpleFS {
         fh: FileHandle,
         offset: u64,
         data: &[u8],
-        _write_flags: WriteFlags,
+        write_flags: WriteFlags,
         _flags: OpenFlags,
         _lock_owner: Option<LockOwner>,
         reply: ReplyWrite,
@@ -1586,12 +1598,12 @@ impl Filesystem for SimpleFS {
                 if end_offset > attrs.size as usize {
                     attrs.size = end_offset as u64;
                 }
-                // if flags & FUSE_WRITE_KILL_PRIV as i32 != 0 {
-                //     clear_suid_sgid(&mut attrs);
-                // }
-                // XXX: In theory we should only need to do this when WRITE_KILL_PRIV is set for 7.31+
-                // However, xfstests fail in that case
-                clear_suid_sgid(&mut attrs);
+                // Only killpriv v2 sets this on a buffered write, which is why honoring it
+                // requires negotiating v2 rather than FUSE_HANDLE_KILLPRIV
+                if write_flags.contains(WriteFlags::FUSE_WRITE_KILL_SUIDGID) {
+                    clear_suid_sgid(&mut attrs);
+                }
+                clear_file_capabilities(&mut attrs);
                 self.write_inode(&attrs);
 
                 reply.written(data.len() as u32);

--- a/src/ll/flags/init_flags.rs
+++ b/src/ll/flags/init_flags.rs
@@ -46,9 +46,14 @@ bitflags! {
         const FUSE_PARALLEL_DIROPS = 1 << 18;
         /// fs handles killing suid/sgid/cap on write/chown/trunc
         ///
-        /// The kernel stops removing those privileges itself, so the filesystem must clear
-        /// suid, sgid and the `security.capability` xattr on every write, chown and truncate.
-        /// No per-request signal accompanies this: the operation itself is the signal
+        /// The filesystem takes responsibility for clearing suid, sgid and the
+        /// `security.capability` xattr on every write, chown and truncate. No per-request
+        /// signal accompanies this: the operation itself is the signal.
+        ///
+        /// Unlike [`Self::FUSE_HANDLE_KILLPRIV_V2`] this does not set `SB_NOSEC`, so the kernel
+        /// still computes the removal and applies it through a `setattr`. What it buys is that
+        /// the kernel skips refreshing attributes first, trusting the filesystem to keep them
+        /// right
         const FUSE_HANDLE_KILLPRIV = 1 << 19;
         /// filesystem supports posix acls
         const FUSE_POSIX_ACL = 1 << 20;
@@ -68,9 +73,12 @@ bitflags! {
         const FUSE_SUBMOUNTS = 1 << 27;
         /// fs handles killing suid/sgid/cap on write/chown/trunc (v2)
         ///
-        /// As with [`Self::FUSE_HANDLE_KILLPRIV`], the kernel stops removing those privileges
-        /// itself, so clearing the `security.capability` xattr on every write, chown and
-        /// truncate remains the filesystem's job and carries no per-request signal.
+        /// As with [`Self::FUSE_HANDLE_KILLPRIV`], clearing the `security.capability` xattr on
+        /// every write, chown and truncate is the filesystem's job and carries no per-request
+        /// signal. This capability additionally sets `SB_NOSEC`, which stops the kernel doing
+        /// it, though only for an inode whose attributes are cached: fuse clears `S_NOSEC` on
+        /// every attribute refresh, since another client may have set the xattr meanwhile. A
+        /// filesystem therefore cannot rely on the kernel having done it.
         ///
         /// What v2 adds is finer control over suid and sgid alone, matching what the VFS would
         /// have done: they are cleared on a write or truncate only when the caller lacks


### PR DESCRIPTION
Gives `FUSE_HANDLE_KILLPRIV_V2` (#721) real coverage from pjdfs and xfstests, and resolves the `XXX` in the write path along the way.

## Why the XXX existed

The example cleared suid and sgid on every write, chown and truncate, with this note:

```rust
// XXX: In theory we should only need to do this when WRITE_KILL_PRIV is set for 7.31+
// However, xfstests fail in that case
clear_suid_sgid(&mut attrs);
```

The cause is the capability being negotiated, not the kernel version. `fuse_send_write` sets `FUSE_WRITE_KILL_SUIDGID` only once `handle_killpriv_v2` is set (`file.c:1134`), so under `FUSE_HANDLE_KILLPRIV` the flag never arrives on a buffered write and gating on it clears nothing — hence the failures. Unconditional clearing was the only thing that could work under v1.

(The direct-IO path at `file.c:1646` sets it on `!capable(CAP_FSETID)` regardless of capability, which is why this looked inconsistent rather than simply broken.)

Negotiating v2 makes the flag arrive on both paths, so the example can clear when the kernel asks.

## Verified against a native filesystem

Same eight scenarios run against tmpfs and against the example, before and after:

| scenario | tmpfs (oracle) | before (v1) | after (v2) |
| --- | --- | --- | --- |
| write as non-root, suid+gx | `755` | `755` | `755` |
| **write as root, suid+gx** | **`6755`** | **`755`** | **`6755`** |
| write as non-root, sgid without gx | `2745` | `2745` | `2745` |
| truncate as non-root, suid+gx | `755` | `755` | `755` |
| **truncate as root, suid+gx** | **`6755`** | **`755`** | **`6755`** |
| chown as root, suid+gx | `755` | `755` | `755` |
| chown as root, sgid without gx | `2745` | `2745` | `2745` |
| chmod only, suid+gx | `6755` | `6755` | `6755` |

The old code was over-clearing: a caller holding `CAP_FSETID` had the bits stripped on write and truncate, where the VFS leaves them alone (`setattr_should_drop_suidgid` returns 0 for such callers). After the switch the example matches tmpfs on all eight.

The chown path also drops its own rules about which bits to clear for uid versus gid changes. v2 has the kernel send the signal for every chown of a non-directory, and applying it is what the VFS does.

## Known limitation, pre-existing and not fixed here

`fallocate()` and `copy_file_range()` mutate file contents without clearing suid, sgid or `security.capability`, so a setuid file modified through either keeps its bits where a native filesystem would drop them. Raised by Codex on this PR; measured to behave identically on master, so it is not caused by enabling v2:

| scenario | tmpfs | master (v1) | this PR (v2) |
| --- | --- | --- | --- |
| `fallocate` as non-root | `755` | `6755` | `6755` |
| `copy_file_range` as non-root | `755` | `6755` | `6755` |

Both syscalls genuinely take effect in the measurement (`fallocate` grows the file 4096 → 8192, `copy_file_range` reports 256 bytes copied), so this is a real divergence rather than a skipped syscall.

Not fixed here because the protocol carries no per-request kill signal on `FUSE_FALLOCATE` or `FUSE_COPY_FILE_RANGE` — those flags exist only on write, setattr, open and create. The filesystem cannot tell whether the caller held `CAP_FSETID`, so clearing unconditionally would reintroduce exactly the over-clearing this PR removes. Fixing it means first establishing what the kernel does send on those paths, since `fuse_file_fallocate` and `__fuse_copy_file_range` both call `file_modified()`.

## Two things worth stating plainly

**The `security.capability` clearing this adds is not load-bearing here.** Both killpriv capabilities make it the filesystem's job, so the example now does it, and it matches tmpfs across write, truncate, chown and chmod. But removing the calls entirely changes nothing observable: `fuse_change_attributes_common` clears `S_NOSEC` on every attribute refresh (`inode.c:315`, with a comment explaining the conservatism), and the example uses zero attribute TTLs, so `IS_NOSEC` is never true and the VFS keeps doing the work. It is kept because a filesystem that caches attributes cannot rely on that — not because it fixes anything visible.

**That experiment showed a doc claim from #721 was wrong, and this corrects it.** I wrote there that under `FUSE_HANDLE_KILLPRIV` "the kernel stops removing those privileges itself". It does not: v1 never sets `SB_NOSEC` (only v2 does, `inode.c:1409-1410`), so the VFS privilege-removal path stays fully active and what v1 actually buys is that the kernel skips refreshing attributes first (`dir.c:2136`). Both flag docs now say this, and the v2 one notes that `SB_NOSEC` is set on the superblock only and is undone per inode by any attribute refresh.

## Testing

- Behavior compared against tmpfs as above, for both suid/sgid and file capabilities, using `setpriv` to drop `CAP_FSETID`.
- 87 unit tests, all three clippy variants, `cargo fmt --check` and `cargo doc` under `RUSTFLAGS`/`RUSTDOCFLAGS=--deny warnings`.
- General filesystem operations through the example: mkdir, create, read, symlink, readlink, rename, unlink, rmdir.
- **Not run locally: pjdfs and xfstests need Docker, unavailable in this environment.** Given that this replaces a change the `XXX` says xfstests rejected, those two jobs are the real test of this PR rather than a formality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjYWzn3mu8Sc2y2eACtJM9