### PR TITLE
Install what xfstests needs to run more of its suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,12 @@ pre:
 xfstests:
 	docker build -t fuser:xfstests -f xfstests.Dockerfile .
 	# Additional permissions are needed to be able to mount FUSE
-	docker run --rm -$(INTERACTIVE)t --cap-add SYS_ADMIN --cap-add IPC_OWNER --device /dev/fuse --security-opt apparmor:unconfined \
+	# LINUX_IMMUTABLE is for chattr +i/+a, and SYS_PACCT for BSD process accounting. Neither
+	# is in Docker's default set, and without them those tests fail rather than skip.
+	# The seccomp profile is left on: turning it off would let the io_uring tests run, but it
+	# also unblocks swapon, and swap is a global resource rather than a per-container one
+	docker run --rm -$(INTERACTIVE)t --cap-add SYS_ADMIN --cap-add IPC_OWNER --cap-add SYS_PACCT \
+	 --cap-add LINUX_IMMUTABLE --device /dev/fuse --security-opt apparmor:unconfined \
 	 --memory=2g --kernel-memory=200m \
 	 -v "$(shell pwd)/logs:/code/logs" fuser:xfstests bash -c "cd /code/fuser && ./xfstests.sh"
 

--- a/xfstests.Dockerfile
+++ b/xfstests.Dockerfile
@@ -2,10 +2,20 @@ FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+# libcap2-bin (setcap/getcap/capsh), fio, acct (accton) and the gdbm headers that build
+# src/dbtest are each what stands between some tests and running at all.
+#
+# liburing-dev is deliberately absent. It would build src/feature with io_uring support and
+# let four more tests run, but only alongside seccomp=unconfined, since Docker's default
+# profile blocks io_uring outright - and turning that off also unblocks swapon, which is
+# global rather than per-container. Without liburing those tests skip, which is what we want:
+# with it and seccomp left on, _require_io_uring reads the EPERM as an error and fails
 RUN apt update && apt install -y git build-essential autoconf curl cmake libfuse-dev pkg-config fuse bc libtool \
-  uuid-dev xfslibs-dev libattr1-dev libacl1-dev libaio-dev attr acl quota bsdmainutils dbench psmisc
+  uuid-dev xfslibs-dev libattr1-dev libacl1-dev libaio-dev attr acl quota bsdmainutils dbench psmisc \
+  libcap2-bin fio acct libgdbm-dev libgdbm-compat-dev
 
-RUN adduser --disabled-password --gecos '' fsgqa
+# Tests that check permissions across two unrelated unprivileged users need both
+RUN adduser --disabled-password --gecos '' fsgqa && adduser --disabled-password --gecos '' fsgqa2
 
 RUN echo 'user_allow_other' >> /etc/fuse.conf
 

--- a/xfstests.sh
+++ b/xfstests.sh
@@ -117,6 +117,20 @@ echo "generic/750" >> xfs_excludes.txt
 # dmesg's complaint about it shows up in the output
 echo "generic/310" >> xfs_excludes.txt
 
+# Setting sysctls is not allowed inside Docker: /proc/sys is mounted read-only. Both tests
+# toggle fs.protected_symlinks / fs.protected_regular, and sysctl's refusal to do so lands in
+# the output. Making /proc/sys writable would let them through, but those knobs are global, so
+# the container would be reaching out and changing the host's
+echo "generic/597" >> xfs_excludes.txt
+echo "generic/598" >> xfs_excludes.txt
+
+# TODO: getcap and setcap now let this one run, and it finds that the filesystem does not drop
+# security.capability when an unprivileged user writes the file. The write it uses is a
+# fallocate, which comes back EPERM without ever reaching the filesystem, because the kernel
+# sends the removal under the writer's credentials and the filesystem wants root for a
+# security.* key. Drop this exclusion once the simple example lets that removal through
+echo "generic/688" >> xfs_excludes.txt
+
 # fsx against hugepage-backed buffers, which cannot be set up here: MADV_COLLAPSE is refused
 # and init_hugepages_buf fails before any filesystem operation runs
 echo "generic/759" >> xfs_excludes.txt


### PR DESCRIPTION
A large number of xfstests skips turn out to have nothing to do with what the
filesystem supports - the image or the container is simply missing something.
This is the container-setup half of that; the filesystem-side fixes follow
separately.

## What's missing

`xfstests.Dockerfile` gains `libcap2-bin` (setcap/getcap/capsh), `fio`, `acct`
(accton), and `libgdbm-dev` + `libgdbm-compat-dev` (which is what builds
`src/dbtest`). Each is the sole reason some test reports itself unrunnable. A
second unprivileged user, `fsgqa2`, is added for the tests that check
permissions between two unrelated users.

`CAP_LINUX_IMMUTABLE` and `CAP_SYS_PACCT` are not in Docker's default capability
set. This matters more than a missing package does: the tests that need them
read the resulting EPERM as an error rather than as absence, so without the
capabilities they *fail* rather than skip.

## What's deliberately left out

The four io_uring tests would run if `liburing-dev` were installed, but only
alongside `--security-opt seccomp=unconfined`, because Docker's default profile
blocks the io_uring syscalls outright and no capability unblocks them.

Measured against the capability set this container already has, turning seccomp
off makes exactly four things newly reachable: the io_uring syscalls, `swapon` /
`swapoff`, `keyctl` / `add_key`, and `open_by_handle_at` (inert without
`CAP_DAC_READ_SEARCH`, which is not granted). Everything else the default
profile guards - `bpf`, `mount`, `perf_event_open`, `quotactl`, `unshare`,
`setns` and friends - is already permitted, because the profile allows that set
whenever the container holds `CAP_SYS_ADMIN`, which this one needs in order to
mount FUSE. The host clock, kernel modules and reboot stay blocked either way,
by capability rather than by seccomp.

`swapon` is the one that reaches past the container: swap is a global kernel
resource, and `_require_scratch_swapfile` genuinely calls `swapon` on a file in
the scratch mount. It currently fails EINVAL because FUSE implements no
`swap_activate`, but that is a property of the filesystem under test rather than
a guarantee from the sandbox. Four tests are not worth it.

The two have to move together, which is why neither is here: with `liburing-dev`
installed but seccomp left on, `src/feature -R` returns 2 and
`_require_io_uring` calls `_fail`, so those tests would fail rather than skip.

## Effect

Four tests go from skipped to passing: generic/010 (dbtest), 093 (setcap and
getcap), and 095 and 366 (fio). Nothing that ran before stops running.

Several more get as far as needing filesystem support and skip on that instead,
which is the honest answer: generic/079, 545 and 555 want `chattr +i`/`+a`, and
596 wants `chattr +S`. They will run once that lands.

Two tests get further than this environment can take them and are excluded:

- generic/597 and generic/598 reach a sysctl write, which `/proc/sys` being
  read-only inside Docker refuses. Mounting it writable would let them through,
  but `fs.protected_symlinks` and `fs.protected_regular` are global, so the
  container would be reaching out and changing the host's.
- generic/688 finds a real gap in the simple example: the filesystem does not
  drop `security.capability` when an unprivileged user writes the file, because
  the kernel sends that removal under the writer's credentials and the
  filesystem wants root for a `security.*` key. The write it uses is a
  `fallocate`, which comes back EPERM without ever reaching the filesystem. The
  exclusion carries a note to drop it once that is fixed.

## Testing

Full suite, green, with the four above the only difference from the previous
run. The io_uring tests skip with the same "kernel does not support IO_URING"
they reported before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4hiZwHE9fEYdn7DK3ZrV2