### PR TITLE
Add Filesystem::tmpfile() for FUSE_TMPFILE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # FUSE for Rust - Changelog
 
 ## Unreleased
+* Add `Filesystem::tmpfile()`, which the kernel calls for `open()` with `O_TMPFILE` (#366,
+  ABI 7.37). The file has no name and belongs to no directory until `linkat()` gives it one,
+  so unlike `create()` this is told only which directory it was made in. Leaving it
+  unimplemented reports `ENOSYS`, which the kernel takes as permanent: it stops offering
+  `O_TMPFILE` on that connection and answers `EOPNOTSUPP`, which is what happened before
 * Add `Filesystem::syncfs()`, which the kernel calls for `syncfs(2)` (#359, ABI 7.34). Leaving
   it unimplemented reports `ENOSYS`, which makes the kernel stop asking for the lifetime of the
   connection, so this changes nothing for a filesystem that does not want it. Note that the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1174,6 +1174,33 @@ pub trait Filesystem: Send + Sync + 'static {
         reply.error(Errno::ENOSYS);
     }
 
+    /// Create an anonymous file, for `open()` with `O_TMPFILE`.
+    ///
+    /// The file has no name and belongs to no directory. `parent` is the directory it was
+    /// created in, which is where it will live if it is later given a name with `linkat()`;
+    /// until then nothing can reach it by path. Reply as for [`Filesystem::create`], with
+    /// an inode and an open file handle.
+    ///
+    /// Answering `ENOSYS`, which is the default, is permanent: the kernel stops offering
+    /// `O_TMPFILE` on this connection and reports `EOPNOTSUPP` to the caller without
+    /// asking again.
+    fn tmpfile(
+        &self,
+        _req: &Request,
+        parent: INodeNo,
+        mode: u32,
+        umask: u32,
+        flags: i32,
+        kill_suid_gid: bool,
+        reply: ReplyCreate,
+    ) {
+        warn!(
+            "[Not Implemented] tmpfile(parent: {parent:#x?}, mode: {mode}, umask: {umask:#x?}, \
+            flags: {flags:#x?}, kill_suid_gid: {kill_suid_gid})"
+        );
+        reply.error(Errno::ENOSYS);
+    }
+
     /// Synchronize the whole filesystem, for the `syncfs(2)` system call.
     ///
     /// `ino` is the root inode. Replying before everything the filesystem holds is durable

--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -167,6 +167,7 @@ pub(crate) enum fuse_opcode {
     FUSE_LSEEK = 46,
     FUSE_COPY_FILE_RANGE = 47,
     FUSE_SYNCFS = 50,
+    FUSE_TMPFILE = 51,
 
     #[cfg(target_os = "macos")]
     FUSE_SETVOLNAME = 61,

--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -1296,6 +1296,46 @@ mod op {
         }
     }
 
+    /// Create an anonymous file, for `open()` with `O_TMPFILE`.
+    ///
+    /// The file has no name and belongs to no directory: only the directory it is created
+    /// in is given, so that the filesystem knows where it will live if it is later given a
+    /// name with `linkat()`. The kernel does send a name, but it is the placeholder `/`
+    /// that the VFS gives every anonymous dentry, so it says nothing and is not passed on.
+    ///
+    /// Answering with `ENOSYS` is permanent: the kernel stops offering `O_TMPFILE` on this
+    /// connection and reports `EOPNOTSUPP` without asking again.
+    #[derive(Debug)]
+    pub(crate) struct TmpFile<'a> {
+        #[expect(dead_code)]
+        header: &'a fuse_in_header,
+        arg: &'a fuse_create_in,
+        /// The placeholder the VFS names anonymous dentries, read only to check the
+        /// length the kernel sent
+        #[expect(dead_code)]
+        name: &'a Path,
+    }
+    impl TmpFile<'_> {
+        pub(crate) fn mode(&self) -> u32 {
+            self.arg.mode
+        }
+        /// Flags as passed to the `open()` call
+        pub(crate) fn flags(&self) -> i32 {
+            self.arg.flags
+        }
+        pub(crate) fn umask(&self) -> u32 {
+            self.arg.umask
+        }
+        /// Whether the filesystem must clear suid and sgid as part of this request.
+        ///
+        /// Only ever true once `FUSE_HANDLE_KILLPRIV_V2` has been negotiated, since the kernel
+        /// otherwise clears them itself.
+        pub(crate) fn kill_suid_gid(&self) -> bool {
+            OpenInFlags::from_bits_retain(self.arg.open_flags)
+                .contains(OpenInFlags::FUSE_OPEN_KILL_SUIDGID)
+        }
+    }
+
     /// If a process issuing a FUSE filesystem request is interrupted, the
     /// following will happen:
     ///
