### PR TITLE
Take ctime and mtime from one clock reading in the simple example

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -573,9 +573,10 @@ impl SimpleFS {
         let file = OpenOptions::new().write(true).open(path).unwrap();
         file.set_len(new_length).unwrap();
 
+        let now = time_now();
         attrs.size = new_length;
-        attrs.last_metadata_changed = time_now();
-        attrs.last_modified = time_now();
+        attrs.last_metadata_changed = now;
+        attrs.last_modified = now;
 
         // Clear SETUID & SETGID on truncate, but only when the kernel asks: under killpriv v2
         // it does so exactly when the caller lacks CAP_FSETID
@@ -621,8 +622,9 @@ impl SimpleFS {
         ) {
             return Err(Errno::EACCES);
         }
-        parent_attrs.last_modified = time_now();
-        parent_attrs.last_metadata_changed = time_now();
+        let now = time_now();
+        parent_attrs.last_modified = now;
+        parent_attrs.last_metadata_changed = now;
         self.write_inode(&parent_attrs);
 
         let mut entries = self.get_directory_content(parent).unwrap();
@@ -655,13 +657,14 @@ impl Filesystem for SimpleFS {
         fs::create_dir_all(Path::new(&self.data_dir).join("contents")).unwrap();
         if self.get_inode(INodeNo::ROOT).is_err() {
             // Initialize with empty filesystem
+            let now = time_now();
             let root = InodeAttributes {
                 inode: INodeNo::ROOT.0,
                 open_file_handles: 0,
                 size: 0,
-                last_accessed: time_now(),
-                last_modified: time_now(),
-                last_metadata_changed: time_now(),
+                last_accessed: now,
+                last_modified: now,
+                last_metadata_changed: now,
                 kind: FileKind::Directory,
                 mode: 0o777,
                 hardlinks: 2,
@@ -974,8 +977,9 @@ impl Filesystem for SimpleFS {
             reply.error(Errno::EACCES);
             return;
         }
-        parent_attrs.last_modified = time_now();
-        parent_attrs.last_metadata_changed = time_now();
+        let now = time_now();
+        parent_attrs.last_modified = now;
+        parent_attrs.last_metadata_changed = now;
         self.write_inode(&parent_attrs);
 
         if _req.uid() != 0 {
@@ -1000,9 +1004,9 @@ impl Filesystem for SimpleFS {
             inode: inode.0,
             open_file_handles: 0,
             size: 0,
-            last_accessed: time_now(),
-            last_modified: time_now(),
-            last_metadata_changed: time_now(),
+            last_accessed: now,
+            last_modified: now,
+            last_metadata_changed: now,
             kind: as_file_kind(mode),
             mode: self.creation_mode(mode),
             hardlinks: 1,
@@ -1070,8 +1074,9 @@ impl Filesystem for SimpleFS {
             reply.error(Errno::EACCES);
             return;
         }
-        parent_attrs.last_modified = time_now();
-        parent_attrs.last_metadata_changed = time_now();
+        let now = time_now();
+        parent_attrs.last_modified = now;
+        parent_attrs.last_metadata_changed = now;
         self.write_inode(&parent_attrs);
 
         if _req.uid() != 0 {
@@ -1086,9 +1091,9 @@ impl Filesystem for SimpleFS {
             inode: inode.0,
             open_file_handles: 0,
             size: u64::from(BLOCK_SIZE),
-            last_accessed: time_now(),
-            last_modified: time_now(),
-            last_metadata_changed: time_now(),
+            last_accessed: now,
+            last_modified: now,
+            last_metadata_changed: now,
             kind: FileKind::Directory,
             mode: self.creation_mode(mode),
             hardlinks: 2, // Directories start with link count of 2, since they have a self link
@@ -1152,12 +1157,13 @@ impl Filesystem for SimpleFS {
             return;
         }
 
-        parent_attrs.last_metadata_changed = time_now();
-        parent_attrs.last_modified = time_now();
+        let now = time_now();
+        parent_attrs.last_metadata_changed = now;
+        parent_attrs.last_modified = now;
         self.write_inode(&parent_attrs);
 
         attrs.hardlinks -= 1;
-        attrs.last_metadata_changed = time_now();
+        attrs.last_metadata_changed = now;
         self.write_inode(&attrs);
         self.gc_inode(&attrs);
 
@@ -1218,12 +1224,13 @@ impl Filesystem for SimpleFS {
             return;
         }
 
-        parent_attrs.last_metadata_changed = time_now();
-        parent_attrs.last_modified = time_now();
+        let now = time_now();
+        parent_attrs.last_metadata_changed = now;
+        parent_attrs.last_modified = now;
         self.write_inode(&parent_attrs);
 
         attrs.hardlinks = 0;
-        attrs.last_metadata_changed = time_now();
+        attrs.last_metadata_changed = now;
         self.write_inode(&attrs);
         self.gc_inode(&attrs);
 
@@ -1262,8 +1269,9 @@ impl Filesystem for SimpleFS {
             reply.error(Errno::EACCES);
             return;
         }
-        parent_attrs.last_modified = time_now();
-        parent_attrs.last_metadata_changed = time_now();
+        let now = time_now();
+        parent_attrs.last_modified = now;
+        parent_attrs.last_metadata_changed = now;
         self.write_inode(&parent_attrs);
 
         let inode = self.allocate_next_inode();
@@ -1271,9 +1279,9 @@ impl Filesystem for SimpleFS {
             inode: inode.0,
             open_file_handles: 0,
             size: target.as_os_str().as_bytes().len() as u64,
-            last_accessed: time_now(),
-            last_modified: time_now(),
-            last_metadata_changed: time_now(),
+            last_accessed: now,
+            last_modified: now,
+            last_metadata_changed: now,
             kind: FileKind::Symlink,
             mode: 0o777,
             hardlinks: 1,
@@ -1433,15 +1441,16 @@ impl Filesystem for SimpleFS {
             );
             self.write_directory_content(parent, &entries);
 
-            parent_attrs.last_metadata_changed = time_now();
-            parent_attrs.last_modified = time_now();
+            let now = time_now();
+            parent_attrs.last_metadata_changed = now;
+            parent_attrs.last_modified = now;
             self.write_inode(&parent_attrs);
-            new_parent_attrs.last_metadata_changed = time_now();
-            new_parent_attrs.last_modified = time_now();
+            new_parent_attrs.last_metadata_changed = now;
+            new_parent_attrs.last_modified = now;
             self.write_inode(&new_parent_attrs);
-            inode_attrs.last_metadata_changed = time_now();
+            inode_attrs.last_metadata_changed = now;
             self.write_inode(&inode_attrs);
-            new_inode_attrs.last_metadata_changed = time_now();
+            new_inode_attrs.last_metadata_changed = now;
             self.write_inode(&new_inode_attrs);
 
             if inode_attrs.kind == FileKind::Directory {
@@ -1499,6 +1508,8 @@ impl Filesystem for SimpleFS {
             return;
         }
 
+        let now = time_now();
+
         // If target already exists decrement its hardlink count
         if let Ok(mut existing_inode_attrs) = self.lookup_name(newparent, newname) {
             let mut entries = self.get_directory_content(newparent).unwrap();
@@ -1510,7 +1521,7 @@ impl Filesystem for SimpleFS {
             } else {
                 existing_inode_attrs.hardlinks -= 1;
             }
-            existing_inode_attrs.last_metadata_changed = time_now();
+            existing_inode_attrs.last_metadata_changed = now;
             self.write_inode(&existing_inode_attrs);
             self.gc_inode(&existing_inode_attrs);
         }
@@ -1526,13 +1537,13 @@ impl Filesystem for SimpleFS {
         );
         self.write_directory_content(newparent, &entries);
 
-        parent_attrs.last_metadata_changed = time_now();
-        parent_attrs.last_modified = time_now();
+        parent_attrs.last_metadata_changed = now;
+        parent_attrs.last_modified = now;
         self.write_inode(&parent_attrs);
-        new_parent_attrs.last_metadata_changed = time_now();
-        new_parent_attrs.last_modified = time_now();
+        new_parent_attrs.last_metadata_changed = now;
+        new_parent_attrs.last_modified = now;
         self.write_inode(&new_parent_attrs);
-        inode_attrs.last_metadata_changed = time_now();
+        inode_attrs.last_metadata_changed = now;
         self.write_inode(&inode_attrs);
 
         if inode_attrs.kind == FileKind::Directory {
@@ -1711,8 +1722,9 @@ impl Filesystem for SimpleFS {
                         return;
                     }
                 };
-                attrs.last_metadata_changed = time_now();
-                attrs.last_modified = time_now();
+                let now = time_now();
+                attrs.last_metadata_changed = now;
+                attrs.last_modified = now;
                 if end_offset > attrs.size as usize {
                     attrs.size = end_offset as u64;
                 }
@@ -2020,8 +2032,9 @@ impl Filesystem for SimpleFS {
             reply.error(Errno::EACCES);
             return;
         }
-        parent_attrs.last_modified = time_now();
-        parent_attrs.last_metadata_changed = time_now();
+        let now = time_now();
+        parent_attrs.last_modified = now;
+        parent_attrs.last_metadata_changed = now;
         self.write_inode(&parent_attrs);
 
         if req.uid() != 0 {
@@ -2046,9 +2059,9 @@ impl Filesystem for SimpleFS {
             inode: inode.0,
             open_file_handles: 1,
             size: 0,
-            last_accessed: time_now(),
-            last_modified: time_now(),
-            last_metadata_changed: time_now(),
+            last_accessed: now,
+            last_modified: now,
+            last_metadata_changed: now,
             kind: as_file_kind(mode),
             mode: self.creation_mode(mode),
             hardlinks: 1,
@@ -2107,8 +2120,9 @@ impl Filesystem for SimpleFS {
                 let mut attrs = self.get_inode(ino).unwrap();
                 // Every fallocate mode changes the file, so the times move even when the size
                 // is pinned: a punch-hole rewrites content, and preallocation commits blocks
-                attrs.last_metadata_changed = time_now();
-                attrs.last_modified = time_now();
+                let now = time_now();
+                attrs.last_metadata_changed = now;
+                attrs.last_modified = now;
                 if mode & libc::FALLOC_FL_KEEP_SIZE == 0 && offset + length > attrs.size {
                     attrs.size = (offset + length) as u64;
                 }
@@ -2166,8 +2180,9 @@ impl Filesystem for SimpleFS {
                         file.write_all(&data).unwrap();
 
                         let mut attrs = self.get_inode(dest_inode).unwrap();
-                        attrs.last_metadata_changed = time_now();
-                        attrs.last_modified = time_now();
+                        let now = time_now();
+                        attrs.last_metadata_changed = now;
+                        attrs.last_modified = now;
                         let Ok(dest_offset_usize): Result<usize, _> = dest_offset.try_into() else {
                             reply.error(Errno::EFBIG);
                             return;

--- a/xfstests.sh
+++ b/xfstests.sh
@@ -47,11 +47,6 @@ echo "generic/127" >> xfs_excludes.txt
 # TODO: requires more complete falloc support. Also fills up the entire hard disk...
 echo "generic/103" >> xfs_excludes.txt
 
-# TODO: requires ctime and mtime to be set from a single clock reading. The example takes
-# them from separate time_now() calls, so statx can see a ctime older than the mtime set
-# moments earlier in the same operation
-echo "generic/423" >> xfs_excludes.txt
-
 # TODO: requires ulimit support for limiting file size
 echo "generic/394" >> xfs_excludes.txt
 


### PR DESCRIPTION
Every timestamp field got its own `time_now()`, so two fields set a few lines apart in the same operation landed on different instants. Where ctime was assigned before mtime, the file ended up with a ctime **older** than its mtime - a state a local filesystem never produces. statx catches it:

```
[!] ctime.nsec is before mtime.nsec (102594528 < 102594591)
```

Anything comparing the two, from backup tools to make-style staleness checks, can draw the wrong conclusion. The window is small but it is hit reliably: generic/423 failed on it every run.

Found while reviewing what was left in the exclusion list after #732 - it had been misfiled there as "requires fifo support", since the test skipped on `_require_mknod` long before reaching the statx check.

## The change

Each operation now takes one reading and uses it for every field it touches. Applied across 14 operations: truncate, write, fallocate, copy_file_range, mknod, mkdir, symlink, create, unlink, rmdir, both rename paths, insert_link, and root inode initialization. That takes 58 `time_now()` calls down to 21.

Two things worth pointing out:

- Where an operation changes both a parent directory and a child inode - mknod, mkdir, symlink, create, unlink, rmdir, rename - the single reading spans both, so the parent's mtime and the child's ctime agree rather than differing by microseconds. They are one operation and should look like one.
- The five sites still calling `time_now()` directly (chmod, chown, link, setxattr, removexattr) each set `last_metadata_changed` alone. With one field there is no ordering to get wrong, so hoisting a binding there would be churn.

The two rename paths take separate readings because they are mutually exclusive branches, not because they are separate operations.

## Testing

- Full xfstests: **passed all 719**, up from 718, 1025s, no regressions
- pjdfstest: **PASS**, 205 files / 2732 tests, 0 failed - relevant here, since it checks timestamp updates across most operations
- generic/423 re-enabled and passing
- `cargo clippy --all-targets` clean under `--deny warnings` (`--all-features` needs libfuse3 headers not present in this environment)

## Remaining in the exclusion list

For anyone tracking what is left after this: generic/078 needs `renameat2(RENAME_WHITEOUT)`, which became implementable once #732 added `CharDevice` - the flag has to leave a 0/0 device at the source, and fuser already passes it through as `RenameFlags`. generic/003 and 192 need atime. generic/394's assertion already passes and only its cleanup fails, needing `CAP_SYS_RESOURCE` on the test container.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSmtYYZ3resRdsCD1PwqUK)_