### PR TITLE
Add Filesystem::syncfs() for FUSE_SYNCFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # FUSE for Rust - Changelog
 
 ## Unreleased
+* Add `Filesystem::syncfs()`, which the kernel calls for `syncfs(2)` (#359, ABI 7.34). Leaving
+  it unimplemented reports `ENOSYS`, which makes the kernel stop asking for the lifetime of the
+  connection, so this changes nothing for a filesystem that does not want it. Note that the
+  kernel only propagates `syncfs(2)` on `fuseblk` and virtiofs connections, neither of which
+  fuser mounts, so this is reachable only for a session built with `Session::from_fd` on such
+  a connection
 * Unmounting from within the mounting process now works with `MountOption::AutoUnmount` (#407).
   Dropping the `BackgroundSession`, calling `umount_and_join()` or `SessionUnmounter::unmount()`
   used to leave the unmount to the `fusermount` helper, which only acts once the process exits.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1174,6 +1174,22 @@ pub trait Filesystem: Send + Sync + 'static {
         reply.error(Errno::ENOSYS);
     }
 
+    /// Synchronize the whole filesystem, for the `syncfs(2)` system call.
+    ///
+    /// `ino` is the root inode. Replying before everything the filesystem holds is durable
+    /// defeats the point of the call, so a filesystem that cannot make that guarantee is
+    /// better off leaving this unimplemented, which reports `ENOSYS` and makes the kernel
+    /// stop asking for the lifetime of the connection.
+    ///
+    /// Note that the kernel only propagates `syncfs(2)` on `fuseblk` and virtiofs
+    /// connections. A filesystem mounted by fuser is neither, so this is reachable only
+    /// for a session built with [`Session::from_fd`] on such a connection. Everywhere
+    /// else `syncfs(2)` succeeds without asking the filesystem anything.
+    fn syncfs(&self, _req: &Request, ino: INodeNo, reply: ReplyEmpty) {
+        warn!("[Not Implemented] syncfs(ino: {ino:#x?})");
+        reply.error(Errno::ENOSYS);
+    }
+
     /// macOS only: Rename the volume. Set `fuse_init_out.flags` during init to
     /// `FUSE_VOL_RENAME` to enable
     #[cfg(target_os = "macos")]

--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -166,6 +166,7 @@ pub(crate) enum fuse_opcode {
     FUSE_RENAME2 = 45,
     FUSE_LSEEK = 46,
     FUSE_COPY_FILE_RANGE = 47,
+    FUSE_SYNCFS = 50,
 
     #[cfg(target_os = "macos")]
     FUSE_SETVOLNAME = 61,
@@ -775,6 +776,12 @@ pub(crate) struct fuse_lseek_in {
 #[derive(Debug, IntoBytes, KnownLayout, Immutable)]
 pub(crate) struct fuse_lseek_out {
     pub(crate) offset: i64,
+}
+
+#[repr(C)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
+pub(crate) struct fuse_syncfs_in {
+    pub(crate) padding: u64,
 }
 
 #[repr(C)]

--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -1603,6 +1603,20 @@ mod op {
         }
     }
 
+    /// Synchronize the whole filesystem.
+    ///
+    /// The kernel sends this for `syncfs(2)`, and only on connections where it
+    /// propagates that call at all, which are `fuseblk` and virtiofs mounts. It carries
+    /// no arguments beyond the root inode the request is addressed to.
+    #[derive(Debug)]
+    pub(crate) struct SyncFs<'a> {
+        #[expect(dead_code)]
+        header: &'a fuse_in_header,
+        /// Read to check the length the kernel sent, and reserved by the protocol
+        #[expect(dead_code)]
+        arg: &'a fuse_syncfs_in,
+    }
+
     /// `MacOS` only: Rename the volume. Set `fuse_init_out.flags` during init to
     /// `FUSE_VOL_RENAME` to enable
     #[cfg(target_os = "macos")]
@@ -1910,6 +1924,10 @@ mod op {
                 header,
                 arg: data.fetch()?,
             }),
