### PR TITLE
Add Filesystem::statx() for FUSE_STATX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # FUSE for Rust - Changelog
 
 ## Unreleased
+* Add `Filesystem::statx()`, which the kernel calls for `statx(2)` (ABI 7.38), along with
+  `StatxAttr` and `ReplyStatx`. This exists to report a creation time, which no other request
+  can carry: `fuse_attr` has a field for it on macOS alone, so on Linux `statx(2)` otherwise
+  reports whatever the kernel cached. Leaving it unimplemented reports `ENOSYS`, which the
+  kernel takes as permanent: it stops sending `FUSE_STATX` on that connection and answers
+  `statx(2)` out of `getattr()`, which is what happened before. Note that `StatxAttr` also
+  carries the `STATX_ATTR_*` properties, such as immutable and append-only, because the wire
+  format does - but the kernel discards them from a FUSE reply, so setting them does not make
+  `chattr +i` visible to `statx(2)`
 * Add `Filesystem::tmpfile()`, which the kernel calls for `open()` with `O_TMPFILE` (#366,
   ABI 7.37). The file has no name and belongs to no directory until `linkat()` gives it one,
   so unlike `create()` this is told only which directory it was made in. Leaving it

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,8 @@ pub use crate::ll::flags::fopen_flags::FopenFlags;
 pub use crate::ll::flags::init_flags::InitFlags;
 pub use crate::ll::flags::ioctl_flags::IoctlFlags;
 pub use crate::ll::flags::poll_flags::PollFlags;
+pub use crate::ll::flags::statx_flags::StatxAttributes;
+pub use crate::ll::flags::statx_flags::StatxMask;
 pub use crate::ll::flags::write_flags::WriteFlags;
 pub use crate::ll::fuse_abi::consts;
 pub use crate::ll::request::FileHandle;
@@ -71,6 +73,7 @@ pub use crate::reply::ReplyLseek;
 pub use crate::reply::ReplyOpen;
 pub use crate::reply::ReplyPoll;
 pub use crate::reply::ReplyStatfs;
+pub use crate::reply::ReplyStatx;
 pub use crate::reply::ReplyWrite;
 pub use crate::reply::ReplyXattr;
 pub use crate::request_param::Request;