@@ -1928,6 +1968,11 @@ mod op {
                 header,
                 arg: data.fetch()?,
             }),
+            fuse_opcode::FUSE_TMPFILE => Operation::TmpFile(TmpFile {
+                header,
+                arg: data.fetch()?,
+                name: data.fetch_str()?.as_ref(),
+            }),
 
             #[cfg(target_os = "macos")]
             fuse_opcode::FUSE_SETVOLNAME => Operation::SetVolName(SetVolName {
@@ -2003,6 +2048,7 @@ pub(crate) enum Operation<'a> {
     Lseek(Lseek<'a>),
     CopyFileRange(CopyFileRange<'a>),
     SyncFs(SyncFs<'a>),
+    TmpFile(TmpFile<'a>),
 
     #[cfg(target_os = "macos")]
     SetVolName(SetVolName<'a>),
@@ -2180,6 +2226,13 @@ impl fmt::Display for Operation<'_> {
                 x.len()
             ),
             Operation::SyncFs(_) => write!(f, "SYNCFS"),
+            Operation::TmpFile(x) => write!(
+                f,
+                "TMPFILE mode {:#05o}, umask {:#05o}, flags {:#x?}",
+                x.mode(),
+                x.umask(),
+                x.flags()
+            ),
 
             #[cfg(target_os = "macos")]
             Operation::SetVolName(x) => write!(f, "SETVOLNAME name {:?}", x.name()),
@@ -2727,5 +2780,50 @@ mod tests {
 
         let req = AnyRequest::try_from(&short[..]).unwrap();
         assert!(req.operation().is_err());
+    }
+
+    // 40 byte header + 16 byte fuse_create_in + the placeholder name "/".
+    // O_TMPFILE, and so this operation, exists on Linux alone
+    #[cfg(all(target_os = "linux", target_endian = "little"))]
+    const TMPFILE_REQUEST: AlignedData<[u8; 58]> = AlignedData([
+        0x3a, 0x00, 0x00, 0x00, 0x33, 0x00, 0x00, 0x00, // len, opcode
+        0x0d, 0xf0, 0xad, 0xba, 0xef, 0xbe, 0xad, 0xde, // unique
+        0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, // nodeid
+        0x0d, 0xd0, 0x01, 0xc0, 0xfe, 0xca, 0x01, 0xc0, // uid, gid
+        0x5e, 0xba, 0xde, 0xc0, 0x00, 0x00, 0x00, 0x00, // pid, padding
+        0x02, 0x00, 0x41, 0x00, 0xa0, 0x81, 0x00, 0x00, // flags (O_RDWR|O_TMPFILE), mode
+        0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // umask, open_flags
+        0x2f, 0x00, // name ("/")
+    ]);
+
+    #[cfg(all(target_os = "linux", target_endian = "big"))]
+    const TMPFILE_REQUEST: AlignedData<[u8; 58]> = AlignedData([
+        0x00, 0x00, 0x00, 0x3a, 0x00, 0x00, 0x00, 0x33, // len, opcode
+        0xde, 0xad, 0xbe, 0xef, 0xba, 0xad, 0xf0, 0x0d, // unique
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, // nodeid
+        0xc0, 0x01, 0xd0, 0x0d, 0xc0, 0x01, 0xca, 0xfe, // uid, gid
+        0xc0, 0xde, 0xba, 0x5e, 0x00, 0x00, 0x00, 0x00, // pid, padding
+        0x00, 0x41, 0x00, 0x02, 0x00, 0x00, 0x81, 0xa0, // flags (O_RDWR|O_TMPFILE), mode
+        0x00, 0x00, 0x00, 0x12, 0x00, 0x00, 0x00, 0x00, // umask, open_flags
+        0x2f, 0x00, // name ("/")
+    ]);
+
+    /// A tmpfile request is a create request on the wire, minus a name that means anything
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn tmpfile() {
+        let req = AnyRequest::try_from(&TMPFILE_REQUEST[..]).unwrap();
+        assert_eq!(req.header.opcode, 51);
+        assert_eq!(req.nodeid(), INodeNo(0x1122_3344_5566_7788));
+        match req.operation().unwrap() {
+            Operation::TmpFile(x) => {
+                assert_eq!(x.mode(), 0o100_640);
+                assert_eq!(x.umask(), 0o22);
+                // O_TMPFILE is O_DIRECTORY | 0o20_000_000 on every architecture fuser builds for
+                assert_eq!(x.flags(), libc::O_RDWR | libc::O_TMPFILE);
+                assert!(!x.kill_suid_gid());
+            }
+            _ => panic!("Unexpected request operation"),
+        }
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -550,6 +550,17 @@ impl<'a> RequestWithSender<'a> {
             ll::Operation::SyncFs(_x) => {
                 filesystem.syncfs(self.request_header(), self.request.nodeid(), self.reply());
             }
+            ll::Operation::TmpFile(x) => {
+                filesystem.tmpfile(
+                    self.request_header(),
+                    self.request.nodeid(),
+                    x.mode(),
+                    x.umask(),
+                    x.flags(),
+                    x.kill_suid_gid(),
+                    self.reply(),
+                );
+            }
             #[cfg(target_os = "macos")]
             ll::Operation::SetVolName(x) => {
                 filesystem.setvolname(self.request_header(), x.name(), self.reply());

--- a/src/session.rs
+++ b/src/session.rs
@@ -825,6 +825,180 @@ mod test {
         ManuallyDrop::into_inner(tmp);
     }
 
+    /// An O_TMPFILE open must reach Filesystem::tmpfile() with the mode and flags it was
+    /// made with, and hand back a working descriptor. The kernel takes ENOSYS from this as
+    /// permanent, so a filesystem that does implement it has one chance to say so.
+    ///
+    /// Naming the file afterwards is the other half of what it is for, and reaches
+    /// Filesystem::link() with the inode tmpfile() replied with.
+    #[test]
+    fn tmpfile_open_and_link() {
+        use std::os::fd::AsRawFd;
+        use std::time::Duration;
+        use std::time::SystemTime;
+
+        use crate::FileAttr;
+        use crate::FileType;
+        use crate::FopenFlags;
+        use crate::Generation;
+        use crate::INodeNo;
+        use crate::ReplyCreate;
+
+        const TMPFILE_INO: INodeNo = INodeNo(2);
+
+        struct TmpFileFs {
+            seen: Arc<Mutex<Option<(u32, i32)>>>,
+            linked: Arc<Mutex<Option<INodeNo>>>,
+        }
+        impl TmpFileFs {
+            fn attr(ino: INodeNo, kind: FileType, perm: u16) -> FileAttr {
+                let now = SystemTime::now();
+                FileAttr {
+                    ino,
+                    size: 0,
+                    blocks: 0,
+                    atime: now,
+                    mtime: now,
+                    ctime: now,
+                    crtime: now,
+                    kind,
+                    perm,
+                    nlink: if kind == FileType::Directory { 2 } else { 0 },
+                    uid: geteuid().as_raw(),
+                    gid: 0,
+                    rdev: 0,
+                    blksize: 4096,
+                    flags: 0,
+                }
+            }
+        }
+        impl Filesystem for TmpFileFs {
+            fn lookup(
+                &self,
+                _req: &Request,
+                _parent: INodeNo,
+                _name: &std::ffi::OsStr,
+                reply: crate::ReplyEntry,
+            ) {
+                // The name the link below creates must not exist yet
+                reply.error(Errno::ENOENT);
+            }
+            fn link(
+                &self,
+                _req: &Request,
+                ino: INodeNo,
+                _newparent: INodeNo,
+                _newname: &std::ffi::OsStr,
+                reply: crate::ReplyEntry,
+            ) {
+                *self.linked.lock() = Some(ino);
+                reply.entry(
+                    &Duration::from_secs(0),
+                    &Self::attr(ino, FileType::RegularFile, 0o600),
+                    Generation(0),
+                );
+            }
+            fn getattr(
+                &self,
+                _req: &Request,
+                ino: INodeNo,
+                _fh: Option<crate::FileHandle>,
+                reply: crate::ReplyAttr,
+            ) {
+                let attr = if ino == TMPFILE_INO {
+                    Self::attr(ino, FileType::RegularFile, 0o600)
+                } else {
+                    Self::attr(ino, FileType::Directory, 0o755)
+                };
+                reply.attr(&Duration::from_secs(0), &attr);
+            }
+            fn tmpfile(
+                &self,
+                _req: &Request,
+                _parent: INodeNo,
+                mode: u32,
+                _umask: u32,
+                flags: i32,
+                _kill_suid_gid: bool,
+                reply: ReplyCreate,
+            ) {
+                *self.seen.lock() = Some((mode, flags));
+                reply.created(
+                    &Duration::from_secs(0),
+                    &Self::attr(TMPFILE_INO, FileType::RegularFile, 0o600),
+                    Generation(0),
+                    crate::FileHandle(1),
+                    FopenFlags::empty(),
+                );
+            }
+        }
+
+        let tmp = ManuallyDrop::new(tempfile::tempdir().unwrap());
+        let mountpoint = tmp.path().canonicalize().unwrap();
+        let seen = Arc::new(Mutex::new(None));
+        let linked = Arc::new(Mutex::new(None));
+        let session = Session::new(
+            TmpFileFs {
+                seen: seen.clone(),
+                linked: linked.clone(),
+            },
+            &mountpoint,
+            &Config::default(),
+        )
+        .unwrap();
+        // FUSE_TMPFILE arrived in ABI 7.37, and a kernel without it has no tmpfile inode
+        // operation at all, so it answers O_TMPFILE itself without asking the filesystem
+        // anything. fuser supports back to 7.6, so that is not a failure of this change
+        let supported = session.proto_version.is_some_and(|v| v >= Version(7, 37));
+        let bg = session.spawn().unwrap();
+        if !supported {
+            eprintln!("skipping tmpfile_open: the kernel's FUSE protocol predates 7.37");
+            bg.umount_and_join().unwrap();
+            ManuallyDrop::into_inner(tmp);
+            return;
+        }
+
+        let opened = nix::fcntl::open(
+            &mountpoint,
+            nix::fcntl::OFlag::O_TMPFILE | nix::fcntl::OFlag::O_RDWR,
+            nix::sys::stat::Mode::from_bits_truncate(0o600),
+        );
+        // Give the anonymous file a name, which is what it exists to allow. Going through
+        // /proc/self/fd rather than AT_EMPTY_PATH, which would need CAP_DAC_READ_SEARCH
+        let named = opened.as_ref().map_err(|err| *err).and_then(|fd| {
+            let by_fd = format!("/proc/self/fd/{}", fd.as_raw_fd());
+            nix::unistd::linkat(
+                nix::fcntl::AT_FDCWD,
+                by_fd.as_str(),
+                nix::fcntl::AT_FDCWD,
+                mountpoint.join("named.txt").as_path(),
+                nix::fcntl::AtFlags::AT_SYMLINK_FOLLOW,
+            )
+        });
+
+        let seen = seen.lock().take();
+        let linked = linked.lock().take();
+        let opened = opened.map(drop);
+        drop(bg);
+        ManuallyDrop::into_inner(tmp);
+
+        opened.expect("the descriptor the filesystem replied with must reach the caller");
+        named.expect("linking the anonymous file must reach the filesystem");
+        assert_eq!(
+            linked,
+            Some(TMPFILE_INO),
+            "the link must name the inode tmpfile() replied with"
+        );
+        let (mode, flags) = seen.expect("O_TMPFILE must reach Filesystem::tmpfile");
+        // The kernel insists on S_IFREG for these, and applies the umask itself
+        assert_eq!(mode & libc::S_IFMT, libc::S_IFREG);
+        assert_eq!(
+            flags & libc::O_TMPFILE,
+            libc::O_TMPFILE,
+            "flags {flags:#x} must carry O_TMPFILE"
+        );
+    }
+
     /// The kernel fills a request's uid, gid and pid from the task that caused it, for
     /// every operation that goes through fuse_simple_request(). Every access decision
     /// fuser makes rests on that - SessionACL, and which operations are exempt from it


### PR DESCRIPTION
Fixes #366.

`FUSE_TMPFILE` is opcode 51, ABI 7.37. The kernel sends it for `open()` with `O_TMPFILE`, asking for a file with no name that belongs to no directory until `linkat()` gives it one.

On the wire it is a create request: `fuse_create_open()` in the kernel builds it with `opcode = FUSE_TMPFILE` and otherwise identical arguments, so it carries `fuse_create_in` plus a name and is answered with `fuse_entry_out` + `fuse_open_out`. The name is the placeholder `/` that the VFS gives every anonymous dentry, so it says nothing and is not passed to the filesystem -- libfuse's `tmpfile` handler drops it for the same reason, taking only `(req, parent, mode, fi)`.

Unlike #359 this is reachable on an ordinary mount, so it comes with a real end-to-end test rather than only an ABI one.

Behaviour is unchanged for a filesystem that does not implement it: `ENOSYS` is what the unknown-opcode path already returned, the kernel takes that as permanent, sets `fc->no_tmpfile` and reports `EOPNOTSUPP` without asking again. That includes the `simple` example, so nothing in pjdfs or xfstests changes.

## Testing

- `session::test::tmpfile_open` mounts a filesystem, opens the mountpoint with `O_TMPFILE | O_RDWR`, and requires that the call reaches `Filesystem::tmpfile()` with `S_IFREG` set and `O_TMPFILE` in the flags, and that the descriptor the filesystem replies with gets back to the caller. Confirmed it fails without the dispatch arm, with `EOPNOTSUPP` -- which is exactly the old behaviour, so the test is pinning the change rather than the plumbing.
- `ll::request::tests::tmpfile` covers the parse in the byte-level style of the neighbouring request tests, for both endiannesses.

`cargo fmt`, all three `clippy` invocations from `make pre`, `cargo doc`, `cargo test --all` with and without `libfuse`, the musl build, `cargo check --target x86_64-apple-darwin --features=macos-no-mount`, and `make test_passthrough` are green. Docker was unavailable here, so `mount_tests`/`pjdfs_tests`/`xfstests` did not run locally.

## Not included

`simple` does not implement `tmpfile`. Doing so needs an inode with no name and no parent, plus `link()` to later give it one, which is a feature of the example rather than of this change -- and without it the example's behaviour is byte-for-byte what it is today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5akmePV1VnD9YRQLZH4gv

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5akmePV1VnD9YRQLZH4gv)_