### PR TITLE
Support O_TMPFILE in the simple example

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -730,6 +730,17 @@ impl SimpleFS {
         rmp_serde::encode::write(&mut file, inode).unwrap();
     }
 
+    /// Drops one open handle and reclaims the inode if that was the last thing keeping it.
+    /// The decrement has to be written back before [`Self::gc_inode`] is consulted, since an
+    /// inode with no links is held on disk only by its open handles - an anonymous file from
+    /// [`Filesystem::tmpfile`] has never had a link, and a file unlinked while open has lost
+    /// its last one, and either way closing the final handle is what makes it collectable
+    fn close_handle(&self, attrs: &mut InodeAttributes) {
+        attrs.open_file_handles = attrs.open_file_handles.saturating_sub(1);
+        self.write_inode(attrs);
+        self.gc_inode(attrs);
+    }
+
     // Check whether a file should be removed from storage. Should be called after decrementing
     // the link count, or closing a file handle
     fn gc_inode(&self, inode: &InodeAttributes) -> bool {
@@ -2132,7 +2143,7 @@ impl Filesystem for SimpleFS {
         reply: ReplyEmpty,
     ) {
         if let Ok(mut attrs) = self.get_inode(_ino) {
-            attrs.open_file_handles -= 1;
+            self.close_handle(&mut attrs);
         }
         reply.ok();
     }
@@ -2229,7 +2240,7 @@ impl Filesystem for SimpleFS {
         reply: ReplyEmpty,
     ) {
         if let Ok(mut attrs) = self.get_inode(_ino) {
-            attrs.open_file_handles -= 1;
+            self.close_handle(&mut attrs);
         }
         reply.ok();
     }
@@ -2575,6 +2586,107 @@ impl Filesystem for SimpleFS {
             self.write_inode(&attrs);
         }
         reply.ioctl(0, &[]);
+    }
+
+    /// Creates a file that no name reaches, for `open(..., O_TMPFILE)`. It belongs to
+    /// `parent`'s directory - that is where its space is accounted, and where it will live if
+    /// `link()` later gives it a name - but no entry points at it, so the descriptor replied
+    /// with here is the only way to it. Answering at all is what keeps the kernel offering
+    /// O_TMPFILE on this connection: the default ENOSYS turns it off permanently
+    fn tmpfile(
+        &self,
+        req: &Request,
+        parent: INodeNo,
+        mut mode: u32,
+        _umask: u32,
+        flags: i32,
+        _kill_suid_gid: bool,
+        reply: ReplyCreate,
+    ) {
+        debug!("tmpfile() called with {parent:?} {mode:o}");
+        let (read, write) = match flags & libc::O_ACCMODE {
+            libc::O_WRONLY => (false, true),
+            libc::O_RDWR => (true, true),
+            // An anonymous file that cannot be written is of no use, and the kernel rejects
+            // the combination before it reaches a filesystem
+            _ => {
+                reply.error(Errno::EINVAL);
+                return;
+            }
+        };
+
+        let parent_attrs = match self.get_inode(parent) {
+            Ok(attrs) => attrs,
+            Err(error_code) => {
+                reply.error(error_code);
+                return;
+            }
+        };
+
+        if parent_attrs.kind != FileKind::Directory {
+            reply.error(Errno::ENOTDIR);
+            return;
+        }
+
+        // The directory has to be writable even though nothing is written to it, and
+        // searchable even though nothing is looked up in it: `vfs_tmpfile` asks its own
+        // filesystems for `MAY_WRITE | MAY_EXEC` here. Unlike create(), neither is implied by
+        // anything the kernel has already checked - the directory is the operand rather than
+        // a path component, so no lookup has passed through it
+        if let Err(error_code) = parent_attrs.check_writable() {
+            reply.error(error_code);
+            return;
+        }
+
+        if !check_access(
+            parent_attrs.uid,
+            parent_attrs.gid,
+            parent_attrs.mode,
+            req.uid(),
+            req.gid(),
+            AccessFlags::W_OK | AccessFlags::X_OK,
+        ) {
+            reply.error(Errno::EACCES);
+            return;
+        }
+
+        // Unlike create(), the parent's timestamps are left alone: no entry is added to it
+
+        if req.uid() != 0 {
+            mode &= !(libc::S_ISUID | libc::S_ISGID) as u32;
+        }
+
+        let now = time_now();
+        let inode = self.allocate_next_inode();
+        let attrs = InodeAttributes {
+            inode: inode.0,
+            open_file_handles: 1,
+            size: 0,
+            last_accessed: now,
+            last_modified: now,
+            last_metadata_changed: now,
+            // The kernel only ever asks for a regular file here
+            kind: FileKind::File,
+            mode: self.creation_mode(mode),
+            // What makes it anonymous. Closing the last handle without linking it collects it,
+            // and link() takes it from here to 1
+            hardlinks: 0,
+            uid: req.uid(),
+            gid: creation_gid(&parent_attrs, req.gid()),
+            rdev: 0,
+            flags: 0,
+            xattrs: BTreeMap::default(),
+        };
+        self.write_inode(&attrs);
+        File::create(self.content_path(inode)).unwrap();
+
+        reply.created(
+            &Duration::new(0, 0),
+            &self.file_attr(attrs),
+            fuser::Generation(0),
+            FileHandle(self.allocate_next_file_handle(read, write)),
+            FopenFlags::empty(),
+        );
     }
 
     #[cfg(target_os = "linux")]