@@ -256,6 +259,45 @@ pub struct FileAttr {
     pub blksize: u32,
     /// Flags (macOS only, see chflags(2))
     pub flags: u32,
+}
+
+/// What `statx(2)` reports, which is [`FileAttr`] plus the fields `stat(2)` has no room for.
+///
+/// In practice that means [`btime`](Self::btime): a creation time, which `FUSE_GETATTR` has
+/// no field for on Linux and which no other request can carry.
+#[derive(Debug, Clone, Copy)]
+pub struct StatxAttr {
+    /// Everything `stat(2)` also reports
+    pub attr: FileAttr,
+    /// Time of creation, reported to the caller only when this is `Some`. Unlike
+    /// [`FileAttr::crtime`] this is not macOS-only, since `statx(2)` has a field for it
+    pub btime: Option<SystemTime>,
+    /// Properties of the file that are set, such as immutable or append-only.
+    ///
+    /// **The kernel currently discards this.** `fuse_do_statx()` takes the mask, the creation
+    /// time and the basic stats out of the reply and ignores the attributes, so nothing set
+    /// here reaches `statx(2)` - checked against mainline as of 6.18. The field is part of
+    /// the wire format and is sent, so a filesystem that fills it is correct today and needs
+    /// no change if the kernel starts reading it, but do not expect `chattr +i` to become
+    /// visible to `statx(2)` this way.
+    pub attributes: StatxAttributes,
+    /// Properties this filesystem knows about at all, set or not, distinguishing "not set"
+    /// from "cannot say".
+    ///
+    /// Discarded by the kernel for the same reason as [`attributes`](Self::attributes).
+    pub attributes_mask: StatxAttributes,
+}
+
+impl From<FileAttr> for StatxAttr {
+    /// Reports what `stat(2)` would, and nothing beyond it
+    fn from(attr: FileAttr) -> Self {
+        Self {
+            attr,
+            btime: None,
+            attributes: StatxAttributes::empty(),
+            attributes_mask: StatxAttributes::empty(),
+        }
+    }
 }
 
 impl TryFrom<&std::fs::Metadata> for FileAttr {
@@ -564,6 +606,38 @@ pub trait Filesystem: Send + Sync + 'static {
     /// Get file attributes.
     fn getattr(&self, _req: &Request, ino: INodeNo, fh: Option<FileHandle>, reply: ReplyAttr) {
         warn!("[Not Implemented] getattr(ino: {ino:#x?}, fh: {fh:#x?})");
+        reply.error(Errno::ENOSYS);
+    }
+
+    /// Get extended file attributes, for `statx(2)`.
+    ///
+    /// Answering this rather than leaving it to [`Filesystem::getattr`] lets a filesystem
+    /// report a creation time, which no other request can carry: `fuse_attr` has a field for
+    /// it on macOS alone, and `statx(2)` otherwise reports whatever the kernel last cached.
+    ///
+    /// It does not, despite the wire format having room for them, make the `STATX_ATTR_*`
+    /// properties reportable - see [`StatxAttr::attributes`].
+    ///
+    /// `mask` is what the caller asked for. It is a request rather than an obligation:
+    /// answering with more costs nothing, and what the reply actually carries is described by
+    /// the reply itself.
+    ///
+    /// Answering `ENOSYS`, which is the default, is permanent: the kernel stops sending
+    /// `FUSE_STATX` on this connection and serves `statx(2)` out of [`Filesystem::getattr`],
+    /// which is what it did before this existed.
+    fn statx(
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        fh: Option<FileHandle>,
+        flags: u32,
+        mask: StatxMask,
+        reply: ReplyStatx,
+    ) {
+        warn!(
+            "[Not Implemented] statx(ino: {ino:#x?}, fh: {fh:#x?}, flags: {flags:#x?}, \
+            mask: {mask:?})"
+        );
         reply.error(Errno::ENOSYS);
     }
 

--- a/src/ll/flags/mod.rs
+++ b/src/ll/flags/mod.rs
@@ -12,4 +12,5 @@ pub(crate) mod open_in_flags;
 pub(crate) mod poll_flags;
 pub(crate) mod read_flags;
 pub(crate) mod release_flags;
+pub(crate) mod statx_flags;
 pub(crate) mod write_flags;

--- a/src/ll/flags/statx_flags.rs
+++ b/src/ll/flags/statx_flags.rs
@@ -1,0 +1,72 @@
+use bitflags::bitflags;
+
+bitflags! {
+    /// Which fields of a `statx` reply are filled in, as `struct statx`'s `stx_mask`.
+    ///
+    /// A filesystem does not choose these: they follow from what it answered with, and
+    /// [`crate::StatxAttr`] derives them. The caller's own request is a separate mask, which
+    /// reaches [`crate::Filesystem::statx`] as `mask`.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct StatxMask: u32 {
+        /// `stx_mode` & `S_IFMT` is filled in.
+        const TYPE = 1 << 0;
+        /// `stx_mode` & `!S_IFMT` is filled in.
+        const MODE = 1 << 1;
+        /// `stx_nlink` is filled in.
+        const NLINK = 1 << 2;
+        /// `stx_uid` is filled in.
+        const UID = 1 << 3;
+        /// `stx_gid` is filled in.
+        const GID = 1 << 4;
+        /// `stx_atime` is filled in.
+        const ATIME = 1 << 5;
+        /// `stx_mtime` is filled in.
+        const MTIME = 1 << 6;
+        /// `stx_ctime` is filled in.
+        const CTIME = 1 << 7;
+        /// `stx_ino` is filled in.
+        const INO = 1 << 8;
+        /// `stx_size` is filled in.
+        const SIZE = 1 << 9;
+        /// `stx_blocks` is filled in.
+        const BLOCKS = 1 << 10;
+        /// Everything a plain `stat(2)` also reports.
+        const BASIC_STATS = 0x0000_07ff;
+        /// `stx_btime` is filled in.
+        const BTIME = 1 << 11;
+    }
+}
+
+bitflags! {
+    /// Properties of a file that `statx(2)` reports beyond `stat(2)`, as `stx_attributes`.
+    ///
+    /// The kernel has no way to learn these from a FUSE filesystem other than being told: it
+    /// fills `stx_attributes` from its own inode flags, which a FUSE filesystem's flags are
+    /// not. Answering `FUSE_STATX` is what makes `chattr +i` and friends visible to
+    /// `statx(2)`.
+    ///
+    /// Whatever is reported here counts only where the matching bit is also set in
+    /// [`crate::StatxAttr::attributes_mask`], which is how a caller tells "not set" from
+    /// "not supported".
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+    pub struct StatxAttributes: u64 {
+        /// The file is compressed by the filesystem.
+        const COMPRESSED = 1 << 2;
+        /// The file is marked immutable, as `chattr +i` sets.
+        const IMMUTABLE = 1 << 4;
+        /// The file is append-only, as `chattr +a` sets.
+        const APPEND = 1 << 5;
+        /// The file is not to be dumped, as `chattr +d` sets.
+        const NODUMP = 1 << 6;
+        /// The file needs a key to be decrypted by the filesystem.
+        const ENCRYPTED = 1 << 11;
+        /// The directory is an automount trigger.
+        const AUTOMOUNT = 1 << 12;
+        /// The entry is the root of a mount.
+        const MOUNT_ROOT = 1 << 13;
+        /// The file is protected by fs-verity.
+        const VERITY = 1 << 20;
+        /// The file is in the DAX state, mapped directly from persistent memory.
+        const DAX = 1 << 21;
+    }
+}

