### PR TITLE
Do not panic when inode metadata cannot be read

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -565,7 +565,7 @@ impl SimpleFS {
         parent_attrs.last_metadata_changed = time_now();
         self.write_inode(&parent_attrs);
 
-        let mut entries = self.get_directory_content(parent).unwrap();
+        let mut entries = self.get_directory_content(parent)?;
         entries.insert(name.as_bytes().to_vec(), (inode.0, kind));
         self.write_directory_content(parent, &entries);
 
@@ -843,7 +843,13 @@ impl Filesystem for SimpleFS {
             self.write_inode(&attrs);
         }
 
-        let attrs = self.get_inode(ino).unwrap();
+        let attrs = match self.get_inode(ino) {
+            Ok(attrs) => attrs,
+            Err(error_code) => {
+                reply.error(error_code);
+                return;
+            }
+        };
         reply.attr(&Duration::new(0, 0), &attrs.into());
         return;
     }
@@ -958,7 +964,13 @@ impl Filesystem for SimpleFS {
             self.write_directory_content(inode, &entries);
         }
 
-        let mut entries = self.get_directory_content(parent).unwrap();
+        let mut entries = match self.get_directory_content(parent) {
+            Ok(entries) => entries,
+            Err(error_code) => {
+                reply.error(error_code);
+                return;
+            }
+        };
         entries.insert(name.as_bytes().to_vec(), (inode.0, attrs.kind));
         self.write_directory_content(parent, &entries);
 
