### PR TITLE
Clear privileges in the simple example's fallocate and copy_file_range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # FUSE for Rust - Changelog
 
 ## Unreleased
+* The `simple` example now clears suid, sgid and `security.capability` in `fallocate()` and
+  `copy_file_range()`, which previously left them intact. Negotiating either killpriv capability
+  stops the kernel removing privileges on those operations, and neither carries a signal saying
+  when to, so the example clears unconditionally: that strips the bits from a caller holding
+  `CAP_FSETID` where a local filesystem would keep them, but the alternative leaves a setuid
+  binary setuid after an unprivileged caller has rewritten it
 * The `simple` example now negotiates `FUSE_HANDLE_KILLPRIV_V2` instead of
   `FUSE_HANDLE_KILLPRIV`, and clears suid and sgid only when the kernel asks rather than on
   every write, chown and truncate. That fixes two cases where it diverged from a native

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -192,6 +192,24 @@ fn clear_file_capabilities(attr: &mut InodeAttributes) {
     attr.xattrs.remove(b"security.capability".as_slice());
 }
 
+/// Drop privileges for an operation the kernel hands over without telling us when to.
+///
+/// Negotiating either killpriv capability stops the kernel removing privileges itself, but
+/// `FUSE_FALLOCATE` and `FUSE_COPY_FILE_RANGE` carry nothing like the `kill_suid_gid` argument
+/// that write, setattr, open and create get, so the filesystem cannot learn whether the caller
+/// held `CAP_FSETID`. Clearing regardless strips bits from a privileged caller that a native
+/// filesystem would keep, which is the better of the two errors available: the alternative
+/// leaves a setuid binary setuid after an unprivileged caller has rewritten it.
+///
+/// This is deliberately not the conditional form used on write and truncate, where the kernel
+/// does say. Call it only when a killpriv capability was negotiated: without one the kernel
+/// still removes privileges itself, and clearing here as well would strip bits from a
+/// privileged caller for no reason
+fn clear_privileges_unconditionally(attr: &mut InodeAttributes) {
+    clear_suid_sgid(attr);
+    clear_file_capabilities(attr);
+}
+
 fn creation_gid(parent: &InodeAttributes, gid: u32) -> u32 {
     if parent.mode & libc::S_ISGID as u16 != 0 {
         return parent.gid;
@@ -330,6 +348,10 @@ struct SimpleFS {
     next_file_handle: AtomicU64,
     direct_io: bool,
     suid_support: bool,
+    /// Whether a killpriv capability was negotiated, and so whether removing privileges is
+    /// this filesystem's job rather than the kernel's. Distinct from `suid_support`, which
+    /// only says whether the caller asked for setuid support
+    killpriv_negotiated: bool,
 }
 
 impl SimpleFS {
@@ -339,6 +361,7 @@ impl SimpleFS {
             next_file_handle: AtomicU64::new(1),
             direct_io,
             suid_support,
+            killpriv_negotiated: false,
         }
     }
 
@@ -564,6 +587,8 @@ impl Filesystem for SimpleFS {
         {
             info!("FUSE_HANDLE_KILLPRIV_V2 not supported");
             self.suid_support = false;
+        } else {
+            self.killpriv_negotiated = true;
         }
 
         fs::create_dir_all(Path::new(&self.data_dir).join("inodes")).unwrap();
@@ -1991,15 +2016,18 @@ impl Filesystem for SimpleFS {
                     reply.error(io::Error::last_os_error().into());
                     return;
                 }
-                if mode & libc::FALLOC_FL_KEEP_SIZE == 0 {
-                    let mut attrs = self.get_inode(ino).unwrap();
-                    attrs.last_metadata_changed = time_now();
-                    attrs.last_modified = time_now();
-                    if offset + length > attrs.size {
-                        attrs.size = (offset + length) as u64;
-                    }
-                    self.write_inode(&attrs);
+                let mut attrs = self.get_inode(ino).unwrap();
+                // Every fallocate mode changes the file, so the times move even when the size
+                // is pinned: a punch-hole rewrites content, and preallocation commits blocks
+                attrs.last_metadata_changed = time_now();
+                attrs.last_modified = time_now();
+                if mode & libc::FALLOC_FL_KEEP_SIZE == 0 && offset + length > attrs.size {
+                    attrs.size = (offset + length) as u64;
                 }
+                if self.killpriv_negotiated {
+                    clear_privileges_unconditionally(&mut attrs);
+                }
+                self.write_inode(&attrs);
                 reply.ok();
             }
             _ => {
@@ -2062,6 +2090,9 @@ impl Filesystem for SimpleFS {
                         };
                         if end_offset > attrs.size as usize {
                             attrs.size = end_offset as u64;
+                        }
+                        if self.killpriv_negotiated {
+                            clear_privileges_unconditionally(&mut attrs);
                         }
                         self.write_inode(&attrs);
 

--- a/src/ll/flags/init_flags.rs
+++ b/src/ll/flags/init_flags.rs
@@ -53,7 +53,13 @@ bitflags! {
         /// Unlike [`Self::FUSE_HANDLE_KILLPRIV_V2`] this does not set `SB_NOSEC`, so the kernel
         /// still computes the removal and applies it through a `setattr`. What it buys is that
         /// the kernel skips refreshing attributes first, trusting the filesystem to keep them
-        /// right
+        /// right.
+        ///
+        /// Note that this reaches further than the write, chown and truncate the contract names.
+        /// Negotiating either killpriv capability also stops the kernel removing privileges on
+        /// `fallocate` and `copy_file_range`, and neither carries a signal saying so, so a
+        /// filesystem that wants those to behave like a local one has to clear the bits there
+        /// itself
         const FUSE_HANDLE_KILLPRIV = 1 << 19;
         /// filesystem supports posix acls
         const FUSE_POSIX_ACL = 1 << 20;
@@ -87,7 +93,9 @@ bitflags! {
         /// [`Filesystem::setattr`](crate::Filesystem::setattr),
         /// [`open`](crate::Filesystem::open) and [`create`](crate::Filesystem::create), and
         /// through [`WriteFlags::FUSE_WRITE_KILL_SUIDGID`](crate::WriteFlags) on a write.
-        /// Honoring those covers suid and sgid only, not file capabilities
+        /// Honoring those covers suid and sgid only, not file capabilities, and only the
+        /// operations that carry a signal: see [`Self::FUSE_HANDLE_KILLPRIV`] for the ones that
+        /// do not
         const FUSE_HANDLE_KILLPRIV_V2 = 1 << 28;
         /// extended setxattr support
         const FUSE_SETXATTR_EXT = 1 << 29;


### PR DESCRIPTION
Follow-up to the limitation recorded on #723, after investigating where the gap actually lives.

## What the investigation found

The killpriv contract in `fuse.h` names **write, chown and truncate**. What the kernel actually suppresses is wider: negotiating either capability also stops it removing privileges on `fallocate` and `copy_file_range`, and neither carries anything like the `kill_suid_gid` argument the other operations get. So the kernel stops doing work its contract never handed over, and the filesystem is never told.

Measured, rather than inferred. Both paths call `file_modified()` (`fuse_file_fallocate`, `__fuse_copy_file_range`), which does reach the filesystem as a `SETATTR` — but dumping the raw wire field shows what it carries:

```
PROBE raw setattr valid=0x0
```

No `FATTR_MODE`, no `FATTR_KILL_SUIDGID`, nothing. fuser is not dropping a signal; there is no signal.

Disabling capability negotiation entirely confirms where the responsibility moves:

| | fallocate as non-root |
| --- | --- |
| no killpriv negotiated | `755` — kernel clears it |
| killpriv v1 | `6755` |
| killpriv v2 | `6755` |

Without a killpriv capability, `fuse_do_setattr` refreshes attributes and computes the mode change itself (`dir.c:2126-2145`); that block is skipped once either capability is set. So this is not caused by #723 — v1 behaves identically — and it is not something fuser can surface.

## The fix

The example clears suid, sgid and `security.capability` in both handlers, **but only once a killpriv capability has actually been negotiated**. That last part was missed in the first version of this PR and raised by Codex: on a kernel too old for v2 the job stays the kernel's, and clearing here as well would strip bits from a privileged caller for no reason.

It is tracked in a new `killpriv_negotiated` field rather than the existing `suid_support`, which would have been wrong in the other direction — `init()` negotiates the capability regardless of `--suid`, so `suid_support` is false in cases where the filesystem does own the job.

Where it does clear, it cannot do so conditionally: with no signal, it has no way to learn whether the caller held `CAP_FSETID`. Clearing regardless strips the bits from a privileged caller where a local filesystem would keep them. That is the better of the two errors available — the alternative leaves a setuid binary setuid after an unprivileged caller has rewritten it. The helper's doc comment says this, because the unconditional form otherwise reads exactly like the over-clearing that #723 removed from write and truncate.

## Timestamps on the KEEP_SIZE path

Also raised by Codex, and traced to a wider defect. `fallocate` updated no timestamps at all when `FALLOC_FL_KEEP_SIZE` was set, so a punch-hole left both ctime and mtime stale — and once this commit started dropping privileges on that path, the mode changed with ctime standing still.

`fallocate` now updates both timestamps for every mode, leaving only the size update conditional. tmpfs does the same for a punch-hole and for a plain `KEEP_SIZE` preallocation; I checked the preallocation case explicitly rather than assuming, since that is where "nothing really changed" is most arguable, and committing blocks counts.

## Compared against tmpfs

| scenario | tmpfs | before | after |
| --- | --- | --- | --- |
| `fallocate` as non-root | `755` | `6755` | `755` |
| punch-hole as non-root, `KEEP_SIZE` | `755` | `6755` | `755` |
| `copy_file_range` as non-root | `755` | `6755` | `755` |
| punch-hole, ctime/mtime advance | yes | no | yes |
| `fallocate` as root, v2 negotiated | `6755` | `6755` | `755` (the accepted divergence) |
| `fallocate` as root, negotiation fails | `6755` | `6755` | `6755` |

Also documents on both killpriv flags that they reach past the operations their contract names, since a filesystem author negotiating either has no way to discover it otherwise.

## Out of scope, found along the way

`fallocate` by an unprivileged caller fails with `EPERM` on a file that has a `security.capability` xattr. Verified identical on master, so it predates this change and is not addressed here — most likely the example's own xattr permission check rejecting the kernel's attempt to remove the capability.

## Testing

- Behavior compared against tmpfs as above, using `setpriv` to drop `CAP_FSETID`, and with capability negotiation forced to fail to exercise the ungated path. Every operation checked to have actually succeeded before its result was read.
- 87 unit tests, all three clippy variants, `cargo fmt --check` and `cargo doc` under `RUSTFLAGS`/`RUSTDOCFLAGS=--deny warnings`.
- pjdfs and xfstests need Docker, unavailable here — they run in CI, and they are the ones that exercise these handlers under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjYWzn3mu8Sc2y2eACtJM9