--- a/src/ll/fuse_abi.rs
+++ b/src/ll/fuse_abi.rs
@@ -168,6 +168,7 @@ pub(crate) enum fuse_opcode {
     FUSE_COPY_FILE_RANGE = 47,
     FUSE_SYNCFS = 50,
     FUSE_TMPFILE = 51,
+    FUSE_STATX = 52,
 
     #[cfg(target_os = "macos")]
     FUSE_SETVOLNAME = 61,
@@ -196,6 +197,70 @@ pub(crate) enum fuse_notify_code {
 /// ABI version that added `FUSE_NOTIFY_INC_EPOCH`. An older kernel has no case for the
 /// code and answers the write with `EINVAL`
 pub(crate) const FUSE_NOTIFY_INC_EPOCH_VERSION: Version = Version(7, 44);
+
+/// ABI version that added `FUSE_STATX`. An older kernel never sends the opcode, and answers
+/// `statx(2)` out of what `FUSE_GETATTR` gives it, so nothing outside the tests has to ask -
+/// and only the Linux ones, since `statx(2)` is Linux's
+#[cfg(all(test, target_os = "linux"))]
+pub(crate) const FUSE_STATX_VERSION: Version = Version(7, 38);
+
+/// A timestamp as `struct statx` carries one, which unlike `fuse_attr`'s pair of fields is a
+/// signed second count with its own padding
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, Clone, Copy, KnownLayout, Immutable)]
+pub(crate) struct fuse_sx_time {
+    pub(crate) tv_sec: i64,
+    pub(crate) tv_nsec: u32,
+    pub(crate) __reserved: i32,
+}
+
+/// The `struct statx` payload, laid out as the kernel's `fuse_statx`. Every field the caller
+/// did not ask for is still sent, and `mask` is what says which of them mean anything
+#[repr(C)]
+#[derive(Debug, Default, IntoBytes, Clone, Copy, KnownLayout, Immutable)]
+pub(crate) struct fuse_statx {
+    pub(crate) mask: u32,
+    pub(crate) blksize: u32,
+    pub(crate) attributes: u64,
+    pub(crate) nlink: u32,
+    pub(crate) uid: u32,
+    pub(crate) gid: u32,
+    pub(crate) mode: u16,
+    pub(crate) __spare0: [u16; 1],
+    pub(crate) ino: u64,
+    pub(crate) size: u64,
+    pub(crate) blocks: u64,
+    pub(crate) attributes_mask: u64,
+    pub(crate) atime: fuse_sx_time,
+    pub(crate) btime: fuse_sx_time,
+    pub(crate) ctime: fuse_sx_time,
+    pub(crate) mtime: fuse_sx_time,
+    pub(crate) rdev_major: u32,
+    pub(crate) rdev_minor: u32,
+    pub(crate) dev_major: u32,
+    pub(crate) dev_minor: u32,
+    pub(crate) __spare2: [u64; 14],
+}
+
+#[repr(C)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
+pub(crate) struct fuse_statx_in {
+    pub(crate) getattr_flags: u32,
+    pub(crate) reserved: u32,
+    pub(crate) fh: u64,
+    pub(crate) sx_flags: u32,
+    pub(crate) sx_mask: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, IntoBytes, KnownLayout, Immutable)]
+pub(crate) struct fuse_statx_out {
+    pub(crate) attr_valid: u64,
+    pub(crate) attr_valid_nsec: u32,
+    pub(crate) flags: u32,
+    pub(crate) spare: [u64; 2],
+    pub(crate) stat: fuse_statx,
+}
 
 #[repr(C)]
 #[derive(Debug, IntoBytes, KnownLayout, Immutable)]

--- a/src/ll/reply.rs
+++ b/src/ll/reply.rs
@@ -4,7 +4,6 @@ use std::io::IoSlice;
 use std::os::unix::prelude::OsStrExt;
 use std::path::Path;
 use std::time::Duration;
-#[cfg(target_os = "macos")]
 use std::time::SystemTime;
 
 use smallvec::SmallVec;
@@ -355,6 +354,77 @@ pub(crate) fn fuse_attr_from_attr(attr: &crate::FileAttr) -> abi::fuse_attr {
     }
 }
 
