### PR TITLE
Add Notifier::inc_epoch() to invalidate every cached entry at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   `inval_entry()` costs one per entry and needs the names up front, so it suits a backing
   store that changed wholesale. Requires ABI 7.44, returning `ENOTSUP` below it, since the
   kernel advertises no capability bit for this and an older one answers only with `EINVAL`
+* The ABI version reported to the kernel on non-macOS platforms is now 7.44, up from 7.40, so
+  that `inc_epoch()` is in protocol rather than relying on the kernel not version-gating its
+  notification dispatch. The features 7.41 through 7.43 add are capabilities the kernel acts
+  on only once negotiated, and all three are already refused
 * Add `TryFrom<&std::fs::Metadata>` for `FileAttr` (#413), so a filesystem backed by files on
   disk can answer `getattr` and `lookup` from the underlying file's metadata. The conversion is
   fallible because `nlink`, `rdev` and `blksize` narrow to the widths the FUSE protocol gives

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # FUSE for Rust - Changelog
 
 ## Unreleased
+* Add `Notifier::inc_epoch()`, which invalidates every cached directory entry at once by
+  incrementing the connection's epoch (#382). This costs one notification where
+  `inval_entry()` costs one per entry and needs the names up front, so it suits a backing
+  store that changed wholesale. Requires ABI 7.44, returning `ENOTSUP` below it, since the
+  kernel advertises no capability bit for this and an older one answers only with `EINVAL`
 * Add `TryFrom<&std::fs::Metadata>` for `FileAttr` (#413), so a filesystem backed by files on
   disk can answer `getattr` and `lookup` from the underlying file's metadata. The conversion is
   fallible because `nlink`, `rdev` and `blksize` narrow to the widths the FUSE protocol gives

--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -30,6 +30,7 @@ use zerocopy::IntoBytes;
 use zerocopy::KnownLayout;
 
 use crate::ll::flags::fattr_flags::FattrFlags;
+use crate::ll::request::Version;
 
 pub(crate) const FUSE_KERNEL_VERSION: u32 = 7;
 
@@ -182,7 +183,13 @@ pub(crate) enum fuse_notify_code {
     FUSE_NOTIFY_STORE = 4,
     FUSE_NOTIFY_RETRIEVE = 5,
     FUSE_NOTIFY_DELETE = 6,
+    FUSE_NOTIFY_RESEND = 7,
+    FUSE_NOTIFY_INC_EPOCH = 8,
 }
+
+/// ABI version that added `FUSE_NOTIFY_INC_EPOCH`. An older kernel has no case for the
+/// code and answers the write with `EINVAL`
+pub(crate) const FUSE_NOTIFY_INC_EPOCH_VERSION: Version = Version(7, 44);
 
 #[repr(C)]
 #[derive(Debug, IntoBytes, KnownLayout, Immutable)]

--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -41,7 +41,11 @@ pub(crate) const FUSE_KERNEL_MINOR_VERSION: u32 = if cfg!(target_os = "macos") {
     // So let's declare protocol version 19 to be safe.
     19
 } else {
-    40
+    // 7.44 is what `FUSE_NOTIFY_INC_EPOCH` needs. Everything 7.41 through 7.43 added is a
+    // capability the kernel only acts on once negotiated, and all three are refused in
+    // `UNSUPPORTED_CAPABILITIES`, so declaring this adds no obligation beyond the
+    // notification itself
+    44
 };
 
 #[repr(C)]

--- a/src/ll/notify.rs
+++ b/src/ll/notify.rs
@@ -115,6 +115,12 @@ impl<'a> Notification<'a> {
         Ok(Self::from_struct_with_name(&r, name.as_bytes()))
     }
 
+    /// The notification carries no payload at all: the kernel's handler takes only the
+    /// connection, ignoring the size and the rest of the message
+    pub(crate) fn new_inc_epoch() -> Self {
+        Self::Bare(NotificationBuf::new())
+    }
+
     pub(crate) fn new_poll(kh: PollHandle) -> Self {
         let r = abi::fuse_notify_poll_wakeup_out { kh: kh.0 };
         Self::from_struct(&r)
@@ -217,6 +223,20 @@ mod test {
             0x24, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x61, 0x62, 0x63, 0x00,
+        ];
+        assert_eq!(n, expected);
+    }
+
+    /// Nothing but a header: 16 bytes of length and code, and no payload for the kernel to
+    /// read past it.
+    #[test]
+    fn inc_epoch() {
+        let n = Notification::new_inc_epoch()
+            .with_iovec(abi::fuse_notify_code::FUSE_NOTIFY_INC_EPOCH, ioslice_to_vec)
+            .unwrap();
+        let expected = vec![
+            0x10, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00,
         ];
         assert_eq!(n, expected);
     }

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -9,6 +9,8 @@ use crate::Version;
 use crate::channel::ChannelSender;
 use crate::ll::flags::init_flags::InitFlags;
 use crate::ll::fuse_abi::FUSE_EXPIRE_ONLY;
+use crate::ll::fuse_abi::FUSE_KERNEL_MINOR_VERSION;
+use crate::ll::fuse_abi::FUSE_KERNEL_VERSION;
 use crate::ll::fuse_abi::FUSE_NOTIFY_INC_EPOCH_VERSION;
 use crate::ll::fuse_abi::fuse_notify_code as notify_code;
 use crate::ll::notify::Notification;
@@ -65,9 +67,10 @@ pub struct Notifier {
     /// meaningful on a kernel that supports them, and the kernel reports success
     /// regardless, so they are refused here rather than silently doing something else
     kernel_capabilities: InitFlags,
-    /// The ABI version the kernel agreed on, or `None` before init has run. Notifications
-    /// added after a given version have no capability bit to key on, so the version is
-    /// what says whether the kernel will understand them
+    /// The ABI version the kernel offered during init, or `None` before init has run.
+    /// Notifications added after a given version have no capability bit to key on, so the
+    /// version is what says whether the kernel will understand them. This is what the kernel
+    /// advertised, not what the connection settled on: see [`Notifier::negotiated_abi`]
     kernel_abi: Option<Version>,
 }
 
@@ -143,22 +146,39 @@ impl Notifier {
     /// prunes unused entries in the background.
     ///
     /// # Errors
-    /// Returns `ENOTSUP` if the kernel agreed on an ABI older than 7.44, which has no case
-    /// for this notification. Such a kernel does reject it, unlike the one
+    /// Returns `ENOTSUP` if the connection settled on an ABI older than 7.44, which has no
+    /// case for this notification. Such a kernel does reject it, unlike the one
     /// [`expire_entry()`](Self::expire_entry) guards against, but only with an `EINVAL`
     /// that says nothing about why, and a caller holding a `Notifier` has no way to check
     /// the version for itself.
     /// Returns an error if the kernel rejects the notification.
     pub fn inc_epoch(&self) -> io::Result<()> {
-        // Unknown before init has run, which is also a kernel that cannot be relied on for it
+        // None before init has run, which is also a connection nothing can be sent on yet
         if self
-            .kernel_abi
+            .negotiated_abi()
             .is_none_or(|v| v < FUSE_NOTIFY_INC_EPOCH_VERSION)
         {
             return Err(io::Error::from_raw_os_error(libc::ENOTSUP));
         }
         let notif = Notification::new_inc_epoch();
         self.send(notify_code::FUSE_NOTIFY_INC_EPOCH, &notif)
+    }
+
+    /// What the connection actually speaks: the lower of what the kernel offered during init
+    /// and what this crate replied with.
+    ///
+    /// Both halves matter. The kernel dispatches a notification on its code alone, without
+    /// consulting the version, so what it offered is what decides whether it has a case for
+    /// one at all. But it records the replied version verbatim as the connection's, so
+    /// sending something newer than that is out of protocol however tolerant the dispatch
+    /// happens to be. Taking the lower keeps to both.
+    fn negotiated_abi(&self) -> Option<Version> {
+        self.kernel_abi.map(|kernel| {
+            Version(
+                kernel.0.min(FUSE_KERNEL_VERSION),
+                kernel.1.min(FUSE_KERNEL_MINOR_VERSION),
+            )
+        })
     }
 
     /// Invalidate the kernel cache for a given inode (metadata and
@@ -267,7 +287,7 @@ mod test {
     /// kernel advertises no bit for it.
     #[test]
     fn inc_epoch_refused_below_its_abi_version() {
-        for abi in [None, Some(Version(7, 43)), Some(Version(6, 99))] {
+        for abi in [None, Some(Version(7, 43)), Some(Version(7, 6))] {
             let err = notifier_with_abi(InitFlags::all(), abi)
                 .inc_epoch()
                 .unwrap_err();
@@ -277,10 +297,24 @@ mod test {
 
     #[test]
     fn inc_epoch_sent_from_its_abi_version_on() {
-        for abi in [Version(7, 44), Version(7, 45), Version(8, 0)] {
+        for abi in [Version(7, 44), Version(7, 45), Version(7, 99)] {
             notifier_with_abi(InitFlags::empty(), Some(abi))
                 .inc_epoch()
                 .unwrap();
         }
+    }
+
+    /// A kernel offering more than this crate replies with does not make the extra versions
+    /// part of the connection, since the kernel records the reply as its own.
+    #[test]
+    fn negotiated_abi_is_capped_by_what_this_crate_replies_with() {
+        let notifier = notifier_with_abi(InitFlags::empty(), Some(Version(7, 99)));
+        assert_eq!(
+            notifier.negotiated_abi(),
+            Some(Version(FUSE_KERNEL_VERSION, FUSE_KERNEL_MINOR_VERSION))
+        );
+        // ...and a kernel offering less than that caps it the other way round
+        let notifier = notifier_with_abi(InitFlags::empty(), Some(Version(7, 31)));
+        assert_eq!(notifier.negotiated_abi(), Some(Version(7, 31)));
     }
 }

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -5,9 +5,11 @@ use std::ffi::OsStr;
 use std::io;
 
 use crate::INodeNo;
+use crate::Version;
 use crate::channel::ChannelSender;
 use crate::ll::flags::init_flags::InitFlags;
 use crate::ll::fuse_abi::FUSE_EXPIRE_ONLY;
+use crate::ll::fuse_abi::FUSE_NOTIFY_INC_EPOCH_VERSION;
 use crate::ll::fuse_abi::fuse_notify_code as notify_code;
 use crate::ll::notify::Notification;
 
@@ -24,10 +26,15 @@ pub struct PollNotifier {
 }
 
 impl PollNotifier {
-    pub(crate) fn new(cs: ChannelSender, kh: PollHandle, kernel_capabilities: InitFlags) -> Self {
+    pub(crate) fn new(
+        cs: ChannelSender,
+        kh: PollHandle,
+        kernel_capabilities: InitFlags,
+        kernel_abi: Option<Version>,
+    ) -> Self {
         Self {
             handle: kh,
-            notifier: Notifier::new(cs, kernel_capabilities),
+            notifier: Notifier::new(cs, kernel_capabilities, kernel_abi),
         }
     }
 
@@ -58,13 +65,22 @@ pub struct Notifier {
     /// meaningful on a kernel that supports them, and the kernel reports success
     /// regardless, so they are refused here rather than silently doing something else
     kernel_capabilities: InitFlags,
+    /// The ABI version the kernel agreed on, or `None` before init has run. Notifications
+    /// added after a given version have no capability bit to key on, so the version is
+    /// what says whether the kernel will understand them
+    kernel_abi: Option<Version>,
 }
 
 impl Notifier {
-    pub(crate) fn new(cs: ChannelSender, kernel_capabilities: InitFlags) -> Self {
+    pub(crate) fn new(
+        cs: ChannelSender,
+        kernel_capabilities: InitFlags,
+        kernel_abi: Option<Version>,
+    ) -> Self {
         Self {
             sender: cs,
             kernel_capabilities,
+            kernel_abi,
         }
     }
 
@@ -109,6 +125,40 @@ impl Notifier {
         let notif = Notification::new_inval_entry(parent, name, FUSE_EXPIRE_ONLY)
             .map_err(Self::too_big_err)?;
         self.send_inval(notify_code::FUSE_NOTIFY_INVAL_ENTRY, &notif)
+    }
+
+    /// Invalidate every cached directory entry at once, by incrementing the connection's
+    /// epoch.
+    ///
+    /// The kernel stamps each dentry with the epoch current when it was looked up, and
+    /// treats one stamped with an older epoch as stale. Incrementing therefore invalidates
+    /// the whole dentry and readdir cache in constant time, where
+    /// [`inval_entry()`](Self::inval_entry) costs a notification per entry and needs the
+    /// filesystem to know the names to begin with. That suits a backing store that has
+    /// changed wholesale, or one whose changes cannot be enumerated.
+    ///
+    /// Invalidation is lazy, as with [`expire_entry()`](Self::expire_entry): entries are
+    /// revalidated on next use rather than forcibly detached, so anything mounted beneath
+    /// one stays mounted. A kernel configured with the `inval_wq` module parameter also
+    /// prunes unused entries in the background.
+    ///
+    /// # Errors
+    /// Returns `ENOTSUP` if the kernel agreed on an ABI older than 7.44, which has no case
+    /// for this notification. Such a kernel does reject it, unlike the one
+    /// [`expire_entry()`](Self::expire_entry) guards against, but only with an `EINVAL`
+    /// that says nothing about why, and a caller holding a `Notifier` has no way to check
+    /// the version for itself.
+    /// Returns an error if the kernel rejects the notification.
+    pub fn inc_epoch(&self) -> io::Result<()> {
+        // Unknown before init has run, which is also a kernel that cannot be relied on for it
+        if self
+            .kernel_abi
+            .is_none_or(|v| v < FUSE_NOTIFY_INC_EPOCH_VERSION)
+        {
+            return Err(io::Error::from_raw_os_error(libc::ENOTSUP));
+        }
+        let notif = Notification::new_inc_epoch();
+        self.send(notify_code::FUSE_NOTIFY_INC_EPOCH, &notif)
     }
 
     /// Invalidate the kernel cache for a given inode (metadata and
@@ -176,12 +226,16 @@ mod test {
     use crate::dev_fuse::DevFuse;
 
     fn notifier(kernel_capabilities: InitFlags) -> Notifier {
+        notifier_with_abi(kernel_capabilities, Some(FUSE_NOTIFY_INC_EPOCH_VERSION))
+    }
+
+    fn notifier_with_abi(kernel_capabilities: InitFlags, kernel_abi: Option<Version>) -> Notifier {
         // /dev/null stands in for the FUSE device: the cases below either return before
         // sending, or send a notification whose fate is not what is under test
         let dev = Arc::new(DevFuse(
             File::options().write(true).open("/dev/null").unwrap(),
         ));
-        Notifier::new(Channel::new(dev).sender(), kernel_capabilities)
+        Notifier::new(Channel::new(dev).sender(), kernel_capabilities, kernel_abi)
     }
 
     /// A kernel that never advertised expiring would invalidate the entry and report
@@ -207,5 +261,26 @@ mod test {
         notifier(InitFlags::empty())
             .inval_entry(INodeNo::ROOT, OsStr::new("x"))
             .unwrap();
+    }
+
+    /// Incrementing the epoch keys on the ABI version rather than a capability, since the
+    /// kernel advertises no bit for it.
+    #[test]
+    fn inc_epoch_refused_below_its_abi_version() {
+        for abi in [None, Some(Version(7, 43)), Some(Version(6, 99))] {
+            let err = notifier_with_abi(InitFlags::all(), abi)
+                .inc_epoch()
+                .unwrap_err();
+            assert_eq!(err.raw_os_error(), Some(libc::ENOTSUP), "{abi:?}");
+        }
+    }
+
+    #[test]
+    fn inc_epoch_sent_from_its_abi_version_on() {
+        for abi in [Version(7, 44), Version(7, 45), Version(8, 0)] {
+            notifier_with_abi(InitFlags::empty(), Some(abi))
+                .inc_epoch()
+                .unwrap();
+        }
     }
 }

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -295,12 +295,18 @@ mod test {
         }
     }
 
+    /// Both sides have to reach 7.44, so what this crate replies with decides it just as much
+    /// as what the kernel offers. On macOS that is 7.19 and never enough, which is the answer
+    /// there however new the kernel is.
     #[test]
-    fn inc_epoch_sent_from_its_abi_version_on() {
+    fn inc_epoch_sent_only_when_this_crate_reports_its_abi_version() {
+        let reported = Version(FUSE_KERNEL_VERSION, FUSE_KERNEL_MINOR_VERSION);
+        let this_crate_reaches_it = reported >= FUSE_NOTIFY_INC_EPOCH_VERSION;
         for abi in [Version(7, 44), Version(7, 45), Version(7, 99)] {
-            notifier_with_abi(InitFlags::empty(), Some(abi))
+            let sent = notifier_with_abi(InitFlags::empty(), Some(abi))
                 .inc_epoch()
-                .unwrap();
+                .is_ok();
+            assert_eq!(sent, this_crate_reaches_it, "{abi:?}");
         }
     }
 
@@ -313,8 +319,9 @@ mod test {
             notifier.negotiated_abi(),
             Some(Version(FUSE_KERNEL_VERSION, FUSE_KERNEL_MINOR_VERSION))
         );
-        // ...and a kernel offering less than that caps it the other way round
-        let notifier = notifier_with_abi(InitFlags::empty(), Some(Version(7, 31)));
-        assert_eq!(notifier.negotiated_abi(), Some(Version(7, 31)));
+        // ...and a kernel offering less caps it the other way round. 7.8 is below what every
+        // platform replies with, macOS included, so this does not depend on which one it is
+        let notifier = notifier_with_abi(InitFlags::empty(), Some(Version(7, 8)));
+        assert_eq!(notifier.negotiated_abi(), Some(Version(7, 8)));
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -460,8 +460,12 @@ impl<'a> RequestWithSender<'a> {
                 );
             }
             ll::Operation::Poll(x) => {
-                let ph =
-                    PollNotifier::new(se.ch.sender(), x.kernel_handle(), se.kernel_capabilities);
+                let ph = PollNotifier::new(
+                    se.ch.sender(),
+                    x.kernel_handle(),
+                    se.kernel_capabilities,
+                    se.kernel_abi,
+                );
 
                 filesystem.poll(
                     self.request_header(),

--- a/src/session.rs
+++ b/src/session.rs
@@ -245,6 +245,7 @@ impl<FS: Filesystem> Session<FS> {
         let sender = self.ch.sender();
         let fuse_device = self.ch.device();
         let kernel_capabilities = self.kernel_capabilities;
+        let kernel_abi = self.proto_version;
         // Take the fuse_session, so that we can unmount it
         let mount = std::mem::take(&mut *self.mount.mount.lock());
         let guard = thread::Builder::new()
@@ -256,6 +257,7 @@ impl<FS: Filesystem> Session<FS> {
             fuse_device,
             mount,
             kernel_capabilities,
+            kernel_abi,
         })
     }
 
@@ -272,7 +274,7 @@ impl<FS: Filesystem> Session<FS> {
             mount: _do_not_umount_yet,
             allowed,
             session_owner,
-            proto_version: _,
+            proto_version,
             negotiated,
             kernel_capabilities,
             config,
@@ -324,6 +326,7 @@ impl<FS: Filesystem> Session<FS> {
                 session_owner,
                 negotiated,
                 kernel_capabilities,
+                kernel_abi: proto_version,
             };
             threads.push(
                 thread::Builder::new()
@@ -519,7 +522,11 @@ impl<FS: Filesystem> Session<FS> {
 
     /// Returns an object that can be used to send notifications to the kernel
     pub fn notifier(&self) -> Notifier {
-        Notifier::new(self.ch.sender(), self.kernel_capabilities)
+        Notifier::new(
+            self.ch.sender(),
+            self.kernel_capabilities,
+            self.proto_version,
+        )
     }
 }
 
@@ -548,6 +555,7 @@ pub(crate) struct SessionEventLoop<FS: Filesystem> {
     pub(crate) session_owner: Uid,
     pub(crate) negotiated: InitFlags,
     pub(crate) kernel_capabilities: InitFlags,
+    pub(crate) kernel_abi: Option<Version>,
 }
 
 impl<FS: Filesystem> SessionEventLoop<FS> {
@@ -617,6 +625,8 @@ pub struct BackgroundSession {
     /// Everything the kernel advertised during init, for notifications whose support
     /// depends on it
     kernel_capabilities: InitFlags,
+    /// The ABI version agreed during init, for notifications with no capability bit
+    kernel_abi: Option<Version>,
 }
 
 /// How long teardown waits for the kernel connection to end after a successful
@@ -644,7 +654,11 @@ impl BackgroundSession {
 
     /// Returns an object that can be used to send notifications to the kernel
     pub fn notifier(&self) -> Notifier {
-        Notifier::new(self.sender.clone(), self.kernel_capabilities)
+        Notifier::new(
+            self.sender.clone(),
+            self.kernel_capabilities,
+            self.kernel_abi,
+        )
     }
 
     /// Join the filesystem thread without unmounting first: blocks until


### PR DESCRIPTION
Closes #382.

The kernel stamps each dentry with the connection epoch current when it was looked up, and `fuse_dentry_revalidate()` treats one stamped with an older epoch as stale (`fs/fuse/dir.c`). `FUSE_NOTIFY_INC_EPOCH` does nothing but `atomic_inc(&fc->epoch)`, so one notification drops the whole dentry and readdir cache.

That is worth having because `inval_entry()` costs a notification per entry *and* requires the filesystem to know the names up front. A backing store that changed wholesale, or one whose changes cannot be enumerated, had no way to say so.

Invalidation is lazy, the same as `expire_entry()`: entries are revalidated on next use rather than forcibly detached, so anything mounted beneath one stays mounted. A kernel configured with the `inval_wq` module parameter additionally schedules `fuse_epoch_work()`, which prunes unused entries in the background.

## The reported ABI version moves to 7.44

**This is the part worth a reviewer's attention, because it affects every mount rather than just this feature.**

The first version of this gated on `init.version()`, the version the kernel *offered*, while the reply hardcoded minor 40. The kernel records the reply verbatim as the connection's version (`fc->minor = arg->minor`, no clamp), so `inc_epoch()` was sending a 7.44 notification on a connection negotiated at 7.40. It worked only because the kernel dispatches a notification on its code alone — `fs/fuse/notify.c` never consults the minor, and every `fc->minor` gate in the tree is `< N` for N ≤ 23. Codex caught this; thanks.

Gating on the negotiated minor alone would have pinned the check at 40 and made `inc_epoch()` unreachable, so the fix is to report 7.44. That is safe here because everything 7.41–7.43 adds is a capability the kernel acts on only once negotiated — `FUSE_ALLOW_IDMAP`, `FUSE_OVER_IO_URING`, `FUSE_REQUEST_TIMEOUT` — and all three are already in `UNSUPPORTED_CAPABILITIES`. No struct fuser parses changed across those versions.

FreeBSD shares the constant, so I checked it too: it stores the reply verbatim and rejects only a version *below* 7.4, and its own `fuse_libabi_geq` gates stop at 7.33, so 40 → 44 is inert there. Its kernel declares minor 35, so `inc_epoch()` still correctly refuses on FreeBSD. macOS keeps its separate 19, which likewise means `inc_epoch()` is always `ENOTSUP` there.

The gate now takes the lower of what the kernel offered and what this crate reports, rather than trusting either alone, so it stays correct if a later notification needs a version above what is reported.

## Why ENOTSUP rather than letting EINVAL through

Deliberately **not** the reasoning from #367. That guard exists because a kernel without `FUSE_HAS_EXPIRE_ONLY` reads the flag as padding, does the destructive thing, and reports success — silence is the hazard. Here the old kernel genuinely rejects the request; `fuse_notify()` has a `default:` arm returning `-EINVAL`. The reason to gate is narrower: `EINVAL` says nothing about *why*, being indistinguishable from a malformed request, and a caller holding a `Notifier` has no way to check the ABI version for itself (`KernelConfig::kernel_abi()` is reachable only inside `Filesystem::init`).

## Testing

Unit tests cover the wire format (a bare 16-byte header, no payload — the kernel's handler takes only the connection and never reads the body), both directions of the version gate including `None` for a notifier built before init has run, and the negotiated-version cap from either side.

The parts unit tests cannot reach were checked against a running kernel, ABI 7.45:

- With a name cached under a 1-hour entry TTL, a second `stat` issues no `lookup`, and a `stat` after `inc_epoch()` does. That is the invalidation actually taking effect, not merely the write being accepted. Re-confirmed after the version bump, along with a mount and a readdir.
- Sending an unrecognised notify code confirmed the kernel's `default:` arm answers `EINVAL` and leaves both the connection and the cache intact — the exact failure mode an older kernel gives for code 8, and the claim the doc comment makes.

The ABI tests are platform-derived rather than assuming the non-macOS constant, which Codex also caught. Verified by building the non-macOS branch with `19` in place of `44`: the earlier versions of those two tests fail, the current ones pass, and the suite still passes with `44` restored. Probe code for all of the above was scratch and is not in the diff.

94 unit tests, three clippy variants, `cargo fmt --check`, `cargo doc` under `--deny warnings`, and cross-compile checks for `x86_64-unknown-freebsd` and `x86_64-apple-darwin`. The integration suites could not be run locally (no docker daemon available), so `mount_tests`, `pjdfs_tests` and `xfstests` were left to CI — all three pass, as does `freebsd-ci`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjYWzn3mu8Sc2y2eACtJM9