### PR TITLE
Support fifos, sockets and device nodes in the simple example

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -94,6 +94,12 @@ struct Args {
     #[clap(long)]
     suid: bool,
 
+    /// Allow device files on this filesystem to be opened, when run as root. Off by default,
+    /// as it is for any other filesystem: a device node the mount's own users can create is a
+    /// way to reach hardware the kernel would not otherwise let them touch
+    #[clap(long)]
+    dev: bool,
+
     #[clap(long, default_value_t = 1)]
     n_threads: usize,
 
@@ -121,6 +127,11 @@ enum FileKind {
     File,
     Directory,
     Symlink,
+    // Appended, so the ordinals of the three above survive in already-written inodes
+    CharDevice,
+    BlockDevice,
+    NamedPipe,
+    Socket,
 }
 
 impl From<FileKind> for fuser::FileType {
@@ -129,6 +140,10 @@ impl From<FileKind> for fuser::FileType {
             FileKind::File => fuser::FileType::RegularFile,
             FileKind::Directory => fuser::FileType::Directory,
             FileKind::Symlink => fuser::FileType::Symlink,
+            FileKind::CharDevice => fuser::FileType::CharDevice,
+            FileKind::BlockDevice => fuser::FileType::BlockDevice,
+            FileKind::NamedPipe => fuser::FileType::NamedPipe,
+            FileKind::Socket => fuser::FileType::Socket,
         }
     }
 }
@@ -353,6 +368,8 @@ struct InodeAttributes {
     pub hardlinks: u32,
     pub uid: u32,
     pub gid: u32,
+    /// Device number, which only a character or block device carries
+    pub rdev: u32,
     pub xattrs: BTreeMap<Vec<u8>, Vec<u8>>,
 }
 
@@ -374,7 +391,7 @@ impl From<InodeAttributes> for fuser::FileAttr {
             nlink: attrs.hardlinks,
             uid: attrs.uid,
             gid: attrs.gid,
-            rdev: 0,
+            rdev: attrs.rdev,
             blksize: BLOCK_SIZE,
             flags: 0,
         }
@@ -650,6 +667,7 @@ impl Filesystem for SimpleFS {
                 hardlinks: 2,
                 uid: 0,
                 gid: 0,
+                rdev: 0,
                 xattrs: BTreeMap::default(),
             };
             self.write_inode(&root);