+impl ResponseStruct<abi::fuse_statx_out> {
+    pub(crate) fn new_statx(ttl: &Duration, attr: &crate::StatxAttr) -> Self {
+        ResponseStruct(abi::fuse_statx_out {
+            attr_valid: ttl.as_secs(),
+            attr_valid_nsec: ttl.subsec_nanos(),
+            flags: 0,
+            spare: [0; 2],
+            stat: fuse_statx_from_attr(attr),
+        })
+    }
+}
+
+/// Splits a device number the way `struct statx` reports it, as a major and minor pair rather
+/// than the single encoded number `fuse_attr` carries.
+///
+/// This is the kernel's `new_decode_dev()`, which is what it applies to `fuse_attr.rdev`, and
+/// it re-encodes the pair with `new_encode_dev()` on the way back out of a statx reply
+fn major_minor(rdev: u32) -> (u32, u32) {
+    let major = (rdev & 0x000f_ff00) >> 8;
+    let minor = (rdev & 0xff) | ((rdev >> 12) & 0x000f_ff00);
+    (major, minor)
+}
+
+fn sx_time(time: &SystemTime) -> abi::fuse_sx_time {
+    let (secs, nanos) = time_from_system_time(time);
+    abi::fuse_sx_time {
+        tv_sec: secs,
+        tv_nsec: nanos,
+        __reserved: 0,
+    }
+}
+
+/// Returns a `fuse_statx` from `StatxAttr`. The mask is derived from what was actually
+/// filled in rather than taken from the caller, so it cannot claim a field that is not there
+pub(crate) fn fuse_statx_from_attr(attr: &crate::StatxAttr) -> abi::fuse_statx {
+    let (rdev_major, rdev_minor) = major_minor(attr.attr.rdev);
+    let mode = mode_from_kind_and_perm(attr.attr.kind, attr.attr.perm);
+    let mut mask = crate::StatxMask::BASIC_STATS;
+    if attr.btime.is_some() {
+        mask |= crate::StatxMask::BTIME;
+    }
+
+    abi::fuse_statx {
+        mask: mask.bits(),
+        blksize: attr.attr.blksize,
+        attributes: attr.attributes.bits(),
+        nlink: attr.attr.nlink,
+        uid: attr.attr.uid,
+        gid: attr.attr.gid,
+        // `struct statx` narrows this to 16 bits, which every file type and permission bit
+        // fits in - the width is all that differs from `fuse_attr`
+        mode: mode as u16,
+        __spare0: [0; 1],
+        ino: attr.attr.ino.0,
+        size: attr.attr.size,
+        blocks: attr.attr.blocks,
+        attributes_mask: attr.attributes_mask.bits(),
+        atime: sx_time(&attr.attr.atime),
+        btime: attr.btime.as_ref().map(sx_time).unwrap_or_default(),
+        ctime: sx_time(&attr.attr.ctime),
+        mtime: sx_time(&attr.attr.mtime),
+        rdev_major,
+        rdev_minor,
+        // The device the file lives on is the kernel's to fill in: it knows the connection's
+        // anonymous device number, and the filesystem does not
+        dev_major: 0,
+        dev_minor: 0,
+        __spare2: [0; 14],
+    }
+}
+
 // TODO: Add methods for creating this without making a `FileAttr` first.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Attr {
@@ -550,6 +620,17 @@ impl DirEntPlusList {
 
 #[cfg(test)]
 mod test {
+    /// The pair has to come back out the way the kernel encoded it, including a minor number
+    /// too large for its low byte, which is the case the shifts exist for
+    #[test]
+    fn statx_major_minor() {
+        // /dev/null and /dev/fuse, as `stat` reports them
+        assert_eq!(super::major_minor(0x0000_0103), (1, 3));
+        assert_eq!(super::major_minor(0x0000_0ae5), (10, 229));
+        // A minor that does not fit in 8 bits, so the high bits are in use
+        assert_eq!(super::major_minor(0x1110_fa70), (250, 70_000));
+    }
+
     use std::num::NonZeroI32;
     use std::time::UNIX_EPOCH;
 

--- a/src/ll/request.rs
+++ b/src/ll/request.rs
@@ -268,6 +268,7 @@ mod op {
     use crate::ll::flags::open_in_flags::OpenInFlags;
     use crate::ll::flags::read_flags::ReadFlags;
     use crate::ll::flags::release_flags::ReleaseFlags;
+    use crate::ll::flags::statx_flags::StatxMask;
     use crate::ll::request::FileHandle;
     use crate::ll::request::FilenameInDir;
     use crate::ll::request::INodeNo;
@@ -340,6 +341,39 @@ mod op {
             } else {
                 None
             }
+        }
+    }
+
+    /// Get extended file attributes, for `statx(2)`.
+    #[derive(Debug)]
+    pub(crate) struct StatX<'a> {
+        #[expect(dead_code)]
+        header: &'a fuse_in_header,
+        arg: &'a fuse_statx_in,
+    }
+
+    impl StatX<'_> {
+        pub(crate) fn file_handle(&self) -> Option<FileHandle> {
+            if GetattrFlags::from_bits_retain(self.arg.getattr_flags)
+                .contains(GetattrFlags::FUSE_GETATTR_FH)
+            {
+                Some(FileHandle(self.arg.fh))
+            } else {
+                None
+            }
+        }
+
+        /// The `AT_STATX_*` sync flags the caller passed. The kernel sends zero for now,
+        /// having no way to act on them yet
+        pub(crate) fn flags(&self) -> u32 {
+            self.arg.sx_flags
+        }
+
+        /// What the caller asked for, which is a request rather than an obligation: answering
+        /// with more than this costs nothing, and answering with less is what
+        /// `StatxAttr`'s own mask reports
+        pub(crate) fn mask(&self) -> StatxMask {
+            StatxMask::from_bits_retain(self.arg.sx_mask)
         }
     }
 
