### PR TITLE
Update atime on read in the simple example

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -509,6 +509,34 @@ impl SimpleFS {
         }
     }
 
+    /// Record that an inode was read, following the kernel's default `relatime` policy.
+    ///
+    /// Moving atime on every read would mean a write per read, so it only moves when it is no
+    /// newer than mtime or ctime - that is, when nothing has read the inode since it last
+    /// changed - or when it has gone stale by more than a day. That preserves the one thing a
+    /// reader can draw from atime: an atime older than mtime means nobody has looked since the
+    /// last write.
+    ///
+    /// A mount can ask for `noatime` or `strictatime` instead, but no FUSE request reports
+    /// which the mount used and this example takes no option for it, so the kernel's default
+    /// is the only policy on offer.
+    ///
+    /// `O_NOATIME` on the caller's handle is honored by `read()`, which is given the flag, on
+    /// Linux - neither macOS nor FreeBSD has the flag.
+    /// `readdir()` and `copy_file_range()` are not, and would have to carry it over from the
+    /// `open()` that set it, so a caller using it there still moves atime
+    fn touch_atime(&self, attrs: &mut InodeAttributes) {
+        let now = time_now();
+        let a_day_ago = now.0 - 24 * 60 * 60;
+        if attrs.last_accessed <= attrs.last_modified
+            || attrs.last_accessed <= attrs.last_metadata_changed
+            || attrs.last_accessed.0 < a_day_ago
+        {
+            attrs.last_accessed = now;
+            self.write_inode(attrs);
+        }
+    }
+
     fn write_inode(&self, inode: &InodeAttributes) {
         let path = Path::new(&self.data_dir)
             .join("inodes")
@@ -920,6 +948,9 @@ impl Filesystem for SimpleFS {
                 let file_size = file.metadata().unwrap().len();
                 let mut buffer = vec![0; file_size as usize];
                 file.read_exact(&mut buffer).unwrap();
+                if let Ok(mut attrs) = self.get_inode(ino) {
+                    self.touch_atime(&mut attrs);
+                }
                 reply.data(&buffer);
             }
             _ => {
@@ -1706,6 +1737,18 @@ impl Filesystem for SimpleFS {
 
                 let mut buffer = vec![0; read_size as usize];
                 file.read_exact_at(&mut buffer, offset as u64).unwrap();
+                // A reader that asked for O_NOATIME wants to leave no trace, and a read
+                // request carries the flag, so it can be honored here. The flag is Linux's;
+                // neither macOS nor FreeBSD defines it
+                #[cfg(target_os = "linux")]
+                let no_atime = _flags.0 & libc::O_NOATIME != 0;
+                #[cfg(not(target_os = "linux"))]
+                let no_atime = false;
+                if !no_atime {
+                    if let Ok(mut attrs) = self.get_inode(ino) {
+                        self.touch_atime(&mut attrs);
+                    }
+                }
                 reply.data(&buffer);
             }
             _ => {
@@ -1861,6 +1904,9 @@ impl Filesystem for SimpleFS {
                 return;
             }
         };
+        if let Ok(mut attrs) = self.get_inode(ino) {
+            self.touch_atime(&mut attrs);
+        }
 
         for (index, entry) in entries.iter().skip(offset as usize).enumerate() {
             let (name, (inode, file_type)) = entry;
@@ -2212,6 +2258,10 @@ impl Filesystem for SimpleFS {
 
                 let mut data = vec![0; read_size as usize];
                 file.read_exact_at(&mut data, src_offset).unwrap();
+                // Copying reads the source, and Linux moves its atime accordingly
+                if let Ok(mut src_attrs) = self.get_inode(src_inode) {
+                    self.touch_atime(&mut src_attrs);
+                }
 
                 let dest_path = self.content_path(dest_inode);
                 match OpenOptions::new().write(true).open(dest_path) {

--- a/xfstests.sh
+++ b/xfstests.sh
@@ -62,9 +62,12 @@ echo "generic/294" >> xfs_excludes.txt
 echo "generic/306" >> xfs_excludes.txt
 echo "generic/452" >> xfs_excludes.txt
 
-# TODO: requires atime support
+# TODO: exercises the noatime, relatime and strictatime mount options, and a read-only
+# mount. fuse-xfstests cannot ask for any of them: _fuser_mount reads $4 for suid and drops
+# the rest, so "_scratch_mount -o relatime" and "_scratch_cycle_mount noatime" both arrive as
+# a plain mount. The example implements the kernel default, relatime, which is what the first
+# phase wants; the noatime and strictatime phases need the option to reach the filesystem
 echo "generic/003" >> xfs_excludes.txt
-echo "generic/192" >> xfs_excludes.txt
 
 # TODO: Passes, but takes ~10min and writes > 20GB. Needs support for writing files with large holes,
 # for this test to be fast


### PR DESCRIPTION
The example set `last_accessed` when an inode was created and when `utimens` asked for it, and never again, so atime never moved for a reader. generic/192 was catching that.

**721 passing**, up from 720.

## The policy

Reads follow `relatime`, the kernel's default: atime moves only when it is no newer than mtime or ctime - that is, when nothing has read the inode since it last changed - or when it has gone stale by more than a day.

Moving it on every read would mean an inode write per read for no gain. What a reader can actually draw from atime is that an atime older than mtime means nobody has looked since the last write, and relatime preserves exactly that. In the steady state a read costs nothing extra: suite runtime is unchanged.

Four paths count as access, as they do on a local filesystem: `read()`, `readdir()`, `readlink()`, and the source side of `copy_file_range()`. That last one was missed in the first version and caught in review - it reads the source with `read_exact_at` without going through `read()`, so listing the handlers *named* after reading was not enough; the question is which handlers read data. Applying that: `readdirplus` is not implemented so the kernel falls back to `readdir`; `getattr`, `lookup` and `getxattr` read metadata rather than data, which Linux does not count; `write` and `fallocate` do not read.

`read()` also honors `O_NOATIME` on Linux. A read request carries the flag - verified by instrumenting a build rather than assuming:

```
normal read     flags=0x8000   noatime=false
O_NOATIME read  flags=0x48000  noatime=true    (O_LARGEFILE | O_NOATIME)
```

`readdir()` and `copy_file_range()` are not given open flags, so honoring it there would mean carrying a third bit in the file handle alongside `FILE_HANDLE_READ_BIT` and `FILE_HANDLE_WRITE_BIT`. I left that out - no test anywhere exercises `O_NOATIME`, and a directory or copy source opened with it is obscure next to a backup tool reading file data - and recorded the limitation in the helper's doc comment so it is not silently inconsistent. Say the word if you would rather have it complete.

A mount can ask for `noatime` or `strictatime` instead, but no FUSE request reports which the mount used and this example takes no option for it, so the kernel default is the only policy on offer.

## Checked against tmpfs

tmpfs also mounts relatime, so it is like-for-like:

| case | fuser | tmpfs |
|---|---|---|
| first read moves atime | yes | yes |
| second read leaves it (relatime) | yes | yes |
| `readlink` moves atime | yes | yes |
| `copy_file_range` moves source atime | yes | yes |
| second copy leaves it (relatime) | yes | yes |
| `O_NOATIME` read suppresses | yes | yes |

generic/192 additionally requires atime to survive a mount cycle, which it does - the inode is on disk.

Worth flagging for review: `O_NOATIME` is the one part of this change with **no coverage in either suite**, so a green run says nothing about it. The tmpfs comparison is the only real check on those lines.

## generic/003 stays excluded, with its reason corrected

It was filed as "requires atime support", which is not the whole story. It exercises the `noatime`, `relatime` and `strictatime` mount options plus a read-only mount, and fuse-xfstests cannot ask for any of them:

```sh
_fuser_mount() {
    local data_dir=$1
    local mnt=$2
    local suid="$4"          # $3, the "-o ..." string, is never read
    fuser --data-dir "$data_dir" --mount-point "$mnt" ${suid} $FUSER_EXTRA_MOUNT_OPTIONS ...
}
```

Its failures moved rather than disappeared, which is the evidence. Before: four errors saying atime never updates. After:

```
ERROR: access time has changed after accessing file3 first time            <- noatime phase
ERROR: access time has not been updated after accessing file3 second time  <- strictatime phase
ERROR: access time has not been updated after accessing file3 third time   <- strictatime phase
ERROR: access time has changed for dir in read-only filesystem             <- ro phase
```

Every one is an option the filesystem never sees. Same category as generic/306 and 452: it needs a change in fuse-xfstests, not in fuser.

## Testing

All against the final commit:

- Full xfstests: **passed all 721**, 1163s, no regressions and no runtime cost
- pjdfstest: **PASS**, 205 files / 2732 tests, 0 failed
- generic/192 re-enabled and passing
- `cargo clippy --all-targets` clean under `--deny warnings`
- `cargo check --target aarch64-apple-darwin --features=macos-no-mount --examples` clean

That last one is new, and I added it because I broke `mac-ci` and `freebsd-ci` on an earlier revision of this PR: `libc::O_NOATIME` is Linux-only and does not exist on either. The flag test is now behind `#[cfg(target_os = "linux")]`, matching how the rename flags are already handled. The darwin cross-check reproduces mac-ci's exact invocation locally, so that class of breakage is catchable before pushing next time.

## Known limitation, not addressed here

Review also raised that the atime write is an unguarded read-modify-write that can roll back a concurrent `write`/`setattr` under `--n-threads > 1`. That is real, but it is the example's existing model: there is no locking anywhere in the file, and all 38 `write_inode` sites have the same shape - two concurrent `write()`s already race identically. Fixing it means per-inode locking across every handler, which is an architectural change rather than part of an atime PR. The one genuinely new element is that reads were previously pure, so read-vs-write was not a racing pair at all; relatime narrows the window to the first read after a change but does not remove it. Happy to do the locking separately if wanted.

## Remaining in the exclusion list

Nothing left that fuser alone can fix. generic/394's assertion already passes and only its cleanup fails, needing `CAP_SYS_RESOURCE` on the test container. generic/003, 294, 306 and 452 need mount options to reach the filesystem, which is a fuse-xfstests change. The rest are Docker restrictions, missing tooling, slow tests, or genuine design mismatches.