### PR TITLE
Let an unprivileged writer drop security.capability in the simple example

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -2037,9 +2037,18 @@ impl Filesystem for SimpleFS {
 
     fn removexattr(&self, request: &Request, inode: INodeNo, key: &OsStr, reply: ReplyEmpty) {
         if let Ok(mut attrs) = self.get_inode(inode) {
-            if let Err(error) = xattr_access_check(key.as_bytes(), libc::W_OK, &attrs, request) {
-                reply.error(error);
-                return;
+            // The kernel drops `security.capability` on behalf of whoever is writing the file,
+            // and sends that removal under their credentials rather than its own. Refusing it
+            // because they are not root fails the operation it was part of - a `fallocate` by
+            // an unprivileged user returns EPERM without ever reaching this filesystem. So
+            // this one key is removable by anyone: doing so only ever takes privilege away.
+            // Setting it still needs root, as it does for any other `security.*` key
+            if key.as_bytes() != b"security.capability" {
+                if let Err(error) = xattr_access_check(key.as_bytes(), libc::W_OK, &attrs, request)
+                {
+                    reply.error(error);
+                    return;
+                }
             }
 
             if attrs.xattrs.remove(key.as_bytes()).is_none() {

--- a/xfstests.sh
+++ b/xfstests.sh
@@ -127,13 +127,6 @@ echo "generic/310" >> xfs_excludes.txt
 echo "generic/597" >> xfs_excludes.txt
 echo "generic/598" >> xfs_excludes.txt
 
-# TODO: getcap and setcap now let this one run, and it finds that the filesystem does not drop
-# security.capability when an unprivileged user writes the file. The write it uses is a
-# fallocate, which comes back EPERM without ever reaching the filesystem, because the kernel
-# sends the removal under the writer's credentials and the filesystem wants root for a
-# security.* key. Drop this exclusion once the simple example lets that removal through
-echo "generic/688" >> xfs_excludes.txt
-
 # fsx against hugepage-backed buffers, which cannot be set up here: MADV_COLLAPSE is refused
 # and init_hugepages_buf fails before any filesystem operation runs
 echo "generic/759" >> xfs_excludes.txt


### PR DESCRIPTION
First of the filesystem-side fixes following #741, which turned this up.

## The bug

When an unprivileged user writes a file carrying `security.capability`, the
kernel clears the xattr on their behalf - and sends that removal under *their*
credentials rather than its own. The simple example refused it, because it wants
root for anything in the `security.*` namespace.

Refusing it does not just leave the capability in place; it fails the operation
the removal was part of. A `fallocate` by an unprivileged user on such a file
returns EPERM without ever reaching the filesystem, because the kernel's
`file_remove_privs()` runs first and gives up when the removal is denied.

That one key is now removable by anyone, since removing it only ever takes
privilege away. Setting it still needs root, as do the other `security.*` keys.

## Effect

generic/688 passes and its exclusion - added in #741 with a note pointing at
exactly this - goes away with it.

## Testing

Full suite, green: 159 tests run, 0 failures. generic/688 goes from excluded to
passing; generic/093 (which checks that a write clears the capability by the
other path, where the filesystem clears it itself), 020 and 097 are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4hiZwHE9fEYdn7DK3ZrV2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4hiZwHE9fEYdn7DK3ZrV2)_