### PR TITLE
Test that a panic in init() leaves nothing mounted

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -785,6 +785,46 @@ mod test {
         ManuallyDrop::into_inner(tmp);
     }
 
+    /// A panic in init() must reach the caller with the filesystem unmounted. The
+    /// handshake used to run inside the session loop, so with spawn() the caller was
+    /// handed a live BackgroundSession while the kernel waited forever for an init
+    /// reply that would never come, hanging every process that touched the mountpoint
+    /// (issue #271). Running the handshake in Session::new() makes the panic unwind
+    /// through it, unmounting on the way out.
+    #[test]
+    fn panic_in_init_leaves_nothing_mounted() {
+        struct PanicInInit;
+        impl Filesystem for PanicInInit {
+            fn init(&mut self, _req: &Request, _config: &mut KernelConfig) -> io::Result<()> {
+                panic!("deliberate panic from a test filesystem's init()");
+            }
+        }
+
+        // Leak the directory on failure: it may still be a mountpoint nothing serves
+        let tmp = ManuallyDrop::new(tempfile::tempdir().unwrap());
+        // The mount table lists the canonical path
+        let mountpoint = tmp.path().canonicalize().unwrap();
+
+        let session = std::panic::catch_unwind(|| {
+            Session::new(PanicInInit, &mountpoint, &Config::default()).and_then(Session::spawn)
+        });
+        assert!(
+            session.is_err(),
+            "the panic must reach the caller, rather than a session thread it cannot see"
+        );
+
+        // Anything left mounted here has nothing serving it, so every access to the
+        // mountpoint would block indefinitely
+        let mounts = std::fs::read_to_string("/proc/self/mounts").unwrap();
+        assert!(
+            !mounts
+                .lines()
+                .any(|line| line.split(' ').nth(1) == mountpoint.to_str()),
+            "the filesystem must not be left mounted with nothing serving it:\n{mounts}"
+        );
+        ManuallyDrop::into_inner(tmp);
+    }
+
     /// Dropping a BackgroundSession must unmount the filesystem and wait for the
     /// session to end, so that Filesystem::destroy has run when drop returns.
     #[test]


### PR DESCRIPTION
Fixes #271.

The behaviour this issue reported is already fixed, but incidentally and with nothing guarding it. This adds the regression test.

## What was broken

`handshake()` -- which calls `Filesystem::init` -- used to run inside the session loop. With `spawn()`, that loop is on the background thread, so `spawn_mount`/`Session::spawn` returned `Ok` and the caller was handed a live `BackgroundSession`. That kept the mount and the `/dev/fuse` fd alive while the kernel waited forever for an init reply that would never come, so every process touching the mountpoint blocked indefinitely -- symptoms 1 and 2 in the issue.

## What fixed it

`9a47847` ("Move handshake into Session::new"), released in v0.17.0. The commit was about API design and does not mention this issue, but it is what fixed it: `init` now runs on the caller's thread before any session exists, so a panic unwinds straight out of `Session::new`, dropping the `Session` and with it `UmountOnDrop`, and the mount is torn down on the way out.

## Verification

A probe that panics in `init`, mounts via `spawn`, keeps the handle alive as a real program would, and then has another process `ls` the mountpoint.

At `9a47847^`:

```
SPAWN: returned Ok, background session alive
thread 'fuser-bg' panicked at: boom
LS exit=Some(124)        <- ls hung until timeout killed it
```

The test process itself then hung too, and the mount was left behind. At `9a47847` and on master:

```
thread '...' panicked at: boom
SPAWN: panicked on the caller's thread
LS exit=Some(0)
```

Mount torn down, mountpoint a plain directory again, process exits normally.

Two notes on scope. The blocking `mount()`/`mount2()` path was never affected on Linux -- I checked v0.14.0, tagged a month before the issue was filed, and the panic already propagated with the mount cleaned up; only the `spawn` path reproduced. And the reporter was on macFUSE and also saw system-wide hangs; the same root cause and fix should apply, but I have no macOS machine, so that part is reasoning rather than measurement.

## The test

`session::test::panic_in_init_leaves_nothing_mounted` asserts both halves: the panic reaches the caller, and nothing is left in the mount table. Anything left mounted there has nothing serving it, which is precisely the hang.

Confirmed it fails at `9a47847^` with `the panic must reach the caller, rather than a session thread it cannot see`, and that it fails fast (exit 101) rather than blocking CI. The panic backtrace is captured by the test harness, so it only appears in the output when the test fails. Test-only change, so no CHANGELOG entry.

`cargo fmt`, all three `clippy` invocations from `make pre`, and `cargo test --all` with and without `libfuse` are green. Docker was unavailable in my environment, so `mount_tests`/`pjdfs_tests`/`xfstests` did not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5akmePV1VnD9YRQLZH4gv

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5akmePV1VnD9YRQLZH4gv)_