### PR TITLE
Report a creation time from the simple example

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -462,6 +462,8 @@ struct InodeAttributes {
     pub last_accessed: (i64, u32),
     pub last_modified: (i64, u32),
     pub last_metadata_changed: (i64, u32),
+    /// Time of creation, which `statx(2)` reports as `stx_btime` and nothing ever changes
+    pub created: (i64, u32),
     pub kind: FileKind,
     // Permissions and special mode bits
     pub mode: u16,
@@ -519,7 +521,7 @@ impl From<InodeAttributes> for fuser::FileAttr {
                 attrs.last_metadata_changed.0,
                 attrs.last_metadata_changed.1,
             ),
-            crtime: SystemTime::UNIX_EPOCH,
+            crtime: system_time_from_time(attrs.created.0, attrs.created.1),
             kind: attrs.kind.into(),
             perm: attrs.mode,
             nlink: attrs.hardlinks,
@@ -891,6 +893,7 @@ impl Filesystem for SimpleFS {
                 last_accessed: now,
                 last_modified: now,
                 last_metadata_changed: now,
+                created: now,
                 kind: FileKind::Directory,
                 mode: 0o777,
                 hardlinks: 2,
@@ -1261,6 +1264,7 @@ impl Filesystem for SimpleFS {
             last_accessed: now,
             last_modified: now,
             last_metadata_changed: now,
+            created: now,
             kind: as_file_kind(mode),
             mode: self.creation_mode(mode),
             hardlinks: 1,
@@ -1358,6 +1362,7 @@ impl Filesystem for SimpleFS {
             last_accessed: now,
             last_modified: now,
             last_metadata_changed: now,
+            created: now,
             kind: FileKind::Directory,
             mode: self.creation_mode(mode),
             hardlinks: 2, // Directories start with link count of 2, since they have a self link
@@ -1575,6 +1580,7 @@ impl Filesystem for SimpleFS {
             last_accessed: now,
             last_modified: now,
             last_metadata_changed: now,
+            created: now,
             kind: FileKind::Symlink,
             mode: 0o777,
             hardlinks: 1,
@@ -1868,6 +1874,7 @@ impl Filesystem for SimpleFS {
                 last_accessed: now,
                 last_modified: now,
                 last_metadata_changed: now,
+                created: now,
                 kind: FileKind::CharDevice,
                 mode: 0,
                 hardlinks: 1,
@@ -2482,6 +2489,7 @@ impl Filesystem for SimpleFS {
             last_accessed: now,
             last_modified: now,
             last_metadata_changed: now,
+            created: now,
             kind: as_file_kind(mode),
             mode: self.creation_mode(mode),
             hardlinks: 1,
@@ -2512,6 +2520,57 @@ impl Filesystem for SimpleFS {
             fuser::Generation(0),
             FileHandle(self.allocate_next_file_handle(read, write)),
             FopenFlags::empty(),
+        );
+    }
+
+    /// Answers `statx(2)`, which differs from `getattr()` in carrying a creation time. That
+    /// is the whole reason to implement it: `fuse_attr` has no field for one on Linux, so
+    /// without this the kernel reports whatever it last cached
+    #[cfg(target_os = "linux")]
+    fn statx(
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        _fh: Option<FileHandle>,
+        _flags: u32,
+        _mask: fuser::StatxMask,
+        reply: fuser::ReplyStatx,
+    ) {
+        debug!("statx() called with {ino:?}");
+        let attrs = match self.get_inode(ino) {
+            Ok(attrs) => attrs,
+            Err(error_code) => {
+                reply.error(error_code);
+                return;
+            }
+        };
+
+        // The inode flags this filesystem honors, in the encoding statx uses. The kernel
+        // discards these today - fuse_do_statx() takes the creation time and the basic stats
+        // out of the reply and nothing else - so `chattr +i` stays invisible to statx(2)
+        // whatever is reported here. Filled in anyway, since it costs nothing and is what the
+        // field is for if the kernel starts reading it
+        let mut attributes = fuser::StatxAttributes::empty();
+        attributes.set(fuser::StatxAttributes::IMMUTABLE, attrs.is_immutable());
+        attributes.set(fuser::StatxAttributes::APPEND, attrs.is_append_only());
+        attributes.set(
+            fuser::StatxAttributes::NODUMP,
+            attrs.flags & FS_NODUMP_FL != 0,
+        );
+
+        let btime = system_time_from_time(attrs.created.0, attrs.created.1);
+        reply.statx(
+            &Duration::new(0, 0),
+            &fuser::StatxAttr {
+                btime: Some(btime),
+                attributes,
+                // The three above are the ones this filesystem can speak to. Leaving the rest
+                // out is what tells a caller "cannot say" rather than "not set"
+                attributes_mask: fuser::StatxAttributes::IMMUTABLE
+                    | fuser::StatxAttributes::APPEND
+                    | fuser::StatxAttributes::NODUMP,
+                ..self.file_attr(attrs).into()
+            },
         );
     }
 
@@ -2665,6 +2724,7 @@ impl Filesystem for SimpleFS {
             last_accessed: now,
             last_modified: now,
             last_metadata_changed: now,
+            created: now,
             // The kernel only ever asks for a regular file here
             kind: FileKind::File,
             mode: self.creation_mode(mode),


### PR DESCRIPTION
Implements `Filesystem::statx()`, added in e039dae, which differs from `getattr()`
in carrying a creation time. That is the reason to answer it: `fuse_attr` has a
field for one on macOS alone, so on Linux the kernel has had nothing to report and
`statx(2)` answered with whatever it last cached.

`InodeAttributes` gains a `created` time, set once when the inode is made and
never touched again. It also fills `FileAttr::crtime`, which was hardcoded to the
epoch, so macOS gets a real creation time through `fuse_attr` as well rather than
only Linux through statx.

## Effect

generic/528 runs and passes. It asks for a creation time through `_require_btime`
and was skipped for want of one. Measured against the parent commit rather than
assumed:

| | reply mask | `stx_btime` |
|---|---|---|
| e039dae (statx in the library, not the example) | `0x17ff` - no `STATX_BTIME` | 0 |
| this commit | `0x1fff` | the creation time |

That is one of the two tests I expected `FUSE_STATX` to reach. The other,
generic/424, stays excluded: it reads the `chattr` flags back through statx, and
the kernel discards the attributes from a FUSE reply, as #746 documents.

The `STATX_ATTR_*` bits are filled in anyway from the flags `chattr` sets, since
that is what the field is for and a filesystem doing so is correct today and needs
no change if the kernel starts reading it. It is noted where they are set, so the
example does not read as a way to make `chattr +i` visible to `statx(2)`.

## Testing

Full suite, green: 175 tests run, 0 failures, no filesystem panics - up from 174,
the difference being 528.

Worth saying why the whole suite mattered here rather than the usual targeted
subset: glibc routes `stat(2)` through `statx(2)` on a current kernel, so this one
method now answers essentially every attribute lookup the suite makes. A mistake
in it would not have been subtle.

Behavior checked directly as well: `STATX_BTIME` is in the result mask, the time
matches creation, it does not move when the file is written while `mtime` does,
the basic stats still arrive, and directories report it too.

Both gates clean, the macOS one now with `--all-targets` so that it builds tests -
which is what #746 needed a second push for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4hiZwHE9fEYdn7DK3ZrV2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4hiZwHE9fEYdn7DK3ZrV2)_