--- a/xfstests.sh
+++ b/xfstests.sh
@@ -55,6 +55,13 @@ echo "generic/099" >> xfs_excludes.txt
 echo "generic/105" >> xfs_excludes.txt
 echo "generic/375" >> xfs_excludes.txt
 
+# TODO: requires inheriting a directory's default ACL at creation. The xattr itself round-trips,
+# but nothing consults it when a file is created, so the umask applies where the default ACL
+# should have: the test asks for mode 0666 under a 0775 default ACL and wants 0664, not 0644.
+# Nothing to do with the O_TMPFILE this test creates the file with - an ordinary create() in the
+# same directory gets the mode wrong the same way
+echo "generic/389" >> xfs_excludes.txt
+
 # TODO: requires support for remounting read-only. 306 and 452 additionally need a change in
 # fuse-xfstests, whose _scratch_remount answers "fuse.fuser does not support any options"
 # without attempting the remount; 294 goes through _try_scratch_mount and does attempt it


### PR DESCRIPTION
Implements `Filesystem::tmpfile()`, added in c55df5d, so that
`open(dir, O_TMPFILE | O_RDWR)` gets an anonymous file: an inode that belongs to
the directory it was created in, holds content, and can later be given a name
with `linkat()`, but that no directory entry reaches in the meantime. Answering
the request at all is what keeps it available - the default `ENOSYS` makes the
kernel stop offering `O_TMPFILE` on the connection for good.

## How it differs from create()

Three ways, beyond the missing name:

- **The inode starts with no links** rather than one. That is what makes it
  anonymous, and what `link()` later takes to one.
- **The parent's timestamps are left alone**, because nothing is added to it.
- **The parent must still be writable**, which is what the kernel asks of its own
  filesystems here even though nothing is written to it.

## The leak this had to fix first

`release()` decremented `open_file_handles` on a *copy* of the attributes and
dropped it - never writing the count back, never calling `gc_inode()`. So on disk
the count only ever grew, and closing a file collected nothing.

For a file with a name that is invisible, since the name holds the inode either
way. An anonymous file has nothing else holding it: every `O_TMPFILE` that was
never linked would have leaked both its inode and its content, on every use.
`release()` and `releasedir()` now go through a helper that writes the decrement
back before consulting `gc_inode()`. The same leak applied to a file unlinked
while open, so that is reclaimed now too.

## Effect

generic/004 runs and passes.

generic/389 creates its file with `O_TMPFILE` as well, so it stops being skipped
and starts running - and fails. It sets a default ACL on the directory and wants
that to supply the mode where the umask otherwise would: mode 0666 under a 0775
default ACL should give 0664, and this filesystem gives 0644. That is not a
tmpfile gap. With the default ACL set and reading back correctly, an ordinary
`create()` in the same directory gets the mode wrong the same way, so nothing
about this PR causes it and implementing tmpfile only made it visible. Excluded
alongside the other ACL tests, with that noted.

generic/509 turns out to need a valid scratch block device, so it stays out of
reach whether or not `O_TMPFILE` works.

## Testing

Full suite, green: 174 tests run, 0 failures, no filesystem panics.

The semantics were checked directly rather than assumed - written data reads
back, `st_nlink` is 0, the file is absent from the directory listing, `linkat`
gives it a name with its content intact and `st_nlink` 1, and
`O_TMPFILE | O_RDONLY` is refused. For the leak: the backing inode and content
appear while the descriptor is open and are gone once it closes, both for a
tmpfile that was never linked and for a file unlinked while open.

Built clean for macOS via
`cargo check --example simple --target x86_64-apple-darwin --features=macos-no-mount`
with `--deny warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4hiZwHE9fEYdn7DK3ZrV2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4hiZwHE9fEYdn7DK3ZrV2)_