@@ -914,7 +932,7 @@ impl Filesystem for SimpleFS {
         name: &OsStr,
         mut mode: u32,
         _umask: u32,
-        _rdev: u32,
+        rdev: u32,
         reply: ReplyEntry,
     ) {
         let file_type = mode & libc::S_IFMT as u32;
@@ -922,11 +940,12 @@ impl Filesystem for SimpleFS {
         if file_type != libc::S_IFREG as u32
             && file_type != libc::S_IFLNK as u32
             && file_type != libc::S_IFDIR as u32
+            && file_type != libc::S_IFCHR as u32
+            && file_type != libc::S_IFBLK as u32
+            && file_type != libc::S_IFIFO as u32
+            && file_type != libc::S_IFSOCK as u32
         {
-            // TODO
-            warn!(
-                "mknod() implementation is incomplete. Only supports regular files, symlinks, and directories. Got {mode:o}"
-            );
+            warn!("mknod() got a mode with no recognized file type: {mode:o}");
             reply.error(Errno::EPERM);
             return;
         }
@@ -989,9 +1008,17 @@ impl Filesystem for SimpleFS {
             hardlinks: 1,
             uid: _req.uid(),
             gid: creation_gid(&parent_attrs, _req.gid()),
+            rdev: match as_file_kind(mode) {
+                FileKind::CharDevice | FileKind::BlockDevice => rdev,
+                // Every other type reports 0, as a local filesystem does
+                _ => 0,
+            },
             xattrs: BTreeMap::default(),
         };
         self.write_inode(&attrs);
+        // A fifo, socket or device node holds no data of its own - the kernel services reads
+        // and writes without ever reaching this filesystem - but the empty file keeps unlink
+        // and the garbage collector uniform across every kind
         File::create(self.content_path(inode)).unwrap();
 
         if as_file_kind(mode) == FileKind::Directory {
@@ -1067,6 +1094,7 @@ impl Filesystem for SimpleFS {
             hardlinks: 2, // Directories start with link count of 2, since they have a self link
             uid: _req.uid(),
             gid: creation_gid(&parent_attrs, _req.gid()),
+            rdev: 0,
             xattrs: BTreeMap::default(),
         };
         self.write_inode(&attrs);
@@ -1251,6 +1279,7 @@ impl Filesystem for SimpleFS {
             hardlinks: 1,
             uid: _req.uid(),
             gid: creation_gid(&parent_attrs, _req.gid()),
+            rdev: 0,
             xattrs: BTreeMap::default(),
         };
 
@@ -2025,6 +2054,7 @@ impl Filesystem for SimpleFS {
             hardlinks: 1,
             uid: req.uid(),
             gid: creation_gid(&parent_attrs, req.gid()),
+            rdev: 0,
             xattrs: BTreeMap::default(),
         };
         self.write_inode(&attrs);
@@ -2213,6 +2243,14 @@ fn as_file_kind(mut mode: u32) -> FileKind {
         return FileKind::Symlink;
     } else if mode == libc::S_IFDIR as u32 {
         return FileKind::Directory;
+    } else if mode == libc::S_IFCHR as u32 {
+        return FileKind::CharDevice;
+    } else if mode == libc::S_IFBLK as u32 {
+        return FileKind::BlockDevice;
+    } else if mode == libc::S_IFIFO as u32 {
+        return FileKind::NamedPipe;
+    } else if mode == libc::S_IFSOCK as u32 {
+        return FileKind::Socket;
     }
     unimplemented!("{mode}");
 }
@@ -2366,6 +2404,10 @@ fn main() {
     if args.suid {
         info!("setuid bit support enabled");
         cfg.mount_options.push(MountOption::Suid);
+    }
+    if args.dev {
+        info!("device file support enabled");
+        cfg.mount_options.push(MountOption::Dev);
     }
     if args.auto_unmount {
         cfg.mount_options.push(MountOption::AutoUnmount);

--- a/xfstests.sh
+++ b/xfstests.sh
@@ -31,7 +31,8 @@ echo "generic/484" >> xfs_excludes.txt
 # Writes directly to scratch block dev
 echo "generic/062" >> xfs_excludes.txt
 
-# TODO: looks like it requires character file support
+# TODO: requires renameat2(RENAME_WHITEOUT), which has to leave a 0/0 character device
+# behind at the source. fuser passes the flag through as RenameFlags; the example ignores it
 echo "generic/078" >> xfs_excludes.txt
 
 # TODO: takes > 10min
@@ -46,13 +47,10 @@ echo "generic/127" >> xfs_excludes.txt
 # TODO: requires more complete falloc support. Also fills up the entire hard disk...
 echo "generic/103" >> xfs_excludes.txt
 
-# TODO: requires support for mknod on character files
-echo "generic/184" >> xfs_excludes.txt
-echo "generic/401" >> xfs_excludes.txt
-
-# TODO: requires fifo support
+# TODO: requires ctime and mtime to be set from a single clock reading. The example takes
+# them from separate time_now() calls, so statx can see a ctime older than the mtime set
+# moments earlier in the same operation
 echo "generic/423" >> xfs_excludes.txt
-echo "generic/434" >> xfs_excludes.txt
 
 # TODO: requires ulimit support for limiting file size
 echo "generic/394" >> xfs_excludes.txt
@@ -66,7 +64,9 @@ echo "generic/099" >> xfs_excludes.txt
 echo "generic/105" >> xfs_excludes.txt
 echo "generic/375" >> xfs_excludes.txt
 
-# TODO: requires support for mounting read-only
+# TODO: requires support for remounting read-only. 306 and 452 additionally need a change in
+# fuse-xfstests, whose _scratch_remount answers "fuse.fuser does not support any options"
+# without attempting the remount; 294 goes through _try_scratch_mount and does attempt it
 echo "generic/294" >> xfs_excludes.txt
 echo "generic/306" >> xfs_excludes.txt
 echo "generic/452" >> xfs_excludes.txt
@@ -178,7 +178,7 @@ echo "generic/208" >> xfs_excludes.txt
 echo "generic/323" >> xfs_excludes.txt
 
 
-FUSER_EXTRA_MOUNT_OPTIONS="--auto-unmount" TEST_DEV="$TEST_DATA_DIR" TEST_DIR="$TEST_DIR" SCRATCH_DEV="$SCRATCH_DATA_DIR" SCRATCH_MNT="$SCRATCH_DIR" \
+FUSER_EXTRA_MOUNT_OPTIONS="--auto-unmount --dev" TEST_DEV="$TEST_DATA_DIR" TEST_DIR="$TEST_DIR" SCRATCH_DEV="$SCRATCH_DATA_DIR" SCRATCH_MNT="$SCRATCH_DIR" \
 ./check-fuser -E xfs_excludes.txt "$@" \
 | tee /code/logs/xfstests.log
 


### PR DESCRIPTION
Seven excluded xfstests were recorded under three separate reasons. All three were the same gap, and two of the reasons were wrong.

The suite goes from **715 to 718 passing**.

## The gap was one thing, not three

xfstests gates these behind `_require_mknod`, which creates a **character device**:

```sh
_require_mknod() { mknod $TEST_DIR/$seq.null c 1 3 || _notrun "$FSTYP does not support mknod/mkfifo"; }
```

So "requires fifo support" (423, 434) and "requires mknod on character files" (184, 401) were the same blocker, and generic/294 and 306 - filed under "requires support for mounting read-only" - were skipping here long before they reached anything to do with read-only.

fuser itself was not missing anything: `FileType` already covers all seven types, `MountOption::Dev` already exists, and `RenameFlags` already carries `RENAME_WHITEOUT`. The gap was entirely in the example.

## What changed

- `FileKind` gains `CharDevice`, `BlockDevice`, `NamedPipe` and `Socket`, appended so the ordinals already serialized into directory records keep their meaning
- `mknod` accepts them rather than answering `EPERM`
- `InodeAttributes` gains `rdev`, which `FileAttr` had been reporting as `0` for every file. Only a character or block device stores one
- `as_file_kind` handles the new modes instead of reaching `unimplemented!()`
- New `--dev` flag mapping to `MountOption::Dev`

A fifo, socket or device node holds no data of its own - the kernel services reads and writes without the request ever reaching the filesystem - but each still gets an empty contents file so `unlink` and the garbage collector stay uniform across every kind.

### Why `--dev` is its own flag

Creating a device node is not enough to open one: FUSE mounts are `nodev` by default, so generic/184 and 434 still failed with `Permission denied` until the mount allowed it. I first hung this off `--suid`, but the two guard different things, so it is a separate flag, off by default as it is for any other filesystem - a device node the mount's own users can create is a route to hardware the kernel would not otherwise permit. The xfstests run opts in through `FUSER_EXTRA_MOUNT_OPTIONS`, which the harness already forwards as CLI arguments, so no change is needed in fuse-xfstests.

## Exclusion list

**Re-enabled:** generic/184, 401, 434 (all under 1s).

The other four now run rather than skip, and their entries record what actually stops them:

| test | real blocker |
|---|---|
| `078` | `renameat2(RENAME_WHITEOUT)`, which must leave a 0/0 character device at the source. Was filed as "character file support" |
| `423` | ctime and mtime come from separate `time_now()` calls, so statx sees `ctime.nsec` older than the mtime set moments earlier in the same operation |
| `294`, `306`, `452` | read-only remount. 306 and 452 additionally need a change in fuse-xfstests, whose `_scratch_remount` answers "fuse.fuser does not support any options" without attempting it; 294 goes through `_try_scratch_mount` and does attempt it |

Each of those is now a self-contained follow-up. The ctime/mtime one is a real bug independent of this change.

## Compatibility note

The inode record gains a field and `rmp_serde` encodes structs as compact arrays, so a data directory written by an earlier build cannot be read back and has to be recreated. Directory records are unaffected, which is why the new `FileKind` variants are appended rather than inserted.

## Testing

- Full xfstests: **passed all 718**, 1424s, no regressions
- pjdfstest: **PASS**, 205 files / 2732 tests, 0 failed - relevant here, since it exercises `mknod` directly and character device creation now succeeds where it returned `EPERM`
- `cargo clippy --all-targets` clean under `--deny warnings` (`--all-features` needs libfuse3 headers not present in this environment)
- Verified the three re-enabled tests pass through the real harness, not just a hand-rolled mount, to confirm `--dev` reaches the mount via `FUSER_EXTRA_MOUNT_OPTIONS`

## Not in scope

`generic/394` is worth a separate mention: its assertion already passes, and the only diff is its cleanup line `ulimit -f unlimited` failing to restore the limit, which needs `CAP_SYS_RESOURCE`. Adding `--cap-add SYS_RESOURCE` to the Makefile would likely enable it, but this environment cannot grant that capability to a container, so I could not verify the fix and have left it alone. Its recorded reason - "requires ulimit support for limiting file size" - is wrong either way.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSmtYYZ3resRdsCD1PwqUK)_