+            fuse_opcode::FUSE_SYNCFS => Operation::SyncFs(SyncFs {
+                header,
+                arg: data.fetch()?,
+            }),
 
             #[cfg(target_os = "macos")]
             fuse_opcode::FUSE_SETVOLNAME => Operation::SetVolName(SetVolName {
@@ -1984,6 +2002,7 @@ pub(crate) enum Operation<'a> {
     Rename2(Rename2<'a>),
     Lseek(Lseek<'a>),
     CopyFileRange(CopyFileRange<'a>),
+    SyncFs(SyncFs<'a>),
 
     #[cfg(target_os = "macos")]
     SetVolName(SetVolName<'a>),
@@ -2160,6 +2179,7 @@ impl fmt::Display for Operation<'_> {
                 x.dest(),
                 x.len()
             ),
+            Operation::SyncFs(_) => write!(f, "SYNCFS"),
 
             #[cfg(target_os = "macos")]
             Operation::SetVolName(x) => write!(f, "SETVOLNAME name {:?}", x.name()),
@@ -2666,5 +2686,46 @@ mod tests {
             }
             _ => panic!("Unexpected request operation"),
         }
+    }
+
+    // 40 byte header + 8 byte fuse_syncfs_in, addressed to the root inode
+    #[cfg(target_endian = "little")]
+    const SYNCFS_REQUEST: AlignedData<[u8; 48]> = AlignedData([
+        0x30, 0x00, 0x00, 0x00, 0x32, 0x00, 0x00, 0x00, // len, opcode
+        0x0d, 0xf0, 0xad, 0xba, 0xef, 0xbe, 0xad, 0xde, // unique
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // nodeid
+        0x0d, 0xd0, 0x01, 0xc0, 0xfe, 0xca, 0x01, 0xc0, // uid, gid
+        0x5e, 0xba, 0xde, 0xc0, 0x00, 0x00, 0x00, 0x00, // pid, padding
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // padding
+    ]);
+
+    #[cfg(target_endian = "big")]
+    const SYNCFS_REQUEST: AlignedData<[u8; 48]> = AlignedData([
+        0x00, 0x00, 0x00, 0x30, 0x00, 0x00, 0x00, 0x32, // len, opcode
+        0xde, 0xad, 0xbe, 0xef, 0xba, 0xad, 0xf0, 0x0d, // unique
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // nodeid
+        0xc0, 0x01, 0xd0, 0x0d, 0xc0, 0x01, 0xca, 0xfe, // uid, gid
+        0xc0, 0xde, 0xba, 0x5e, 0x00, 0x00, 0x00, 0x00, // pid, padding
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // padding
+    ]);
+
+    #[test]
+    fn syncfs() {
+        let req = AnyRequest::try_from(&SYNCFS_REQUEST[..]).unwrap();
+        assert_eq!(req.header.opcode, 50);
+        assert_eq!(req.nodeid(), INodeNo::ROOT);
+        assert!(matches!(req.operation().unwrap(), Operation::SyncFs(_)));
+    }
+
+    /// The kernel sends the whole `fuse_syncfs_in`, and a request whose header is honest
+    /// about carrying none of it is not one this can answer
+    #[test]
+    fn syncfs_without_its_argument() {
+        let mut short = AlignedData([0u8; 40]);
+        short.0.copy_from_slice(&SYNCFS_REQUEST[..40]);
+        short.0[..4].copy_from_slice(&40u32.to_ne_bytes());
+
+        let req = AnyRequest::try_from(&short[..]).unwrap();
+        assert!(req.operation().is_err());
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -547,6 +547,9 @@ impl<'a> RequestWithSender<'a> {
                     self.reply(),
                 );
             }
+            ll::Operation::SyncFs(_x) => {
+                filesystem.syncfs(self.request_header(), self.request.nodeid(), self.reply());
+            }
             #[cfg(target_os = "macos")]
             ll::Operation::SetVolName(x) => {
                 filesystem.setvolname(self.request_header(), x.name(), self.reply());

--- a/src/session.rs
+++ b/src/session.rs
@@ -825,6 +825,64 @@ mod test {
         ManuallyDrop::into_inner(tmp);
     }
 
+    /// The kernel fills a request's uid, gid and pid from the task that caused it, for
+    /// every operation that goes through fuse_simple_request(). Every access decision
+    /// fuser makes rests on that - SessionACL, and which operations are exempt from it
+    /// because the kernel issues them with no caller - so it is worth pinning down rather
+    /// than assuming. `FUSE_ARGS()` zero-initializes, so a header fuser had merely copied
+    /// from there would carry uid 0 and pid 0.
+    #[test]
+    fn requests_carry_the_calling_task() {
+        struct CallerFs {
+            seen: Arc<Mutex<Option<(u32, u32)>>>,
+        }
+        impl Filesystem for CallerFs {
+            fn getattr(
+                &self,
+                req: &Request,
+                _ino: crate::INodeNo,
+                _fh: Option<crate::FileHandle>,
+                reply: crate::ReplyAttr,
+            ) {
+                *self.seen.lock() = Some((req.uid(), req.pid()));
+                reply.error(Errno::ENOSYS);
+            }
+        }
+
+        let tmp = ManuallyDrop::new(tempfile::tempdir().unwrap());
+        let mountpoint = tmp.path().canonicalize().unwrap();
+        let seen = Arc::new(Mutex::new(None));
+        let bg = Session::new(
+            CallerFs { seen: seen.clone() },
+            &mountpoint,
+            &Config::default(),
+        )
+        .unwrap()
+        .spawn()
+        .unwrap();
+
+        // Any operation will do; this one is answered from the mountpoint's root inode
+        let _ = std::fs::metadata(&mountpoint);
+        let seen = seen.lock().take();
+        drop(bg);
+        ManuallyDrop::into_inner(tmp);
+
+        let (uid, pid) = seen.expect("the filesystem must have been asked for the root inode");
+        assert_eq!(
+            uid,
+            geteuid().as_raw(),
+            "the request must carry the caller's uid"
+        );
+        // Discriminating even when the test runs as root, where the uid above is 0 either
+        // way. The kernel takes this from task_pid(current), so it is the id of the thread
+        // that made the call rather than of the process
+        assert_eq!(
+            pid,
+            nix::unistd::gettid().as_raw() as u32,
+            "the request must carry the calling thread's id"
+        );
+    }
+
     /// Dropping a BackgroundSession must unmount the filesystem and wait for the
     /// session to end, so that Filesystem::destroy has run when drop returns.
     #[test]


### PR DESCRIPTION
Fixes #359.

`FUSE_SYNCFS` is opcode 50, ABI 7.34, carrying `struct fuse_syncfs_in { uint64_t padding; }` and answered with an empty reply. fuser reports 7.44, so nothing needs version gating on the receive side. Adds the opcode, the argument struct, an `Operation::SyncFs`, the dispatch, and `Filesystem::syncfs()`.

Leaving `syncfs()` unimplemented reports `ENOSYS`, which is what the unknown-opcode path already produced, and the kernel then clears `fc->sync_fs` and stops asking for the lifetime of the connection. So this changes nothing for a filesystem that does not want it.

## One thing worth knowing before merging

**The kernel only propagates `syncfs(2)` on `fuseblk` and virtiofs connections.** `fc->sync_fs` is set in exactly two places -- `fuse_fill_super_common()` under `if (ctx->is_bdev)`, and `virtio_fs.c` -- and `fuse_sync_fs()` returns 0 immediately when it is unset. fuser mounts filesystem type `fuse`, never `fuseblk`, so on a filesystem fuser mounts the kernel never sends this and `syncfs(2)` succeeds without a round trip.

That leaves one reachable path: a session built with `Session::from_fd` on a `fuseblk` or virtiofs connection. The trait method and the changelog both say so, so nobody implements it expecting it to fire on an ordinary mount.

It is still worth having -- it is protocol coverage, it is what the issue asked for, and `from_fd` is public API -- but it is not something I can demonstrate end to end, and I would rather you knew that than found it later.

## Testing

`ll::request::tests::syncfs` and `syncfs_without_its_argument`, in the byte-level style of the existing request tests, for both endiannesses. They cover the parse and that a request whose header declares no argument is rejected rather than parsed. Confirmed the second fails if the argument fetch is dropped.

No e2e test, for the reason above: the kernel will not send this to anything fuser can mount, so a `fuser-tests` case would assert nothing.

`cargo fmt`, all three `clippy` invocations from `make pre`, `cargo doc`, `cargo test --all` with and without `libfuse`, the musl build, `cargo check --target x86_64-apple-darwin --features=macos-no-mount`, and `make test_passthrough` are green. Docker was unavailable here, so `mount_tests`/`pjdfs_tests`/`xfstests` did not run locally; this adds an opcode none of them exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5akmePV1VnD9YRQLZH4gv

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5akmePV1VnD9YRQLZH4gv)_