@@ -1973,6 +2007,10 @@ mod op {
                 arg: data.fetch()?,
                 name: data.fetch_str()?.as_ref(),
             }),
+            fuse_opcode::FUSE_STATX => Operation::StatX(StatX {
+                header,
+                arg: data.fetch()?,
+            }),
 
             #[cfg(target_os = "macos")]
             fuse_opcode::FUSE_SETVOLNAME => Operation::SetVolName(SetVolName {
@@ -2006,6 +2044,7 @@ pub(crate) enum Operation<'a> {
     Lookup(Lookup<'a>),
     Forget(Forget<'a>),
     GetAttr(GetAttr<'a>),
+    StatX(StatX<'a>),
     SetAttr(SetAttr<'a>),
     ReadLink(#[expect(dead_code)] ReadLink<'a>),
     SymLink(SymLink<'a>),
@@ -2067,6 +2106,7 @@ impl fmt::Display for Operation<'_> {
             Operation::Lookup(x) => write!(f, "LOOKUP name {:?}", x.name()),
             Operation::Forget(x) => write!(f, "FORGET nlookup {}", x.nlookup()),
             Operation::GetAttr(_) => write!(f, "GETATTR"),
+            Operation::StatX(x) => write!(f, "STATX mask {:?}", x.mask()),
             Operation::SetAttr(x) => x.fmt(f),
             Operation::ReadLink(_) => write!(f, "READLINK"),
             Operation::SymLink(x) => {
@@ -2364,6 +2404,7 @@ mod tests {
     use std::ffi::OsStr;
     use std::path::Path;
 
+    use crate::StatxMask;
     use crate::ll::request::*;
     use crate::ll::test::AlignedData;
 
@@ -2807,6 +2848,64 @@ mod tests {
         0x00, 0x00, 0x00, 0x12, 0x00, 0x00, 0x00, 0x00, // umask, open_flags
         0x2f, 0x00, // name ("/")
     ]);
+
+    // 40 byte header + 24 byte fuse_statx_in
+    #[cfg(target_endian = "little")]
+    const STATX_REQUEST: AlignedData<[u8; 64]> = AlignedData([
+        0x40, 0x00, 0x00, 0x00, 0x34, 0x00, 0x00, 0x00, // len, opcode (52)
+        0x0d, 0xf0, 0xad, 0xba, 0xef, 0xbe, 0xad, 0xde, // unique
+        0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, // nodeid
+        0x0d, 0xd0, 0x01, 0xc0, 0xfe, 0xca, 0x01, 0xc0, // uid, gid
+        0x5e, 0xba, 0xde, 0xc0, 0x00, 0x00, 0x00, 0x00, // pid, padding
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // getattr_flags (FH), reserved
+        0xbb, 0xaa, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, // fh
+        0x00, 0x00, 0x00, 0x00, 0xff, 0x0f, 0x00, 0x00, // sx_flags, sx_mask
+    ]);
+
+    #[cfg(target_endian = "big")]
+    const STATX_REQUEST: AlignedData<[u8; 64]> = AlignedData([
+        0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x34, // len, opcode (52)
+        0xde, 0xad, 0xbe, 0xef, 0xba, 0xad, 0xf0, 0x0d, // unique
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, // nodeid
+        0xc0, 0x01, 0xd0, 0x0d, 0xc0, 0x01, 0xca, 0xfe, // uid, gid
+        0xc0, 0xde, 0xba, 0x5e, 0x00, 0x00, 0x00, 0x00, // pid, padding
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, // getattr_flags (FH), reserved
+        0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, // fh
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0f, 0xff, // sx_flags, sx_mask
+    ]);
+
+    #[test]
+    fn statx() {
+        let req = AnyRequest::try_from(&STATX_REQUEST[..]).unwrap();
+        assert_eq!(req.header.opcode, 52);
+        assert_eq!(req.nodeid(), INodeNo(0x1122_3344_5566_7788));
+        match req.operation().unwrap() {
+            Operation::StatX(x) => {
+                assert_eq!(x.file_handle(), Some(FileHandle(0x4455_6677_8899_aabb)));
+                assert_eq!(x.flags(), 0);
+                // What the kernel asks for: STATX_BASIC_STATS | STATX_BTIME
+                assert_eq!(x.mask(), StatxMask::BASIC_STATS | StatxMask::BTIME);
+            }
+            _ => panic!("Unexpected request operation"),
+        }
+    }
+
+    /// Without `FUSE_GETATTR_FH` the handle is absent whatever the field holds, as for getattr
+    #[test]
+    fn statx_without_file_handle() {
+        let mut data = STATX_REQUEST;
+        // getattr_flags occupies bytes 40..44; its low byte is where FUSE_GETATTR_FH sits
+        data.0[if cfg!(target_endian = "little") {
+            40
+        } else {
+            43
+        }] = 0x00;
+        let req = AnyRequest::try_from(&data[..]).unwrap();
+        match req.operation().unwrap() {
+            Operation::StatX(x) => assert_eq!(x.file_handle(), None),
+            _ => panic!("Unexpected request operation"),
+        }
+    }
 
     /// A tmpfile request is a create request on the wire, minus a name that means anything
     #[test]

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -21,6 +21,7 @@ use crate::Errno;
 use crate::FileAttr;
 use crate::FileType;
 use crate::PollEvents;
+use crate::StatxAttr;
 use crate::channel::ChannelSender;
 use crate::ll::Generation;
 use crate::ll::INodeNo;
@@ -297,6 +298,35 @@ impl ReplyAttr {
     pub fn attr(self, ttl: &Duration, attr: &FileAttr) {
         self.reply
             .send_ll(&ll::ResponseStruct::new_attr(ttl, &attr.into()));
+    }
+
+    /// Reply to a request with the given error code
+    pub fn error(self, err: Errno) {
+        self.reply.error(err);
+    }
+}
+
+///
+/// Statx Reply
+///
+#[derive(Debug)]
+pub struct ReplyStatx {
+    reply: ReplyRaw,
+}
+
+impl Reply for ReplyStatx {
+    fn new(unique: ll::RequestId, sender: ReplySender) -> ReplyStatx {
+        ReplyStatx {
+            reply: Reply::new(unique, sender),
+        }
+    }
+}
+
+impl ReplyStatx {
+    /// Reply to a request with the given attributes
+    pub fn statx(self, ttl: &Duration, attr: &StatxAttr) {
+        self.reply
+            .send_ll(&ll::ResponseStruct::new_statx(ttl, attr));
     }
 
     /// Reply to a request with the given error code

--- a/src/request.rs
+++ b/src/request.rs
@@ -550,6 +550,16 @@ impl<'a> RequestWithSender<'a> {
             ll::Operation::SyncFs(_x) => {
                 filesystem.syncfs(self.request_header(), self.request.nodeid(), self.reply());
             }
+            ll::Operation::StatX(x) => {
+                filesystem.statx(
+                    self.request_header(),
+                    self.request.nodeid(),
+                    x.file_handle(),
+                    x.flags(),
+                    x.mask(),
+                    self.reply(),
+                );
+            }
             ll::Operation::TmpFile(x) => {
                 filesystem.tmpfile(
                     self.request_header(),

--- a/src/session.rs
+++ b/src/session.rs
@@ -825,6 +825,190 @@ mod test {
         ManuallyDrop::into_inner(tmp);
     }
 
+    /// statx(2) must reach Filesystem::statx(), and the creation time it carries - which no
+    /// other request can express on Linux - must arrive intact. Also pins the one field the
+    /// wire format carries but the kernel drops, so that a kernel change shows up here.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn statx_reports_btime() {
+        use std::os::unix::ffi::OsStringExt;
+        use std::time::Duration;
+        use std::time::SystemTime;
+
+        use crate::FileAttr;
+        use crate::FileType;
+        use crate::INodeNo;
+        use crate::ReplyStatx;
+        use crate::StatxAttr;
+        use crate::StatxAttributes;
+        use crate::StatxMask;
+
+        const FILE_INO: INodeNo = INodeNo(2);
+        /// Distinctive enough that reading it out of the wrong field would show
+        const BTIME_SECS: u64 = 1_000_000_000;
+
+        struct StatxFs {
+            asked: Arc<Mutex<Option<StatxMask>>>,
+        }
+
+        impl StatxFs {
+            fn attr(ino: INodeNo, kind: FileType) -> FileAttr {
+                FileAttr {
+                    ino,
+                    size: 4096,
+                    blocks: 8,
+                    atime: SystemTime::UNIX_EPOCH,
+                    mtime: SystemTime::UNIX_EPOCH,
+                    ctime: SystemTime::UNIX_EPOCH,
+                    crtime: SystemTime::UNIX_EPOCH,
+                    kind,
+                    perm: if kind == FileType::Directory {
+                        0o755
+                    } else {
+                        0o644
+                    },
+                    nlink: 1,
+                    uid: 0,
+                    gid: 0,
+                    rdev: 0,
+                    blksize: 512,
+                    flags: 0,
+                }
+            }
+        }
+
+        impl Filesystem for StatxFs {
+            fn lookup(
+                &self,
+                _req: &Request,
+                _parent: INodeNo,
+                _name: &std::ffi::OsStr,
+                reply: crate::ReplyEntry,
+            ) {
+                reply.entry(
+                    &Duration::from_secs(0),
+                    &Self::attr(FILE_INO, FileType::RegularFile),
+                    crate::Generation(0),
+                );
+            }
+            fn getattr(
+                &self,
+                _req: &Request,
+                ino: INodeNo,
+                _fh: Option<crate::FileHandle>,
+                reply: crate::ReplyAttr,
+            ) {
+                let kind = if ino == FILE_INO {
+                    FileType::RegularFile
+                } else {
+                    FileType::Directory
+                };
+                reply.attr(&Duration::from_secs(0), &Self::attr(ino, kind));
+            }
+            fn statx(
+                &self,
+                _req: &Request,
+                ino: INodeNo,
+                _fh: Option<crate::FileHandle>,
+                _flags: u32,
+                mask: StatxMask,
+                reply: ReplyStatx,
+            ) {
+                *self.asked.lock() = Some(mask);
+                let kind = if ino == FILE_INO {
+                    FileType::RegularFile
+                } else {
+                    FileType::Directory
+                };
+                reply.statx(
+                    &Duration::from_secs(0),
+                    &StatxAttr {
+                        btime: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(BTIME_SECS)),
+                        attributes: StatxAttributes::IMMUTABLE | StatxAttributes::APPEND,
+                        attributes_mask: StatxAttributes::IMMUTABLE
+                            | StatxAttributes::APPEND
+                            | StatxAttributes::NODUMP,
+                        ..Self::attr(ino, kind).into()
+                    },
+                );
+            }
+        }
+
+        let tmp = ManuallyDrop::new(tempfile::tempdir().unwrap());
+        let mountpoint = tmp.path().canonicalize().unwrap();
+        let asked = Arc::new(Mutex::new(None));
+        let session = Session::new(
+            StatxFs {
+                asked: asked.clone(),
+            },
+            &mountpoint,
+            &Config::default(),
+        )
+        .unwrap();
+        // FUSE_STATX arrived in ABI 7.38. An older kernel answers statx(2) out of
+        // FUSE_GETATTR without ever asking, so there is nothing to assert against
+        let supported = session
+            .proto_version
+            .is_some_and(|v| v >= crate::ll::fuse_abi::FUSE_STATX_VERSION);
+        let bg = session.spawn().unwrap();
+        if !supported {
+            eprintln!("skipping statx: the kernel's FUSE protocol predates 7.38");
+            bg.umount_and_join().unwrap();
+            ManuallyDrop::into_inner(tmp);
+            return;
+        }
+
+        let mut buf: libc::statx = unsafe { std::mem::zeroed() };
+        let path =
+            std::ffi::CString::new(mountpoint.join("file").into_os_string().into_vec()).unwrap();
+        let rc = unsafe {
+            libc::statx(
+                libc::AT_FDCWD,
+                path.as_ptr(),
+                libc::AT_SYMLINK_NOFOLLOW,
+                libc::STATX_BASIC_STATS | libc::STATX_BTIME,
+                &mut buf,
+            )
+        };
+        let err = std::io::Error::last_os_error();
+
+        let asked = asked.lock().take();
+        drop(bg);
+        ManuallyDrop::into_inner(tmp);
+
+        assert_eq!(rc, 0, "statx(2) must be answered: {err}");
+        assert!(
+            asked.is_some(),
+            "statx(2) must reach Filesystem::statx rather than falling back to getattr"
+        );
+        assert_eq!(
+            buf.stx_btime.tv_sec as u64, BTIME_SECS,
+            "the creation time must survive the round trip"
+        );
+        assert_ne!(
+            buf.stx_mask & libc::STATX_BTIME,
+            0,
+            "the reply must mark the creation time as filled in"
+        );
+        assert_eq!(
+            buf.stx_size, 4096,
+            "the fields stat(2) also carries must still be right"
+        );
+        eprintln!(
+            "DIAG stx_attributes={:#x} stx_attributes_mask={:#x} stx_mask={:#x} btime={}",
+            buf.stx_attributes, buf.stx_attributes_mask, buf.stx_mask, buf.stx_btime.tv_sec
+        ); // The kernel does not pass `attributes` on to the caller: fuse_do_statx() copies the
+        // mask, btime and basic stats out of the reply and ignores this field, so the
+        // immutable and append-only bits set above go nowhere. Asserted so that this stops
+        // being true loudly rather than silently, since the wire format has carried the field
+        // since 7.38 and only the kernel's use of it is missing
+        assert_eq!(
+            buf.stx_attributes, 0,
+            "STATX_ATTR_* from a FUSE filesystem is dropped by the kernel; if this now \
+             arrives, StatxAttr::attributes and the CHANGELOG need their caveats removed"
+        );
+    }
+
     /// An O_TMPFILE open must reach Filesystem::tmpfile() with the mode and flags it was
     /// made with, and hand back a working descriptor. The kernel takes ENOSYS from this as
     /// permanent, so a filesystem that does implement it has one chance to say so.


### PR DESCRIPTION
The kernel sends `FUSE_STATX` for `statx(2)` once the connection is at ABI 7.38 or
above, and falls back to `FUSE_GETATTR` when the filesystem answers `ENOSYS` -
which it takes as permanent, the same way it does for `tmpfile()` and `syncfs()`.

## What it is worth implementing for

The creation time. `fuse_attr` has a field for it on macOS alone, so on Linux
there has been no way for a filesystem to report one and `statx(2)` answers with
whatever the kernel last cached.

`StatxAttr` carries it as an `Option<SystemTime>`, and the reply's `stx_mask` is
derived from what was actually filled in rather than supplied by the caller, so
it cannot claim a field that is not there.

## What it is not worth implementing for

I went in expecting this to make `chattr +i` visible to `statx(2)`, which would
have let generic/424 run. It does not, and the reason is worth recording since
the wire format suggests otherwise.

`struct fuse_statx` has an `attributes` field carrying the `STATX_ATTR_*` bits,
and this PR fills and sends it. The kernel ignores it. `fuse_do_statx()` copies
the mask, the creation time and the basic stats out of the reply and nothing
else:

```c
stat->result_mask = sx->mask & (STATX_BASIC_STATS | STATX_BTIME);
stat->btime.tv_sec = sx->btime.tv_sec;
stat->btime.tv_nsec = min_t(u32, sx->btime.tv_nsec, NSEC_PER_SEC - 1);
fuse_fillattr(idmap, inode, &attr, stat);
stat->result_mask |= STATX_TYPE;
```

Measured before it was read, by setting `IMMUTABLE | APPEND` in a test filesystem
and calling `statx(2)` against it:

```
stx_attributes=0x0  stx_attributes_mask=0x203000  stx_mask=0x1fff  btime=1000000000
```

The creation time arrives; the attributes do not, and `stx_attributes_mask` holds
only the VFS's own `MOUNT_ROOT | AUTOMOUNT | DAX`. Since `btime` sits at offset 80
of the struct and `size` at 40, and both arrive intact, this is the kernel
discarding the field rather than a layout mistake on this side.

The field is kept and sent regardless: a filesystem that fills it is correct today
and needs no change if the kernel starts reading it. But it is documented as
inert on the field itself, in the CHANGELOG, and pinned by the test, so nobody
implements it expecting `chattr +i` to show up.

## Testing

- Two wire-format tests over a byte-exact `FUSE_STATX` request, for both
  endiannesses, covering the file handle being present and absent.
- An integration test that mounts a filesystem and calls `statx(2)` for real,
  asserting the creation time survives the round trip and that the request
  reaches `statx()` rather than falling back to `getattr()`. It also asserts the
  attributes are dropped, so a kernel that starts honoring them fails here rather
  than silently outdating the documentation. Skipped below 7.38, as the tmpfile
  test is below 7.37.
- A unit test for the device-number split, checked against `/dev/null` and
  `/dev/fuse` as `stat` reports them plus a minor number too large for its low
  byte, since `struct statx` wants a major/minor pair where `fuse_attr` carries
  the encoded number.

`cargo test --all` is 104 passed, 1 failed - `mnt::test::mount_unmount_auto_unmount`,
which fails the same way on unmodified master here for want of a `fusermount3`
binary. Clippy clean with `--deny warnings`, and
`cargo check --target x86_64-apple-darwin --features=macos-no-mount` clean, which
caught two things: a version constant that is only needed by the tests, and
`nix::sys::stat::major`/`minor` not existing on macOS - replaced with the
kernel's own `new_decode_dev()` split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4hiZwHE9fEYdn7DK3ZrV2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4hiZwHE9fEYdn7DK3ZrV2)_