### PR TITLE
Leave a whiteout behind on RENAME_WHITEOUT in the simple example

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1411,9 +1411,21 @@ impl Filesystem for SimpleFS {
         #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         let (exchange, no_replace) = (false, false);
 
+        // Leaving a whiteout behind is Linux-only; macOS has no equivalent
+        #[cfg(target_os = "linux")]
+        let whiteout = flags.contains(RenameFlags::RENAME_WHITEOUT);
+        #[cfg(not(target_os = "linux"))]
+        let whiteout = false;
+
         // Exchanging and refusing to replace are contradictory: renameat2(2) and
         // renamex_np(2) both reject the combination
         if exchange && no_replace {
+            reply.error(Errno::EINVAL);
+            return;
+        }
+
+        // An exchange leaves nothing behind to white out, so renameat2(2) refuses the pair
+        if exchange && whiteout {
             reply.error(Errno::EINVAL);
             return;
         }
@@ -1528,6 +1540,34 @@ impl Filesystem for SimpleFS {
 
         let mut entries = self.get_directory_content(parent).unwrap();
         entries.remove(name.as_bytes());
+        // A whiteout rename puts a placeholder where the entry was, so a filesystem stacked
+        // above this one can tell "removed here" apart from "never existed". The kernel's own
+        // is a character device with device number 0 and no permission bits, which is not a
+        // node anything can be read from or written to
+        if whiteout {
+            let whiteout_inode = self.allocate_next_inode();
+            let whiteout_attrs = InodeAttributes {
+                inode: whiteout_inode.0,
+                open_file_handles: 0,
+                size: 0,
+                last_accessed: now,
+                last_modified: now,
+                last_metadata_changed: now,
+                kind: FileKind::CharDevice,
+                mode: 0,
+                hardlinks: 1,
+                uid: _req.uid(),
+                gid: creation_gid(&parent_attrs, _req.gid()),
+                rdev: 0,
+                xattrs: BTreeMap::default(),
+            };
+            self.write_inode(&whiteout_attrs);
+            File::create(self.content_path(whiteout_inode)).unwrap();
+            entries.insert(
+                name.as_bytes().to_vec(),
+                (whiteout_attrs.inode, whiteout_attrs.kind),
+            );
+        }
         self.write_directory_content(parent, &entries);
 
         let mut entries = self.get_directory_content(newparent).unwrap();

--- a/xfstests.sh
+++ b/xfstests.sh
@@ -31,10 +31,6 @@ echo "generic/484" >> xfs_excludes.txt
 # Writes directly to scratch block dev
 echo "generic/062" >> xfs_excludes.txt
 
-# TODO: requires renameat2(RENAME_WHITEOUT), which has to leave a 0/0 character device
-# behind at the source. fuser passes the flag through as RenameFlags; the example ignores it
-echo "generic/078" >> xfs_excludes.txt
-
 # TODO: takes > 10min
 echo "generic/069" >> xfs_excludes.txt
 


### PR DESCRIPTION
`renameat2(2)` with `RENAME_WHITEOUT` renames as usual and additionally leaves a placeholder at the source, so a filesystem stacked above can tell an entry removed here apart from one that never existed. fuser has always passed the flag through as `RenameFlags`; the example ignored it and left the source empty. That is what generic/078 was catching.

**720 passing**, up from 719.

## What a whiteout is

What `vfs_whiteout()` creates: a character device with device number 0 and no permission bits, owned by the caller. Representing that needs `FileKind::CharDevice`, so this was not implementable before #732 added it - which is also why generic/078 sat misfiled as "looks like it requires character file support" until this series got to it.

An exchange combined with a whiteout is refused with `EINVAL`, as `renameat2(2)` refuses it: swapping the two entries leaves nothing behind to white out.

## How the attributes were established

By measuring tmpfs rather than reading them out of the kernel headers, then diffing fuser against it:

| case | fuser | tmpfs |
|---|---|---|
| whiteout node | `char, perm=0, rdev=0,0, nlink=1, size=0` | identical |
| destination contents | preserved | identical |
| unprivileged caller | `uid=1001 gid=1001` | identical |
| `EXCHANGE\|WHITEOUT` | `EINVAL` | `EINVAL` |

The ownership row is the one worth having: the whiteout follows the caller, not root, and every test in the suite runs as root, so hardcoding 0 would have passed everything.

The same-directory case needs no special handling. The existing code re-reads the parent's entries between the two directory writes, so when `parent == newparent` the second read already contains the whiteout and does not clobber it. Verified as part of the comparison above, where source and destination share a directory.

## Testing

- Full xfstests: **passed all 720**, 1490s, no regressions
- pjdfstest: **PASS**, 205 files / 2732 tests, 0 failed - it has a large rename suite
- generic/078 re-enabled and passing
- `cargo clippy --all-targets` clean under `--deny warnings` (`--all-features` needs libfuse3 headers not present in this environment)

## Remaining in the exclusion list

generic/003 and 192 need atime. generic/394's assertion already passes and only its cleanup fails, needing `CAP_SYS_RESOURCE` on the test container. generic/294, 306 and 452 need read-only remount, and two of the three additionally need a change in fuse-xfstests, whose `_scratch_remount` answers "fuse.fuser does not support any options" without attempting it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSmtYYZ3resRdsCD1PwqUK)_