### PR TITLE
Convert std::fs::Metadata into FileAttr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # FUSE for Rust - Changelog
 
 ## Unreleased
+* Add `TryFrom<&std::fs::Metadata>` for `FileAttr` (#413), so a filesystem backed by files on
+  disk can answer `getattr` and `lookup` from the underlying file's metadata. The conversion is
+  fallible because `nlink`, `rdev` and `blksize` narrow to the widths the FUSE protocol gives
+  them, and because a file whose type `FileType` cannot represent has no valid conversion. Note
+  that `ino` is the underlying file's inode number, which a filesystem assigning its own will
+  want to overwrite
 * The `simple` example now clears suid, sgid and `security.capability` in `fallocate()` and
   `copy_file_range()`, which previously left them intact. Negotiating either killpriv capability
   stops the kernel removing privileges on those operations, and neither carries a signal saying

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,6 +258,67 @@ pub struct FileAttr {
     pub flags: u32,
 }
 
+impl TryFrom<&std::fs::Metadata> for FileAttr {
+    type Error = io::Error;
+
+    /// Convert the metadata of a local file, as returned by [`std::fs::metadata`] and friends.
+    ///
+    /// This suits a filesystem backed by files on disk, which can answer `getattr` and `lookup
+    /// ` largely by passing the underlying file's metadata through. Note that `ino` is the
+    /// inode number of that underlying file, which a filesystem assigning its own inode
+    /// numbers will want to overwrite.
+    ///
+    /// `flags` carries the BSD file flags on macOS, where the FUSE protocol has a field for
+    /// them, and is zero everywhere else. `crtime` falls back to the epoch on a platform or
+    /// filesystem that does not record a creation time.
+    ///
+    /// # Errors
+    /// Returns [`io::ErrorKind::InvalidData`] if the file is of a kind [`FileType`] cannot
+    /// represent, or if a field does not fit the width the FUSE protocol gives it. The latter
+    /// needs a filesystem well outside what Linux itself can represent, since the kernel reads
+    /// these back into the same widths.
+    fn try_from(metadata: &std::fs::Metadata) -> Result<Self, Self::Error> {
+        use std::os::unix::fs::MetadataExt;
+
+        fn narrow(value: u64, field: &str) -> io::Result<u32> {
+            u32::try_from(value).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("{field} is {value}, which does not fit the FUSE protocol's u32"),
+                )
+            })
+        }
+
+        let kind = FileType::from_std(metadata.file_type()).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unsupported file type {:?}", metadata.file_type()),
+            )
+        })?;
+
+        Ok(FileAttr {
+            ino: INodeNo(metadata.ino()),
+            size: metadata.size(),
+            blocks: metadata.blocks(),
+            atime: time::system_time_from_time(metadata.atime(), metadata.atime_nsec() as u32),
+            mtime: time::system_time_from_time(metadata.mtime(), metadata.mtime_nsec() as u32),
+            ctime: time::system_time_from_time(metadata.ctime(), metadata.ctime_nsec() as u32),
+            crtime: metadata.created().unwrap_or(SystemTime::UNIX_EPOCH),
+            kind,
+            perm: (metadata.mode() & 0o7777) as u16,
+            nlink: narrow(metadata.nlink(), "nlink")?,
+            uid: metadata.uid(),
+            gid: metadata.gid(),
+            rdev: narrow(metadata.rdev(), "rdev")?,
+            blksize: narrow(metadata.blksize(), "blksize")?,
+            #[cfg(target_os = "macos")]
+            flags: std::os::macos::fs::MetadataExt::st_flags(metadata),
+            #[cfg(not(target_os = "macos"))]
+            flags: 0,
+        })
+    }
+}
+
 /// Configuration of the fuse kernel module connection
 #[derive(Debug)]
 pub struct KernelConfig {
@@ -1175,6 +1236,69 @@ pub fn spawn_mount<'a, FS: Filesystem + Send + 'static + 'a, P: AsRef<Path>>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn file_attr_from_metadata() {
+        use std::os::unix::fs::MetadataExt;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("f");
+        std::fs::write(&file, b"0123456789").unwrap();
+        // Ask for every mode bit the protocol carries, so that a conversion masking the wrong
+        // width shows up here. FreeBSD refuses setgid on a file whose group the caller is not
+        // in, where Linux drops the bit silently, so take whatever the platform stored rather
+        // than assuming the request succeeded
+        let set = std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o6754)).is_ok();
+
+        let metadata = std::fs::metadata(&file).unwrap();
+        let attr = FileAttr::try_from(&metadata).unwrap();
+
+        assert_eq!(attr.kind, FileType::RegularFile);
+        assert_eq!(attr.size, 10);
+        // The file type bits belong to `kind`, and must not leak into `perm`
+        assert_eq!(u32::from(attr.perm), metadata.mode() & 0o7777);
+        // ...which only tests anything if the raw mode has bits outside that mask to drop
+        assert_ne!(metadata.mode() & !0o7777, 0);
+        if set {
+            // Where the platform took the whole request, every bit above the permissions has
+            // to survive too, which is what a conversion masking the wrong width would lose
+            assert_eq!(attr.perm, 0o6754);
+        }
+        assert_eq!(attr.ino, INodeNo(metadata.ino()));
+        assert_eq!(attr.uid, metadata.uid());
+        assert_eq!(attr.gid, metadata.gid());
+        assert_eq!(attr.nlink, 1);
+        assert_eq!(attr.blocks, metadata.blocks());
+        assert_eq!(
+            attr.mtime,
+            time::system_time_from_time(metadata.mtime(), metadata.mtime_nsec() as u32,)
+        );
+        // std exposes no accessor for the BSD flags, so they are always absent
+        assert_eq!(attr.flags, 0);
+
+        let attr = FileAttr::try_from(&std::fs::metadata(dir.path()).unwrap()).unwrap();
+        assert_eq!(attr.kind, FileType::Directory);
+
+        // A symlink only reports as one when the metadata was taken without following it
+        let link = dir.path().join("l");
+        std::os::unix::fs::symlink(&file, &link).unwrap();
+        let attr = FileAttr::try_from(&std::fs::symlink_metadata(&link).unwrap()).unwrap();
+        assert_eq!(attr.kind, FileType::Symlink);
+        let attr = FileAttr::try_from(&std::fs::metadata(&link).unwrap()).unwrap();
+        assert_eq!(attr.kind, FileType::RegularFile);
+    }
+
+    #[test]
+    fn file_attr_from_metadata_of_a_fifo() {
+        let dir = tempfile::tempdir().unwrap();
+        let fifo = dir.path().join("p");
+        nix::unistd::mkfifo(&fifo, nix::sys::stat::Mode::S_IRUSR).unwrap();
+
+        let attr = FileAttr::try_from(&std::fs::symlink_metadata(&fifo).unwrap()).unwrap();
+        assert_eq!(attr.kind, FileType::NamedPipe);
+        assert_eq!(attr.perm, 0o400);
+    }
 
     #[test]
     fn kernel_config_set_max_write_bounds() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,7 +270,9 @@ impl TryFrom<&std::fs::Metadata> for FileAttr {
     ///
     /// `flags` carries the BSD file flags on macOS, where the FUSE protocol has a field for
     /// them, and is zero everywhere else. `crtime` falls back to the epoch on a platform or
-    /// filesystem that does not record a creation time.
+    /// filesystem that does not record a creation time. `rdev` is taken from the metadata
+    /// only for a character or block device, being unspecified for every other kind of file,
+    /// and is zero otherwise.
     ///
     /// # Errors
     /// Returns [`io::ErrorKind::InvalidData`] if the file is of a kind [`FileType`] cannot
@@ -309,7 +311,14 @@ impl TryFrom<&std::fs::Metadata> for FileAttr {
             nlink: narrow(metadata.nlink(), "nlink")?,
             uid: metadata.uid(),
             gid: metadata.gid(),
-            rdev: narrow(metadata.rdev(), "rdev")?,
+            // `st_rdev` is only defined for device files, and reading it elsewhere gets
+            // whatever the filesystem left there: FreeBSD's UFS stores a fast symlink's
+            // target in the same inode field, so a symlink reports the first eight bytes
+            // of its target as an rdev
+            rdev: match kind {
+                FileType::CharDevice | FileType::BlockDevice => narrow(metadata.rdev(), "rdev")?,
+                _ => 0,
+            },
             blksize: narrow(metadata.blksize(), "blksize")?,
             #[cfg(target_os = "macos")]
             flags: std::os::macos::fs::MetadataExt::st_flags(metadata),
@@ -1277,6 +1286,9 @@ mod tests {
         // std exposes no accessor for the BSD flags, so they are always absent
         assert_eq!(attr.flags, 0);
 
+        // Nothing but a device file has an rdev, whatever the platform left in the field
+        assert_eq!(attr.rdev, 0);
+
         let attr = FileAttr::try_from(&std::fs::metadata(dir.path()).unwrap()).unwrap();
         assert_eq!(attr.kind, FileType::Directory);
 
@@ -1285,8 +1297,25 @@ mod tests {
         std::os::unix::fs::symlink(&file, &link).unwrap();
         let attr = FileAttr::try_from(&std::fs::symlink_metadata(&link).unwrap()).unwrap();
         assert_eq!(attr.kind, FileType::Symlink);
+        // FreeBSD's UFS keeps a fast symlink's target in the inode field that a device file
+        // uses for its rdev, so reading it here would report the target's first eight bytes
+        assert_eq!(attr.rdev, 0);
         let attr = FileAttr::try_from(&std::fs::metadata(&link).unwrap()).unwrap();
         assert_eq!(attr.kind, FileType::RegularFile);
+    }
+
+    #[test]
+    fn file_attr_from_metadata_of_a_device() {
+        use std::os::unix::fs::MetadataExt;
+
+        // Every platform this builds on has /dev/null, and it is a character device on all of
+        // them, but its device number is assigned by the system and is not worth predicting
+        let metadata = std::fs::metadata("/dev/null").unwrap();
+        let attr = FileAttr::try_from(&metadata).unwrap();
+
+        assert_eq!(attr.kind, FileType::CharDevice);
+        assert_eq!(u64::from(attr.rdev), metadata.rdev());
+        assert_ne!(attr.rdev, 0);
     }
 
     #[test]


### PR DESCRIPTION
Closes #413.

A filesystem backed by files on disk answers `getattr` and `lookup` largely by passing the underlying file's metadata through, and every one of them writes the same mapping by hand. This provides it as `TryFrom<&std::fs::Metadata> for FileAttr`.

## Why TryFrom rather than From

The issue says `From`/`Into` cannot be used "since we don't own the trait". That premise is wrong, and worth correcting since it shaped the issue's conclusion: the orphan rule permits a foreign trait on a **local** `Self` type, so `impl From<&Metadata> for FileAttr` is allowed. I confirmed it compiles in a scratch crate before deciding. What is not allowed is the blanket `impl From for FileAttr` the issue sketches, which is a different problem.

`TryFrom` is used because the conversion genuinely can fail, not because `From` is unavailable:

- `nlink`, `blksize`, and `rdev` on a device file, narrow from the `u64` that `MetadataExt` returns to the `u32` the FUSE protocol carries.
- A file of a type `FileType` cannot represent has no valid answer.

The narrowing needs a filesystem well outside what Linux can itself represent, since the kernel reads these fields back into the same widths. Saturating them would corrupt an inode rather than report a problem, so they return `io::ErrorKind::InvalidData` instead.

## Three fields worth knowing about

- `ino` is the **underlying file's** inode number. A filesystem assigning its own inode numbers will want to overwrite it, so the doc comment says so rather than leaving it to be discovered.
- `rdev` is read from the metadata only for a character or block device, and is zero for everything else. `st_rdev` is unspecified for any other kind of file, and reading it gets whatever the filesystem left in the field — see below.
- `flags` carries the BSD file flags on macOS, via `std::os::darwin::fs::MetadataExt::st_flags`, and is zero elsewhere. That matches where the reply forwards it: `reply.rs` maps `flags` only under `#[cfg(target_os = "macos")]`.

`crtime` comes from `Metadata::created()` where the platform and filesystem record one, falling back to the epoch rather than failing.

## What FreeBSD taught us about rdev

The first version narrowed `rdev` unconditionally, and `freebsd-ci` rejected an ordinary **symlink** with:

```
rdev is 7886979628717143087, which does not fit the FUSE protocol's u32
```

`7886979628717143087` is `0x6D742E2F706D742F`, which little-endian is the ASCII `/tmp/.tm` — the first eight bytes of that symlink's target path. UFS defines `di_rdev` as `di_db[0]`, the first direct block pointer, and a fast symlink stores its target inline in that array; `ufs_getattr()` copies the field into `va_rdev` with no check on the file type.

So POSIX leaving `st_rdev` undefined outside block and character devices is not a formality, and a conversion that reads it anywhere else is reporting filesystem-internal state as a device number. Hence the field is now taken only where it is defined.

## Testing

Three tests, using real files on disk rather than a constructed `Metadata`:

- Regular file, directory and symlink map to the right `FileType`, with the symlink checked both ways round — `symlink_metadata` gives `Symlink`, plain `metadata` follows the link and gives `RegularFile`.
- Every mode bit the protocol carries survives: the file is `chmod 6754`, and `perm` must match what the platform actually stored, so a conversion masking the wrong width fails here rather than silently dropping setuid. The chmod is checked rather than assumed, since FreeBSD refuses setgid on a file whose group the caller is not in where Linux drops the bit silently.
- Regular file and symlink must both report `rdev` as zero, which is the FreeBSD regression above.
- `/dev/null` must carry its `rdev` through unchanged and non-zero, so the device path cannot regress to zeroing everything.
- A FIFO created with `mkfifo`, covering a type that only `symlink_metadata` reports.

90 unit tests, all three clippy variants, `cargo fmt --check` and `cargo doc` under `RUSTFLAGS`/`RUSTDOCFLAGS=--deny warnings`. Cross-checked `x86_64-apple-darwin` and `x86_64-unknown-freebsd`, since the conversion uses `std::os::unix::fs::MetadataExt` rather than anything Linux-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjYWzn3mu8Sc2y2eACtJM9

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjYWzn3mu8Sc2y2eACtJM9)_