### PR TITLE
Keep auto_unmount without a fusermount helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,15 @@ jobs:
         if: steps.rust-cache.outputs.cache-hit != 'true'
         run: |
           rustup target add x86_64-unknown-linux-musl
+          rustup target add aarch64-linux-android
 
       - name: Run tests
         run: |
           cargo build --all --all-targets --features=libfuse,${{ matrix.features }}
           cargo build --all --all-targets --features=${{ matrix.features }}
           cargo build --target=x86_64-unknown-linux-musl
+          # No Android runner to test on, but the pure Rust mount path must keep building
+          cargo check --target=aarch64-linux-android
           cargo test --all --features=libfuse,${{ matrix.features }}
           cargo test --all --features=${{ matrix.features }}
           cargo doc --all --no-deps --features=${{ matrix.features }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # FUSE for Rust - Changelog
 
 ## Unreleased
+* `MountOption::AutoUnmount` now works on systems that ship no `fusermount` helper (#283).
+  Unmounting once the mounting process is gone takes something that outlives it, which was
+  always left to that helper; where there is none, fuser forks a watcher of its own, which
+  works wherever the process may mount directly. Where neither is available the mount now
+  fails naming `auto_unmount` as what needed them, rather than only reporting a missing
+  helper - which said nothing about mounting without the option being fine
+* Android now selects the pure Rust mount implementation, as the other Linux targets do.
+  Building for Android without the `libfuse` feature previously failed outright, because the
+  build script fell through to searching for libfuse. This is what makes the `auto_unmount`
+  change above reach the platform it was reported from
 * Unmounting from within the mounting process now works with `MountOption::AutoUnmount` (#407).
   Dropping the `BackgroundSession`, calling `umount_and_join()` or `SessionUnmounter::unmount()`
   used to leave the unmount to the `fusermount` helper, which only acts once the process exits.

--- a/build.rs
+++ b/build.rs
@@ -9,7 +9,7 @@ fn main() {
 
     if matches!(
         target_os.as_str(),
-        "linux" | "freebsd" | "dragonfly" | "openbsd" | "netbsd"
+        "linux" | "android" | "freebsd" | "dragonfly" | "openbsd" | "netbsd"
     ) && cfg!(not(feature = "libfuse"))
     {
         println!("cargo::rustc-cfg=fuser_mount_impl=\"pure-rust\"");

--- a/fuser-tests/src/commands/mount.rs
+++ b/fuser-tests/src/commands/mount.rs
@@ -21,6 +21,7 @@ use crate::features::features_to_flags;
 use crate::fuse_conf::fuse_conf_remove_user_allow_other;
 use crate::fuse_conf::fuse_conf_write_user_allow_other;
 use crate::fusermount::Fusermount;
+use crate::hidden_fusermount::HiddenFusermount;
 use crate::libfuse::Libfuse;
 use crate::mount_util::assert_no_fuse_mount;
 use crate::mount_util::wait_for_fuse_mount;
@@ -43,6 +44,7 @@ async fn run_mount_tests_inner(libfuse: Libfuse) -> anyhow::Result<()> {
     run_test(&[], Unmount::Manual, Fusermount::False, 1, false).await?;
     run_test(&[], Unmount::Auto, libfuse.fusermount(), 1, false).await?;
     test_no_user_allow_other(&[], &libfuse).await?;
+    test_auto_unmount_without_helper().await?;
 
     // Tests with libfuse
     run_test(
@@ -213,6 +215,48 @@ async fn run_test_inner(
     kill_and_unmount(fuse_process, unmount, mount_path_str).await?;
 
     green!("OK {description}");
+
+    Ok(())
+}
+
+/// Without a mount helper there is nothing to keep watch for auto_unmount, so fuser forks
+/// a watcher of its own, which only a process that may mount directly can do (issue #283).
+/// Hiding the helper is what takes fuser down that path.
+async fn test_auto_unmount_without_helper() -> anyhow::Result<()> {
+    eprintln!("\n=== Running test_auto_unmount_without_helper ===");
+
+    // Restored when this is dropped, including when a step below fails
+    let _hidden = HiddenFusermount::hide().await?;
+
+    let mount_dir = CanonicalTempDir::new()?;
+    let mount_path = mount_dir.path();
+    eprintln!("Mount dir: {}", mount_path.display());
+
+    // The watcher lives in the pure Rust mount implementation, so no libfuse feature
+    let hello_exe = cargo_build_example("hello", &[]).await?;
+    let fuse_process = Command::new(&hello_exe)
+        .arg(mount_path)
+        .arg("--auto-unmount")
+        // An override would give fuser a helper again, defeating the test
+        .env_remove(Fusermount::ENV_VAR)
+        .kill_on_drop(true)
+        .spawn()
+        .context("Failed to start hello example")?;
+
+    wait_for_fuse_mount(mount_path).await?;
+
+    let content = tokio::fs::read_to_string(mount_path.join("hello.txt"))
+        .await
+        .context("Failed to read hello.txt")?;
+    if content != "Hello World!\n" {
+        bail!("hello.txt content mismatch: expected 'Hello World!', got '{content}'");
+    }
+
+    // Killing the filesystem outright is what auto_unmount is for: nothing gets the
+    // chance to unmount by hand, so only the watcher can clean the mountpoint up
+    kill_and_unmount(fuse_process, Unmount::Auto, mount_path.to_str().unwrap()).await?;
+
+    green!("OK auto_unmount without a mount helper");
 
     Ok(())
 }

--- a/fuser-tests/src/hidden_fusermount.rs
+++ b/fuser-tests/src/hidden_fusermount.rs
@@ -1,0 +1,60 @@
+//! Hiding the FUSE mount helpers, to test what fuser does without them
+
+use std::path::PathBuf;
+
+use anyhow::Context;
+use tokio::fs;
+
+/// Renames every mount helper out of the way for as long as it is held, so that fuser
+/// finds none. The helpers `detect_fusermount_bin()` looks for are either bare names it
+/// resolves through PATH or paths under /sbin and /bin, and both of those are symlinks
+/// into /usr on the distributions the tests run on, so renaming the files below covers
+/// every candidate.
+pub(crate) struct HiddenFusermount {
+    /// Where each helper was moved from, and to
+    hidden: Vec<(PathBuf, PathBuf)>,
+}
+
+impl HiddenFusermount {
+    const HELPERS: [&'static str; 4] = [
+        "/usr/bin/fusermount3",
+        "/usr/bin/fusermount",
+        "/usr/sbin/fusermount3",
+        "/usr/sbin/fusermount",
+    ];
+
+    pub(crate) async fn hide() -> anyhow::Result<Self> {
+        let mut hidden = Vec::new();
+        for helper in Self::HELPERS {
+            let from = PathBuf::from(helper);
+            // Not following symlinks: one helper is usually a symlink to the other, and
+            // leaving it behind pointing at a renamed target would be enough to fail the
+            // test for the wrong reason
+            if fs::symlink_metadata(&from).await.is_err() {
+                continue;
+            }
+            let to = from.with_extension("hidden");
+            fs::rename(&from, &to)
+                .await
+                .context(format!("Failed to rename {}", from.display()))?;
+            hidden.push((from, to));
+        }
+        anyhow::ensure!(
+            !hidden.is_empty(),
+            "No FUSE mount helper found to hide, so the test would prove nothing"
+        );
+        Ok(Self { hidden })
+    }
+}
+
+impl Drop for HiddenFusermount {
+    fn drop(&mut self) {
+        // Every later test needs the helpers back, so report a failure to restore them
+        // rather than letting it show up as an unrelated test failing
+        for (from, to) in &self.hidden {
+            if let Err(err) = std::fs::rename(to, from) {
+                eprintln!("Failed to restore {}: {err}", from.display());
+            }
+        }
+    }
+}

--- a/fuser-tests/src/main.rs
+++ b/fuser-tests/src/main.rs
@@ -9,6 +9,7 @@ mod experimental;
 mod features;
 mod fuse_conf;
 mod fusermount;
+mod hidden_fusermount;
 mod libfuse;
 mod mount_util;
 mod unmount;

--- a/src/ll/mod.rs
+++ b/src/ll/mod.rs
@@ -231,17 +231,19 @@ impl Errno {
     pub const EFTYPE: Errno = errno!(libc::EFTYPE);
 
     /// No data available
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const ENODATA: Errno = errno!(libc::ENODATA);
     #[doc = no_xattr_doc!()]
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub const NO_XATTR: Errno = Self::ENODATA;
 
     /// Attribute not found
-    #[cfg(not(target_os = "linux"))]
+    // Android has no ENOATTR of its own: libc deprecates it there in favour of ENODATA,
+    // which is the same value, so it follows Linux above
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     pub const ENOATTR: Errno = errno!(libc::ENOATTR);
     #[doc = no_xattr_doc!()]
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     pub const NO_XATTR: Errno = Self::ENOATTR;
 
     /// Make errno from `i32`, defaulting to `EIO` if it is not positive.

--- a/src/mnt/fuse_pure.rs
+++ b/src/mnt/fuse_pure.rs
@@ -25,6 +25,7 @@ use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::process::Command;
 use std::process::Stdio;
+use std::ptr;
 use std::sync::Arc;
 
 use log::debug;
@@ -107,14 +108,13 @@ fn fuse_mount_pure(
     acl: SessionACL,
 ) -> Result<(DevFuse, Option<UnixStream>), io::Error> {
     if options.contains(&MountOption::AutoUnmount) {
-        // Auto unmount is only supported via fusermount
-        return fuse_mount_fusermount(mountpoint, options, acl);
+        return fuse_mount_auto_unmount(mountpoint, options, acl);
     }
 
     // The direct mount path is currently implemented only for Linux and macOS.
     // Other supported Unix targets (such as the BSDs) rely on the setuid
     // mount helper, which mirrors libfuse's approach.
-    if cfg!(target_os = "linux") || cfg!(target_os = "macos") {
+    if cfg!(any(target_os = "linux", target_os = "android")) || cfg!(target_os = "macos") {
         let res = fuse_mount_sys(mountpoint, options, acl)?;
         match res {
             Some(file) => return Ok((file, None)),
@@ -124,7 +124,218 @@ fn fuse_mount_pure(
         }
     }
 
-    fuse_mount_fusermount(mountpoint, options, acl)
+    fuse_mount_fusermount(&detect_fusermount_bin()?, mountpoint, options, acl)
+}
+
+/// `auto_unmount` needs something that outlives this process to do the unmount, which is
+/// normally the fusermount helper: it keeps running holding the other end of a socket, and
+/// unmounts once this process has let go of it. Systems that ship no FUSE userspace at all
+/// have no such helper (issue #283), so where this process may mount by itself, keep that
+/// watch here instead.
+fn fuse_mount_auto_unmount(
+    mountpoint: &OsStr,
+    options: &[MountOption],
+    acl: SessionACL,
+) -> Result<(DevFuse, Option<UnixStream>), Error> {
+    // Naming the option matters: mounting without it may well work, and nothing else
+    // says that the helper was needed only because auto_unmount asked for it
+    let no_helper = match detect_fusermount_bin() {
+        Ok(fusermount_bin) => {
+            return fuse_mount_fusermount(&fusermount_bin, mountpoint, options, acl)
+                .map_err(|err| crate::mnt::context("mounting with auto_unmount", err));
+        }
+        Err(err) => err,
+    };
+
+    // Unmounting takes the same privilege as mounting by hand does, so wherever this
+    // succeeds the watcher can finish the job
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        let (watcher_socket, session_socket) = UnixStream::pair()?;
+        // Fork before the FUSE device is opened, so that the watcher never holds it: a
+        // live device descriptor keeps the connection alive after this process is gone,
+        // leaving every access to the mountpoint blocked rather than failing
+        spawn_unmount_watcher(mountpoint, &watcher_socket, &session_socket)?;
+        if let Some(file) = fuse_mount_sys(mountpoint, options, acl)? {
+            return Ok((file, Some(session_socket)));
+        }
+        // Unprivileged, so dropping the socket ends the watcher, which then finds the
+        // mountpoint unmounted and leaves it alone
+    }
+
+    Err(crate::mnt::context(
+        "mounting with auto_unmount, which needs either a FUSE mount helper or the \
+         privilege to mount directly",
+        no_helper,
+    ))
+}
+
+/// Fork a watcher that unmounts `mountpoint` once `socket` reaches EOF, which is once
+/// every copy of the session's end is closed - including by this process dying, which is
+/// what `auto_unmount` is for.
+///
+/// Unlike the setuid fusermount helper, the watcher keeps this process's credentials, so
+/// it can always tell an unserved mount of its own from one it may not look at. That
+/// distinction is what fusermount needs `allow_other` for.
+///
+/// Forks twice, so that the watcher is init's child rather than this process's: nothing
+/// here would ever reap it, and a caller reaping its own children must not find one it
+/// never started.
+///
+/// The watcher reports itself over a pipe rather than through an exit status, because a
+/// caller that reaps its own children takes that status first and leaves nothing to read.
+/// A mount whose watcher silently failed to start is one that outlives the process that
+/// asked for it to be unmounted, so this has to be known rather than assumed.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn spawn_unmount_watcher(
+    mountpoint: &OsStr,
+    socket: &UnixStream,
+    session_socket: &UnixStream,
+) -> io::Result<()> {
+    // Everything the watcher touches has to be ready before the fork, because only
+    // async-signal-safe work is allowed afterwards, and that rules out allocating
+    let mountpoint = CString::new(mountpoint.as_bytes())?;
+    let socket_fd = socket.as_raw_fd();
+    // The watcher inherits this end too, and holding the only other writer would keep it
+    // from ever reaching EOF, so it closes this before anything else
+    let session_fd = session_socket.as_raw_fd();
+    let (started_read, started_write) = nix::unistd::pipe2(OFlag::O_CLOEXEC)?;
+    let started_write_fd = started_write.as_raw_fd();
+
+    match unsafe { nix::unistd::fork() }? {
+        nix::unistd::ForkResult::Child => match unsafe { nix::unistd::fork() } {
+            Ok(nix::unistd::ForkResult::Child) => {
+                unmount_watcher(&mountpoint, socket_fd, session_fd, started_write_fd)
+            }
+            // Whether or not there is a watcher, this exit closes the copy of the pipe
+            // that came with the fork, and orphans any watcher onto init
+            Ok(nix::unistd::ForkResult::Parent { .. }) | Err(_) => unsafe { libc::_exit(0) },
+        },
+        nix::unistd::ForkResult::Parent { child } => {
+            // Leaves the watcher as the only writer, so that the read below ends either
+            // with its byte or, if there is no watcher, with end of file
+            drop(started_write);
+            // The intermediate exits as soon as it has forked. Its status says nothing
+            // reliable, but it still has to be reaped by someone, and a caller reaping
+            // children of its own may have taken it already
+            while let Err(nix::errno::Errno::EINTR) = nix::sys::wait::waitpid(child, None) {}
+
+            // A signal handler the caller installed without SA_RESTART interrupts this
+            // read, which says nothing about whether there is a watcher
+            let mut started = [0u8; 1];
+            let started = loop {
+                match nix::unistd::read(&started_read, &mut started) {
+                    Ok(read) => break read == 1,
+                    Err(nix::errno::Errno::EINTR) => continue,
+                    Err(_) => break false,
+                }
+            };
+            if started {
+                Ok(())
+            } else {
+                Err(Error::other(
+                    "auto_unmount: failed to fork a watcher to unmount the filesystem",
+                ))
+            }
+        }
+    }
+}
+
+/// Close everything the watcher inherited except `keep` and stdio.
+///
+/// This is not tidiness: the watcher outlives the process it was forked from, so a FUSE
+/// device it holds for some other mount of that process keeps that mount's connection
+/// alive with nothing left to serve it, and every access to it blocks rather than
+/// failing. `close_range()` does it in one call, but it needs Linux 5.9, which the
+/// systems without a mount helper are the least likely to have, so fall back to closing
+/// them one at a time as libfuse does.
+///
+/// Runs in a forked child: async-signal-safe calls only.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn close_inherited_fds(keep: RawFd) {
+    /// Bounds the fallback when the descriptor limit is unset or absurd. Well above any
+    /// real one, and the sweep only ever runs once
+    const MAX_SWEPT_FD: RawFd = 1 << 20;
+
+    unsafe {
+        let above = libc::syscall(
+            libc::SYS_close_range,
+            keep as libc::c_uint + 1,
+            libc::c_uint::MAX,
+            0,
+        ) == 0;
+        let below = keep <= libc::STDERR_FILENO + 1
+            || libc::syscall(
+                libc::SYS_close_range,
+                libc::STDERR_FILENO as libc::c_uint + 1,
+                keep as libc::c_uint - 1,
+                0,
+            ) == 0;
+        if above && below {
+            return;
+        }
+
+        // rlim_cur is not the same width on every target, and may be RLIM_INFINITY
+        let mut limit: libc::rlimit = mem::zeroed();
+        let last = if libc::getrlimit(libc::RLIMIT_NOFILE, &mut limit) == 0 {
+            RawFd::try_from(limit.rlim_cur).unwrap_or(MAX_SWEPT_FD)
+        } else {
+            MAX_SWEPT_FD
+        }
+        .min(MAX_SWEPT_FD);
+        for fd in (libc::STDERR_FILENO + 1)..last {
+            if fd != keep {
+                libc::close(fd);
+            }
+        }
+    }
+}
+
+/// Runs in a forked child, so every call it makes must be async-signal-safe: no
+/// allocation, and no way to report an error even if one occurs.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn unmount_watcher(mountpoint: &CStr, socket_fd: RawFd, session_fd: RawFd, started_fd: RawFd) -> ! {
+    unsafe {
+        // Holding the session's end here would keep the read below from ever reaching
+        // EOF. The sweep further down would close it too, but it is bounded by a
+        // descriptor limit that this one descriptor must not depend on
+        libc::close(session_fd);
+
+        // Leave the caller's session and block its signals, so that a Ctrl-C on its
+        // terminal cannot kill the watcher before it has done its job. Blocking them
+        // first also keeps the handshake below from being interrupted
+        libc::setsid();
+        let mut signals: libc::sigset_t = mem::zeroed();
+        libc::sigfillset(&mut signals);
+        libc::sigprocmask(libc::SIG_BLOCK, &signals, ptr::null_mut());
+
+        // Reaching this at all is what the caller is waiting to hear: everything from
+        // here on either cannot fail or does not decide whether there is a watcher. The
+        // sweep below closes the pipe, which is all that is left to do with it
+        libc::write(started_fd, [1u8].as_ptr().cast(), 1);
+
+        close_inherited_fds(socket_fd);
+
+        let mut buf = [0u8; 16];
+        loop {
+            let read = libc::read(socket_fd, buf.as_mut_ptr().cast(), buf.len());
+            if read == 0 || (read < 0 && nix::errno::Errno::last() != nix::errno::Errno::EINTR) {
+                break;
+            }
+        }
+
+        // Unmount only a mountpoint that is still this filesystem and no longer served,
+        // which is exactly when opening it fails with ENOTCONN. A successful open means
+        // it was unmounted already, or that something else has taken the path since, and
+        // unmounting would then take out the wrong filesystem
+        let fd = libc::open(mountpoint.as_ptr(), libc::O_RDONLY | libc::O_CLOEXEC);
+        if fd >= 0 {
+            libc::close(fd);
+        } else if nix::errno::Errno::last() == nix::errno::Errno::ENOTCONN {
+            libc::umount2(mountpoint.as_ptr(), libc::MNT_DETACH);
+        }
+        libc::_exit(0)
+    }
 }
 
 /// Only reached once `libc_umount()` has failed with EPERM, i.e. unprivileged, so
@@ -244,19 +455,18 @@ unsafe fn clear_cloexec_in_pre_exec(command: &mut Command, fd: BorrowedFd<'_>) {
 }
 
 fn fuse_mount_fusermount(
+    fusermount_bin: &str,
     mountpoint: &OsStr,
     options: &[MountOption],
     acl: SessionACL,
 ) -> Result<(DevFuse, Option<UnixStream>), Error> {
-    let fusermount_bin = detect_fusermount_bin()?;
-
     if fusermount_bin.ends_with(MOUNT_FUSEFS_BIN) {
-        return fuse_mount_mount_fusefs(&fusermount_bin, mountpoint, options, acl);
+        return fuse_mount_mount_fusefs(fusermount_bin, mountpoint, options, acl);
     }
 
     let (child_socket, receive_socket) = UnixStream::pair()?;
 
-    let mut builder = Command::new(&fusermount_bin);
+    let mut builder = Command::new(fusermount_bin);
     builder.stdout(Stdio::piped()).stderr(Stdio::piped());
     let mut options_strs: Vec<String> = options.iter().map(option_to_escaped_string).collect();
     options_strs.extend(acl.to_mount_option().map(|s| s.to_owned()));
@@ -372,7 +582,7 @@ fn fuse_mount_mount_fusefs(
 }
 
 // If returned option is none. Then fusermount binary should be tried
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
 fn fuse_mount_sys(
     mountpoint: &OsStr,
     options: &[MountOption],
@@ -385,9 +595,6 @@ fn fuse_mount_sys(
         .metadata()?
         .permissions()
         .mode();
-
-    // Auto unmount requests must be sent to fusermount binary
-    assert!(!options.contains(&MountOption::AutoUnmount));
 
     let file = DevFuse::open()?;
     assert!(
@@ -416,14 +623,14 @@ fn fuse_mount_sys(
         mount_options.push_str(acl_option);
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     let mut flags = nix::mount::MsFlags::empty();
     #[cfg(target_os = "macos")]
     let mut flags = nix::mount::MntFlags::empty();
 
     if !options.contains(&MountOption::Dev) {
         // Default to nodev
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             flags |= nix::mount::MsFlags::MS_NODEV;
         }
@@ -434,7 +641,7 @@ fn fuse_mount_sys(
     }
     if !options.contains(&MountOption::Suid) {
         // Default to nosuid
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             flags |= nix::mount::MsFlags::MS_NOSUID;
         }
@@ -465,7 +672,7 @@ fn fuse_mount_sys(
         source = name;
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     let result = nix::mount::mount(
         Some(source),
         mountpoint,
@@ -488,7 +695,7 @@ fn fuse_mount_sys(
     }
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
 fn fuse_mount_sys(
     _mountpoint: &OsStr,
     _options: &[MountOption],

--- a/src/mnt/mount_options.rs
+++ b/src/mnt/mount_options.rs
@@ -43,7 +43,14 @@ pub enum MountOption {
     /* Parameterless options */
     /// Automatically unmount when the mounting process exits
     ///
-    /// `AutoUnmount` requires `AllowOther` or `AllowRoot`. If `AutoUnmount` is set and neither `Allow...` is set, the FUSE configuration must permit `allow_other`, otherwise mounting will fail.
+    /// Unmounting once that process is gone takes something that outlives it: normally the
+    /// `fusermount` helper, or, on systems that ship no FUSE userspace, a watcher fuser
+    /// forks itself, which takes the privilege to mount directly. With neither available
+    /// the mount fails, rather than quietly not honouring the option.
+    ///
+    /// Requires a [`SessionACL`](crate::SessionACL) other than `SessionACL::Owner`, because
+    /// the helper does its unmount as root, and a filesystem that admits only its owner
+    /// refuses root the look at the mountpoint that decides whether to unmount.
     AutoUnmount,
     /// Enable permission checking in the kernel
     DefaultPermissions,
@@ -144,7 +151,7 @@ pub(crate) fn check_option_values(options: &[MountOption]) -> Result<(), io::Err
             // Linux is the only platform where every consumer of fsname either takes it
             // verbatim (as the mount(2) source) or decodes the escapes added by
             // option_to_escaped_string
-            MountOption::FSName(name) if cfg!(target_os = "linux") => {
+            MountOption::FSName(name) if cfg!(any(target_os = "linux", target_os = "android")) => {
                 check_option_value(option, name, &['\0'])?;
             }
             MountOption::FSName(value)
@@ -268,7 +275,7 @@ pub(crate) fn option_group(option: &MountOption) -> MountOptionGroup {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 #[allow(dead_code)]
 pub(crate) fn option_to_flag(option: &MountOption) -> io::Result<nix::mount::MsFlags> {
     match option {
@@ -393,7 +400,7 @@ mod test {
         // Only on Linux can fsname be escaped everywhere it is used
         assert_eq!(
             check_option_values(&[FSName("comma,and\\backslash".to_owned())]).is_ok(),
-            cfg!(target_os = "linux")
+            cfg!(any(target_os = "linux", target_os = "android"))
         );
         assert!(
             check_option_values(&[FSName("plain".to_owned()), CUSTOM("plain".to_owned())]).is_ok()

--- a/tests/auto_unmount_helper.rs
+++ b/tests/auto_unmount_helper.rs
@@ -1,0 +1,42 @@
+//! `auto_unmount` needs something that outlives the mounting process to do the unmount.
+//! Where neither a mount helper nor the privilege to mount directly is available, the
+//! error has to say that the option is what asked for them: mounting without it may well
+//! work, and nothing else points that out (issue #283).
+//!
+//! This is a test binary of its own because it sets `FUSERMOUNT_PATH`, which the whole
+//! process sees, and which is only sound to set before any second thread exists.
+
+#![cfg(fuser_mount_impl = "pure-rust")]
+
+use fuser::Config;
+use fuser::Filesystem;
+use fuser::MountOption;
+use fuser::Session;
+use fuser::SessionACL;
+
+struct NullFs;
+impl Filesystem for NullFs {}
+
+#[test]
+fn auto_unmount_names_itself_when_the_mount_helper_cannot_run() {
+    // SAFETY: the only test in this binary, so nothing else is running yet
+    unsafe { std::env::set_var("FUSERMOUNT_PATH", "/nonexistent/fusermount") };
+
+    let tmp = tempfile::tempdir().unwrap();
+    let mut config = Config::default();
+    config.mount_options = vec![MountOption::AutoUnmount];
+    config.acl = SessionACL::All;
+
+    let err = Session::new(NullFs, tmp.path(), &config)
+        .err()
+        .expect("mounting must fail when the configured mount helper cannot be run");
+    let message = err.to_string();
+    assert!(
+        message.contains("auto_unmount"),
+        "the error must name the option that needed the helper: {message}"
+    );
+    assert!(
+        message.contains("/nonexistent/fusermount"),
+        "the error must name the helper it could not run: {message}"
+    );
+}


### PR DESCRIPTION
Fixes #283.

Rewritten after review: the description below matches the current single commit, not the original design.

## The problem

`auto_unmount` needs something that outlives the mounting process to do the unmount, and fuser left that entirely to the `fusermount` helper. Systems that ship no FUSE userspace -- Android, in the report -- have no helper, so the option could not be used there at all. As you noted on the issue, libfuse has the same limitation, so linking it does not help either.

The failure also said the wrong thing. It named only the missing binary, with nothing to say that `auto_unmount` was what required it, or that mounting without the option would work fine -- which is exactly what confused the reporter, whose plain mounts worked "out of the box".

And fuser did not build for Android at all without the `libfuse` feature: `cargo check --target aarch64-linux-android` panics in the build script on master, because Android matches no branch and falls through to searching for libfuse.

## The change

Where `detect_fusermount_bin()` finds no helper, mount directly and fork a watcher that unmounts once the socket it holds reaches EOF, which is what happens when this process dies. That needs the privilege to mount directly -- the same privilege the setuid helper was standing in for -- so it only helps where it can, which is the reporter's case (their plain mounts and manual `umount` both work).

Behaviour is unchanged wherever a helper exists: that path is tried first and is untouched.

The watcher, in the order it does things:

- **Forked before the FUSE device is opened**, so it never holds this mount's device. A live device descriptor keeps the connection alive after this process is gone, and every access to the mountpoint then blocks instead of failing -- the #271 symptom, reintroduced by the fix for #283.
- **Forked twice**, so it is init's child. Nothing here would reap it, and a caller reaping its own children must not find one it never started.
- **Reports itself over a pipe**, one byte written as soon as it is running. The parent drops its write end after forking, so the read ends either with that byte or, when there is no watcher, with end of file. An exit status cannot carry this: a caller that reaps its own children takes it first, and a mount whose watcher silently failed to start is one that outlives the process that asked for it to be unmounted.
- **Closes what it inherited**, including any FUSE device belonging to another mount of the same process, which would otherwise keep that mount's connection alive with nothing serving it. `close_range()` needs Linux 5.9, which the systems without a mount helper are the least likely to have, so there is a fallback that closes them one at a time, bounded by `RLIMIT_NOFILE`, as `close_inherited_fds()` in `fusermount.c` does.
- **Unmounts only on `ENOTCONN`.** A successful open means the filesystem was already unmounted, or something else has taken the path since, and unmounting then would take out the wrong filesystem. This is `should_auto_unmount()` from `fusermount.c`, minus the part that needs `allow_other`: the watcher keeps this process's credentials, so unlike the setuid helper it never gets `EACCES` where it wanted `ENOTCONN`, and needs no `recheck_ENOTCONN_as_owner()` equivalent.

Everything after the fork is async-signal-safe: the `CString` is built beforehand, and the child cannot report an error at all.

Android now selects the pure Rust mount implementation like the other Linux targets, which is what lets any of the above reach the platform this was reported from. `libc::ENOATTR` is deprecated there in favour of `ENODATA`, so `Errno::NO_XATTR` follows the Linux branch. CI builds the target so it stays working.

When neither a helper nor the privilege is available, the error now reads:

```
mounting with auto_unmount, which needs either a FUSE mount helper or the privilege to
mount directly: no FUSE mount helper found, tried fusermount3, fusermount, mount_fusefs,
/sbin/fusermount3, ... (set FUSERMOUNT_PATH to override)
```

## Testing

- `fuser-tests`: `test_auto_unmount_without_helper` renames every mount helper out of the way (restored by a `Drop` guard, including when a step fails), runs `hello --auto-unmount`, reads through the mount, `SIGKILL`s it, and requires the mountpoint to go away on its own. It runs in the `test (mount_tests)` CI job, which is root in Docker, and that is the only place the watcher path is reachable -- it needs the privilege to mount directly, which the `compile` job's runner does not have.
- `tests/auto_unmount_helper.rs`: asserts the error names `auto_unmount`, in `cargo test` for the pure-Rust backend. Its own test binary because it sets `FUSERMOUNT_PATH`. Confirmed it fails without the added context.
- Each failure mode was reproduced before being fixed, and re-checked after: mount left behind with `close_range` stubbed out; `/dev/fuse` of an earlier mount held in the watcher's fd table; mount succeeding with no watcher when the second fork fails, both with and without the caller auto-reaping via `SIGCHLD`.
- Repeated kill-and-unmount cycles with the helpers hidden, including under an auto-reaping caller: clean every time, no stray watchers, no leftover mounts. While mounted, the filesystem process has no direct children and the watcher's PPID is 1.
- Full `linux-mount-libfuse3` suite run locally: `OK auto_unmount without a mount helper`, helpers restored, rest of the suite green.
- `cargo fmt`, all three `clippy` invocations from `make pre`, `cargo doc`, `cargo test --all` with and without `libfuse`, the musl and Android target builds, and `make test_passthrough` are green.

## Two things left alone

- `Session::new` still rejects `auto_unmount` with `SessionACL::Owner`. That requirement exists because the setuid helper cannot see a mount it is not admitted to (verified separately: on libfuse 3.14, which Ubuntu 24.04 ships, auto-unmount silently does nothing without `allow_other`; 3.15 added `recheck_ENOTCONN_as_owner()` to work around it). The forked watcher does not need it, so the check could be relaxed for that path, but deciding it in `Session::new` means probing for the helper before mounting -- a separate change, and it would touch #230/#321.
- Between the socket reaching EOF and the FUSE device closing, a dying process could in principle let the watcher probe a mountpoint that is still connected but unserved, where the probe would block. libfuse's watcher has the same shape. It has not reproduced in any run; closing it properly would mean a probe that cannot block, which seemed like more machinery than the risk justifies. Happy to add it if you disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5akmePV1VnD9YRQLZH4gv