@@ -1033,7 +1045,13 @@ impl Filesystem for SimpleFS {
         entries.insert(b"..".to_vec(), (parent.0, FileKind::Directory));
         self.write_directory_content(inode, &entries);
 
-        let mut entries = self.get_directory_content(parent).unwrap();
+        let mut entries = match self.get_directory_content(parent) {
+            Ok(entries) => entries,
+            Err(error_code) => {
+                reply.error(error_code);
+                return;
+            }
+        };
         entries.insert(name.as_bytes().to_vec(), (inode.0, FileKind::Directory));
         self.write_directory_content(parent, &entries);
 
@@ -1090,7 +1108,13 @@ impl Filesystem for SimpleFS {
         self.write_inode(&attrs);
         self.gc_inode(&attrs);
 
-        let mut entries = self.get_directory_content(parent).unwrap();
+        let mut entries = match self.get_directory_content(parent) {
+            Ok(entries) => entries,
+            Err(error_code) => {
+                reply.error(error_code);
+                return;
+            }
+        };
         entries.remove(name.as_bytes());
         self.write_directory_content(parent, &entries);
 
@@ -1116,12 +1140,14 @@ impl Filesystem for SimpleFS {
         };
 
         // Directories always have a self and parent link
-        if self
-            .get_directory_content(INodeNo(attrs.inode))
-            .unwrap()
-            .len()
-            > 2
-        {
+        let entries = match self.get_directory_content(INodeNo(attrs.inode)) {
+            Ok(entries) => entries,
+            Err(error_code) => {
+                reply.error(error_code);
+                return;
+            }
+        };
+        if entries.len() > 2 {
             reply.error(Errno::ENOTEMPTY);
             return;
         }
@@ -1156,7 +1182,13 @@ impl Filesystem for SimpleFS {
         self.write_inode(&attrs);
         self.gc_inode(&attrs);
 
-        let mut entries = self.get_directory_content(parent).unwrap();
+        let mut entries = match self.get_directory_content(parent) {
+            Ok(entries) => entries,
+            Err(error_code) => {
+                reply.error(error_code);
+                return;
+            }
+        };
         entries.remove(name.as_bytes());
         self.write_directory_content(parent, &entries);
 
@@ -1347,14 +1379,26 @@ impl Filesystem for SimpleFS {
                 }
             };
 
-            let mut entries = self.get_directory_content(newparent).unwrap();
+            let mut entries = match self.get_directory_content(newparent) {
+                Ok(entries) => entries,
+                Err(error_code) => {
+                    reply.error(error_code);
+                    return;
+                }
+            };
             entries.insert(
                 newname.as_bytes().to_vec(),
                 (inode_attrs.inode, inode_attrs.kind),
             );
             self.write_directory_content(newparent, &entries);
 
-            let mut entries = self.get_directory_content(parent).unwrap();
+            let mut entries = match self.get_directory_content(parent) {
+                Ok(entries) => entries,
+                Err(error_code) => {
+                    reply.error(error_code);
+                    return;
+                }
+            };
             entries.insert(
                 name.as_bytes().to_vec(),
                 (new_inode_attrs.inode, new_inode_attrs.kind),
@@ -1373,16 +1417,24 @@ impl Filesystem for SimpleFS {
             self.write_inode(&new_inode_attrs);
 
             if inode_attrs.kind == FileKind::Directory {
-                let mut entries = self
-                    .get_directory_content(INodeNo(inode_attrs.inode))
-                    .unwrap();
+                let mut entries = match self.get_directory_content(INodeNo(inode_attrs.inode)) {
+                    Ok(entries) => entries,
+                    Err(error_code) => {
+                        reply.error(error_code);
+                        return;
+                    }
+                };
                 entries.insert(b"..".to_vec(), (newparent.0, FileKind::Directory));
                 self.write_directory_content(INodeNo(inode_attrs.inode), &entries);
             }
             if new_inode_attrs.kind == FileKind::Directory {
-                let mut entries = self
-                    .get_directory_content(INodeNo(new_inode_attrs.inode))
-                    .unwrap();
+                let mut entries = match self.get_directory_content(INodeNo(new_inode_attrs.inode)) {
+                    Ok(entries) => entries,
+                    Err(error_code) => {
+                        reply.error(error_code);
+                        return;
+                    }
+                };
                 entries.insert(b"..".to_vec(), (parent.0, FileKind::Directory));
                 self.write_directory_content(INodeNo(new_inode_attrs.inode), &entries);
             }
@@ -1398,15 +1450,18 @@ impl Filesystem for SimpleFS {
 
         // Only overwrite an existing directory if it's empty
         if let Ok(new_name_attrs) = self.lookup_name(newparent, newname) {
-            if new_name_attrs.kind == FileKind::Directory
-                && self
-                    .get_directory_content(INodeNo(new_name_attrs.inode))
-                    .unwrap()
-                    .len()
-                    > 2
-            {
-                reply.error(Errno::ENOTEMPTY);
-                return;
+            if new_name_attrs.kind == FileKind::Directory {
+                let entries = match self.get_directory_content(INodeNo(new_name_attrs.inode)) {
+                    Ok(entries) => entries,
+                    Err(error_code) => {
+                        reply.error(error_code);
+                        return;
+                    }
+                };
+                if entries.len() > 2 {
+                    reply.error(Errno::ENOTEMPTY);
+                    return;
+                }
             }
         }
 
@@ -1429,7 +1484,13 @@ impl Filesystem for SimpleFS {
 
         // If target already exists decrement its hardlink count
         if let Ok(mut existing_inode_attrs) = self.lookup_name(newparent, newname) {
-            let mut entries = self.get_directory_content(newparent).unwrap();
+            let mut entries = match self.get_directory_content(newparent) {
+                Ok(entries) => entries,
+                Err(error_code) => {
+                    reply.error(error_code);
+                    return;
+                }
+            };
             entries.remove(newname.as_bytes());
             self.write_directory_content(newparent, &entries);
 
@@ -1443,11 +1504,23 @@ impl Filesystem for SimpleFS {
             self.gc_inode(&existing_inode_attrs);
         }
 
-        let mut entries = self.get_directory_content(parent).unwrap();
+        let mut entries = match self.get_directory_content(parent) {
+            Ok(entries) => entries,
+            Err(error_code) => {
+                reply.error(error_code);
+                return;
+            }
+        };
         entries.remove(name.as_bytes());
         self.write_directory_content(parent, &entries);
 
-        let mut entries = self.get_directory_content(newparent).unwrap();
+        let mut entries = match self.get_directory_content(newparent) {
+            Ok(entries) => entries,
+            Err(error_code) => {
+                reply.error(error_code);
+                return;
+            }
+        };
         entries.insert(
             newname.as_bytes().to_vec(),
             (inode_attrs.inode, inode_attrs.kind),
@@ -1464,9 +1537,13 @@ impl Filesystem for SimpleFS {
         self.write_inode(&inode_attrs);
 
         if inode_attrs.kind == FileKind::Directory {
-            let mut entries = self
-                .get_directory_content(INodeNo(inode_attrs.inode))
-                .unwrap();
+            let mut entries = match self.get_directory_content(INodeNo(inode_attrs.inode)) {
+                Ok(entries) => entries,
+                Err(error_code) => {
+                    reply.error(error_code);
+                    return;
+                }
+            };
             entries.insert(b"..".to_vec(), (newparent.0, FileKind::Directory));
             self.write_directory_content(INodeNo(inode_attrs.inode), &entries);
         }
@@ -1994,7 +2071,13 @@ impl Filesystem for SimpleFS {
             self.write_directory_content(inode, &entries);
         }
 
-        let mut entries = self.get_directory_content(parent).unwrap();
+        let mut entries = match self.get_directory_content(parent) {
+            Ok(entries) => entries,
+            Err(error_code) => {
+                reply.error(error_code);
+                return;
+            }
+        };
         entries.insert(name.as_bytes().to_vec(), (inode.0, attrs.kind));
         self.write_directory_content(parent, &entries);
 
@@ -2031,7 +2114,17 @@ impl Filesystem for SimpleFS {
                     reply.error(io::Error::last_os_error().into());
                     return;
                 }
-                let mut attrs = self.get_inode(ino).unwrap();
+                // Release the descriptor before opening the inode, so that the read below cannot
+                // be the open that runs into RLIMIT_NOFILE, as in write()
+                drop(file);
+
+                let mut attrs = match self.get_inode(ino) {
+                    Ok(attrs) => attrs,
+                    Err(error_code) => {
+                        reply.error(error_code);
+                        return;
+                    }
+                };
                 // Every fallocate mode changes the file, so the times move even when the size
                 // is pinned: a punch-hole rewrites content, and preallocation commits blocks
                 attrs.last_metadata_changed = time_now();
@@ -2085,14 +2178,24 @@ impl Filesystem for SimpleFS {
 
                 let mut data = vec![0; read_size as usize];
                 file.read_exact_at(&mut data, src_offset).unwrap();
+                // The contents are buffered now, so hold neither descriptor open across the
+                // opens that follow, for the same reason as in write()
+                drop(file);
 
                 let dest_path = self.content_path(dest_inode);
                 match OpenOptions::new().write(true).open(dest_path) {
                     Ok(mut file) => {
                         file.seek(SeekFrom::Start(dest_offset)).unwrap();
                         file.write_all(&data).unwrap();
+                        drop(file);
 
-                        let mut attrs = self.get_inode(dest_inode).unwrap();
+                        let mut attrs = match self.get_inode(dest_inode) {
+                            Ok(attrs) => attrs,
+                            Err(error_code) => {
+                                reply.error(error_code);
+                                return;
+                            }
+                        };
                         attrs.last_metadata_changed = time_now();
                         attrs.last_modified = time_now();
                         let Ok(dest_offset_usize): Result<usize, _> = dest_offset.try_into() else {


### PR DESCRIPTION
Finishes the cleanup started in #722 (`lookup()`) and #724 (`write()`), covering every remaining `get_inode()` / `get_directory_content()` call site in the example.

## The bug

All 19 remaining sites read their result with `.unwrap()`, so any failure panicked the session thread and took the whole mount down instead of failing the one request. Both helpers report every open failure as `ENOENT`, including `EMFILE`, so this is reachable two ways:

- **Descriptor pressure.** Nothing exotic needed — that is exactly how the leak in #722 escalated from a single failing test into every subsequent test in the run failing.
- **Torn state.** `gc_inode()` removes `inodes/<ino>` before `contents/<ino>`, so a crash between the two leaves a content file whose inode is gone.

Sites touched: `insert_link`, `setattr`, `mknod`, `mkdir`, `unlink`, `rmdir`, `rename` (7), `create`, `fallocate`, `copy_file_range`.

## The change

Return the error, matching `lookup()` and `write()`. `insert_link()` already returns `Result`, so it just propagates with `?`.

Also drops the content file before opening the inode in `fallocate()` and `copy_file_range()`, so the error paths this PR adds cannot misfire on an `EMFILE` caused by the request's own descriptors — same reasoning as the `drop(file)` in #724.

Worth being explicit about a limitation: these sites are all mid-operation, so returning an error can leave a directory entry that no longer matches its inode. That is inherent to a filesystem with no journal, and unwinding is not something this example can do. Panicking did not avoid the inconsistency — it just killed the mount as well.

## Verification

| Check | Result |
| --- | --- |
| xfstests, full suite | passed all 704 |
| pjdfstest (libfuse3) | `Result: PASS`, 205 files / 2732 tests, 0 failed |
| Panics in either mount log | 0 |
| `cargo fmt --check` | clean |
| `cargo clippy --all-targets` under `RUSTFLAGS=--deny warnings` | clean |
| `cargo test` | 87 passed |

## Follow-up not included here

While testing, the disk filled and the example panicked on it:

```
thread 'fuser-0' panicked at examples/simple.rs:1702:38:
called `Result::unwrap()` on an `Err` value:
  Os { code: 28, kind: StorageFull, message: "No space left on device" }
   3: <simple::SimpleFS as fuser::Filesystem>::write
```

That is `file.write_all(data).unwrap()` — a different family of unwrap (raw I/O rather than metadata), roughly 20 sites: `write_all`, `read_exact_at`, `.open()`, `set_len`, `remove_file`, and the msgpack encode/decode inside `write_inode()` / `get_inode()`. A full disk is an ordinary condition and needs no race to hit, so this is arguably more severe than what this PR fixes, but it is a comparable amount of change and folding it in would make this diff hard to review. Happy to do it as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSmtYYZ3resRdsCD1PwqUK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSmtYYZ3resRdsCD1PwqUK)_