### PR TITLE
Do not panic in the simple example's write()

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1575,12 +1575,6 @@ impl Filesystem for SimpleFS {
         let path = self.content_path(ino);
         match OpenOptions::new().write(true).open(path) {
             Ok(mut file) => {
-                file.seek(SeekFrom::Start(offset)).unwrap();
-                file.write_all(data).unwrap();
-
-                let mut attrs = self.get_inode(ino).unwrap();
-                attrs.last_metadata_changed = time_now();
-                attrs.last_modified = time_now();
                 let Ok(offset_usize): Result<usize, _> = offset.try_into() else {
                     reply.error(Errno::EFBIG);
                     return;
@@ -1589,6 +1583,27 @@ impl Filesystem for SimpleFS {
                     reply.error(Errno::EFBIG);
                     return;
                 };
+
+                file.seek(SeekFrom::Start(offset)).unwrap();
+                file.write_all(data).unwrap();
+                // Release the descriptor before opening the inode. Near RLIMIT_NOFILE this write
+                // may hold the last one, and get_inode() reports the resulting EMFILE as ENOENT,
+                // which would fail a write whose data already landed.
+                drop(file);
+
+                // Read the inode only once the data is written. Holding a copy across the write
+                // would let this write back a record that a setattr() completing in the meantime
+                // had already updated. Contents and metadata are separate files, so the inode can
+                // be unreadable even though the write itself succeeded.
+                let mut attrs = match self.get_inode(ino) {
+                    Ok(attrs) => attrs,
+                    Err(error_code) => {
+                        reply.error(error_code);
+                        return;
+                    }
+                };
+                attrs.last_metadata_changed = time_now();
+                attrs.last_modified = time_now();
                 if end_offset > attrs.size as usize {
                     attrs.size = end_offset as u64;
                 }

--- a/xfstests.sh
+++ b/xfstests.sh
@@ -152,7 +152,6 @@ echo "generic/684" >> xfs_excludes.txt
 echo "generic/685" >> xfs_excludes.txt
 echo "generic/732" >> xfs_excludes.txt
 echo "generic/748" >> xfs_excludes.txt
-echo "generic/749" >> xfs_excludes.txt
 echo "generic/750" >> xfs_excludes.txt
 echo "generic/754" >> xfs_excludes.txt
 echo "generic/756" >> xfs_excludes.txt


### PR DESCRIPTION
Follow-up to #722, which fixed the same class of bug in `lookup()`.

## The bug

`write()` read the inode metadata with an unwrap:

```rust
let mut attrs = self.get_inode(ino).unwrap();
```

Contents and metadata live in separate files, so the inode can be unreadable while the contents are still there. Two ways that happens:

- `gc_inode()` removes `inodes/<ino>` before `contents/<ino>`, so a crash or a race between the two leaves exactly that state.
- `get_inode()` reports every open failure as `ENOENT`, including `EMFILE`. Under descriptor pressure the content open can succeed while the inode open fails.

When it does happen the unwrap panics the session thread, which takes the whole mount down rather than failing the one request. That is what turned the descriptor leak in #722 into a cascade: after the `lookup()` panic, the half-finished `gc_inode()` left a content file with no inode file, and the next write against that inode killed the session again.

Deterministic repro against master — hold a writable handle open, drop the inode metadata behind fuser's back, then write:

```
inode=2
content file still present

thread 'fuser-0' panicked at examples/simple.rs:1581:53:
called `Result::unwrap()` on an `Err` value: Errno(2)
   3: <simple::SimpleFS as fuser::Filesystem>::write
   4: fuser::request::RequestWithSender::dispatch
   5: fuser::session::SessionEventLoop<FS>::event_loop
RESULT: write failed: printf: write error: Input/output error
RESULT: fuser DIED
```

## The change

Return the error instead of unwrapping. Around that:

- The inode is still read **after** the data is written, as on master. Reading it up front and holding the record across `write_all()` would let this write back a record that a `setattr()` completing in the meantime had already updated — a lost `chmod`/`chown` on a `--n-threads > 1` mount.
- The content file is dropped before the inode is opened, so `write()` peaks at one descriptor instead of two and opening the inode cannot be the open that runs into `RLIMIT_NOFILE`.
- The `EFBIG` size checks move ahead of the write. They need no metadata, and there is no point writing data that is about to be rejected.

Both of the first two came out of Codex review on this PR; see the threads below.

Same repro after the fix:

```
RESULT: write failed: printf: write error: No such file or directory
RESULT: fuser still alive
```

Also drops `generic/749` from the excludes — see below.

## Verification

| | before | after |
| --- | --- | --- |
| repro above | panic, session dies | `ENOENT` to the caller, mount survives |
| `generic/749` standalone | — | 5/5 runs pass, 1-2s each |
| xfstests `-g quick` (repo exclude list) | — | passed all 579 |
| xfstests `-g quick`, `749` un-excluded | — | passed all 580 |
| pjdfstest (libfuse3) | — | `Result: PASS`, 205 files / 2732 tests, 0 failed |

`cargo fmt --check`, `cargo clippy --all-targets` under `RUSTFLAGS=--deny warnings`, and `cargo test` (87 tests) are clean.

One caveat stated plainly: the `EMFILE` interleaving is addressed by inspection and by the reduction in peak descriptors, not by a live repro. With the leak from #722 fixed, `write()` holds no descriptors across requests, so there is no way to drive the process to its limit from outside.

## On generic/749

#722's description claimed `generic/749` hit this panic. That was wrong. `generic/749` passes on its own in ~2s, and re-running the whole neighbourhood (`631`, `683`, `684`, `685`, `732`, `748`, `749`) on current master produces no panic at all — the `write()` panic in that batch was fallout from the `generic/610` crash earlier in the same run. Which is why the repro above constructs the state directly rather than going through a test.

Since it is quick and it only ever failed as collateral from that crash, it comes off the exclude list here. Verified with 5 standalone runs plus a full `-g quick` run with it in its natural position, which also confirms it leaves nothing behind that breaks later tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSmtYYZ3resRdsCD1PwqUK